### PR TITLE
created theme props to replace style which is deprecated. close #96

### DIFF
--- a/src/MessageBox/FooterLayout1.js
+++ b/src/MessageBox/FooterLayout1.js
@@ -2,17 +2,26 @@ import React from 'react';
 import Button from '../Button';
 import * as styles from './FooterLayout.scss';
 
-const FooterLayout1 = ({children, style, cancelText, onCancel, onOk, confirmText}) => {
+const FooterLayout1 = ({children, style, theme, cancelText, onCancel, onOk, confirmText}) => {
+  //TODO When deprecation ends, _theme won't be needed.
+  let _theme;
+  if (style) {
+    console.warn('[wix-style-react>FooterLayout1] Warning. Property \'style\' has been deprecated, and will be removed Jan 1st 2017. Please use \'theme\' instead.');
+    _theme = style;
+  } else {
+    _theme = theme;
+  }
+
   return (
     <div className={styles.footer} >
       {children}
       <div className={styles.footerbuttons}>
         {cancelText ?
-          <Button theme={'empty' + style} onClick={onCancel} >
+          <Button theme={'empty' + _theme} onClick={onCancel} >
             {cancelText}
           </Button> : null
         }
-        <Button theme={'full' + style} onClick={onOk} >
+        <Button theme={'full' + _theme} onClick={onOk} >
           {confirmText}
         </Button>
       </div>
@@ -26,11 +35,12 @@ FooterLayout1.propTypes = {
   onCancel: React.PropTypes.func,
   onOk: React.PropTypes.func,
   style: React.PropTypes.string,
+  theme: React.PropTypes.string,
   children: React.PropTypes.any
 };
 
 FooterLayout1.defaultProps = {
-  style: 'blue'
+  theme: 'blue'
 };
 
 export default FooterLayout1;

--- a/src/MessageBox/HeaderLayout1.js
+++ b/src/MessageBox/HeaderLayout1.js
@@ -3,9 +3,18 @@ import classNames from 'classnames';
 import * as styles from './HeaderLayout1.scss';
 import SvgX from '../svg/X.js';
 
-const HeaderLayout1 = ({title, onCancel, style}) => {
+const HeaderLayout1 = ({title, onCancel, style, theme}) => {
+  //TODO When deprecation ends, _theme won't be needed.
+  let _theme;
+  if (style) {
+    console.warn('[wix-style-react>HeaderLayout1] Warning. Property \'style\' has been deprecated, and will be removed Jan 1st 2017. Please use \'theme\' instead.');
+    _theme = style;
+  } else {
+    _theme = theme;
+  }
+
   return (
-    <div className={classNames(styles.header, styles[style])} >
+    <div className={classNames(styles.header, styles[_theme])} >
       {title}
       <button className={styles.close} onClick={onCancel}>
         <SvgX width={9} height={9} thickness={1} color={'white'}/>
@@ -14,10 +23,15 @@ const HeaderLayout1 = ({title, onCancel, style}) => {
   );
 };
 
+HeaderLayout1.defaultProps = {
+  theme: 'blue'
+};
+
 HeaderLayout1.propTypes = {
   title: React.PropTypes.node,
   onCancel: React.PropTypes.func,
-  style: React.PropTypes.oneOf(['red', 'green', 'blue', 'lightGreen'])
+  style: React.PropTypes.oneOf(['red', 'green', 'blue', 'lightGreen']),
+  theme: React.PropTypes.oneOf(['red', 'green', 'blue', 'lightGreen'])
 };
 
 export default HeaderLayout1;

--- a/src/MessageBox/MessageBoxLayout1.js
+++ b/src/MessageBox/MessageBoxLayout1.js
@@ -1,4 +1,5 @@
 /* eslint-disable react/style-prop-object */
+//TODO remove the above lint-disable after style is finaly deprecated
 
 import React from 'react';
 import Button from '../Button';

--- a/src/MessageBox/MessageBoxLayout2.js
+++ b/src/MessageBox/MessageBoxLayout2.js
@@ -2,16 +2,23 @@ import React from 'react';
 import * as styles from './MessageBoxLayout2.scss';
 import {HeaderLayout1, FooterLayout1} from './';
 
-const MessageBoxLayout2 = ({title, onCancel, onOk, confirmText, children, hideFooter, cancelText, style}) => {
+const MessageBoxLayout2 = ({title, onCancel, onOk, confirmText, children, hideFooter, cancelText, style, theme}) => {
+  //TODO When deprecation ends, _theme won't be needed.
+  const _theme = theme || style;
+
+  if (style) {
+    console.warn('[wix-style-react>MessageBoxLayout2] Warning. Property \'style\' has been deprecated, and will be removed Jan 1st 2017. Please use \'theme\' instead.');
+  }
+
   return (
     <div className={styles.content}>
-      <HeaderLayout1 title={title} onCancel={onCancel} style={style}/>
+      <HeaderLayout1 title={title} onCancel={onCancel} theme={_theme}/>
       <div className={styles.body} >
         {children}
       </div>
       {
         !hideFooter ?
-          <FooterLayout1 confirmText={confirmText} cancelText={cancelText} onCancel={onCancel} onOk={onOk} style={style}/> : null
+          <FooterLayout1 confirmText={confirmText} cancelText={cancelText} onCancel={onCancel} onOk={onOk} theme={_theme}/> : null
       }
     </div>
   );
@@ -22,6 +29,7 @@ MessageBoxLayout2.propTypes = {
   confirmText: React.PropTypes.string,
   cancelText: React.PropTypes.string,
   style: React.PropTypes.string,
+  theme: React.PropTypes.string,
   onOk: React.PropTypes.func,
   onCancel: React.PropTypes.func,
   title: React.PropTypes.node,

--- a/src/MessageBox/README.md
+++ b/src/MessageBox/README.md
@@ -1,6 +1,6 @@
 # MessageBox component
 
-> Message box Layouts 
+> Message box Layouts
 
 ## MessageBoxLayout1 Properties
 
@@ -22,7 +22,7 @@
 | hideFooter | bool | - | - | Hide or show footer |
 | confirmText | string | - | - | Confirm button Label |
 | cancelText | string | - | - | Cancel button Label |
-| style | string | - | - | style of the message box, (green, blue , red) |
+| theme | string | - | - | theme of the message box, (green, blue , red) |
 | onOk | func | - | - | Ok callback |
 | onCancel | func | - | - | Cancel callback |
 | title | Node | - | - | title of the Message Box |

--- a/stories/MessageBox/ExampleStandard.js
+++ b/stories/MessageBox/ExampleStandard.js
@@ -38,7 +38,7 @@ class ControlledMessageBoxes extends Component {
             onSecondaryButtonClick={log('secondary button click')}
             onPrimaryButtonClick={log('primary button click')}
             onClose={close}
-            style="blue"
+            theme="blue"
             imageUrl="http://www.domstechblog.com/wp-content/uploads/2015/09/wix.png"
             />
         </NgIf>
@@ -49,7 +49,7 @@ class ControlledMessageBoxes extends Component {
             primaryButtonLabel="Got It"
             confirmText="Confirm"
             cancelText="Cancel"
-            style="red"
+            theme="red"
             onCancel={close}
             onOk={log('all ok')}
             >


### PR DESCRIPTION
- [x] The component uses **style** prop which causes linting errors. This  problem was already handled by @3LOK in the Button component (issue #49). I have implemented a similar solution with warnings about deprecation of this prop. Instead **theme** props should be the one to use.
After the deprecation will take place, there are some //TODO which should be taken care of.

- [x] There is no default value to the **style** prop, so if style isn't provided, it will use white title on top of an white background, so the title is invisible. I have created a default value of 'blue' for the theme.





