### PR TITLE
feature(composite validators): add composite validators

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -27,6 +27,7 @@ function loadStories() {
   require('../stories/DataTable');
   require('../stories/Dropdown');
   require('../stories/Common');
+  require('../stories/Composite');
 }
 
 configure(loadStories, module);

--- a/src/Composite/CompositeValidation.js
+++ b/src/Composite/CompositeValidation.js
@@ -1,0 +1,54 @@
+import {Children} from 'react';
+
+const validators = {
+  ONCE: (types, i, type) =>
+    types[i] && types[i].type === type ? i + 1 : false,
+
+  OPTIONAL: (types, i, type) =>
+    types[i] && types[i].type === type ? i + 1 : i,
+
+  ANY: types =>
+    types.length,
+
+  MULTIPLE: (types, i, type) => {
+    if (!types[i] || types[i].type !== type) {
+      return false;
+    }
+    while (types[i] && types[i].type === type) {
+      ++i;
+    }
+    return i;
+  }
+};
+
+const error = (componentName, rules) => {
+  const orderedTypes = rules.map(rule => {
+    return rule.validation === 'ANY' ?
+      `* (${rule.validation})` :
+      `${rule.type.name} (${rule.validation})`;
+  }).join(', ');
+  return new Error(`${componentName} should have children of the following types in this order: ${orderedTypes}`);
+};
+
+export const once = type => ({validation: 'ONCE', type});
+export const optional = type => ({validation: 'OPTIONAL', type});
+export const multiple = type => ({validation: 'MULTIPLE', type});
+export const any = () => ({validation: 'ANY'});
+
+export const children = (...rules) => {
+  return (props, propName, componentName) => {
+    if (!rules || rules.length === 0) {
+      return new Error(`${componentName} should have at least a single child declaration rule`);
+    }
+    const childrenAsArray = Children.toArray(props[propName]);
+    const result = rules.reduce((acc, curr) => {
+      if (acc === false) {
+        return acc;
+      }
+      return validators[curr.validation](childrenAsArray, acc, curr.type);
+    }, 0);
+    if (result === false || childrenAsArray[result]) {
+      return error(componentName, rules);
+    }
+  };
+};

--- a/src/Composite/CompositeValidation.spec.js
+++ b/src/Composite/CompositeValidation.spec.js
@@ -1,0 +1,110 @@
+import React, {Component} from 'react';
+import {children, once, any, multiple, optional} from './CompositeValidation';
+
+const Label = () => null;
+
+class Input extends Component {
+  render = () => null
+}
+
+describe('CompositeValidation', () => {
+
+  describe('children()', () => {
+
+    it('should return an error if no rules are passed', () => {
+      const validator = children();
+      expect(validator({}, 'children', 'TextField'))
+        .toEqual(new Error('TextField should have at least a single child declaration rule'));
+    });
+
+    describe('once()', () => {
+
+      it('should return an error if once() component is missing', () => {
+        const validator = children(once(Input));
+        expect(validator({children: []}, 'children', 'TextField'))
+          .toEqual(new Error('TextField should have children of the following types in this order: Input (ONCE)'));
+      });
+
+      it('should return an error if multiple once components are missing', () => {
+        const validator = children(once(Label), once(Input));
+        expect(validator({children: []}, 'children', 'TextField'))
+          .toEqual(new Error('TextField should have children of the following types in this order: Label (ONCE), Input (ONCE)'));
+      });
+
+      it('should pass if component exists', () => {
+        const validator = children(once(Label), once(Input));
+        expect(validator({children: [<Label key={1}/>, <Input key={2}/>]}, 'children', 'TextField'))
+          .toEqual(undefined);
+      });
+
+    });
+
+    describe('optional()', () => {
+
+      it('should return an error if optional() component is missing and there are no more rules', () => {
+        const validator = children(optional(Label));
+        expect(validator({children: [<Input key={1}/>]}, 'children', 'TextField'))
+          .toEqual(new Error('TextField should have children of the following types in this order: Label (OPTIONAL)'));
+      });
+
+      it('should pass if optional() component is missing but another component is present', () => {
+        const validator = children(optional(Label), once(Input));
+        expect(validator({children: [<Input key={1}/>]}, 'children', 'TextField'))
+          .toEqual(undefined);
+      });
+
+      it('should pass if optional() component is in the middle', () => {
+        const validator = children(once(Label), optional(Input), once(Label));
+        expect(validator({children: [<Label key={1}/>, <Label key={2}/>]}, 'children', 'TextField'))
+          .toEqual(undefined);
+      });
+
+      it('should pass if optional() component is the last one', () => {
+        const validator = children(once(Input), optional(Label));
+        expect(validator({children: [<Input key={1}/>]}, 'children', 'TextField'))
+          .toEqual(undefined);
+      });
+
+    });
+
+    describe('multiple()', () => {
+
+      it('should return an error if multiple() components are missing', () => {
+        const validator = children(multiple(Label));
+        expect(validator({children: []}, 'children', 'TextField'))
+          .toEqual(new Error('TextField should have children of the following types in this order: Label (MULTIPLE)'));
+      });
+
+      it('should pass if at least one multiple() component exists', () => {
+        const validator = children(multiple(Label));
+        expect(validator({children: [<Label key={1}/>]}, 'children', 'TextField'))
+          .toEqual(undefined);
+      });
+
+      it('should pass if several multiple() component exist', () => {
+        const validator = children(multiple(Label));
+        expect(validator({children: [<Label key={1}/>, <Label key={2}/>]}, 'children', 'TextField'))
+          .toEqual(undefined);
+      });
+
+    });
+
+  });
+
+  describe('any()', () => {
+
+    it('should pass if any() is being used', () => {
+      const validator = children(any());
+      expect(validator({children: [<Label key={1}/>, <Input key={2}/>]}, 'children', 'TextField'))
+        .toEqual(undefined);
+    });
+
+    it('should pass if any() is being used as last option', () => {
+      const validator = children(once(Label), any());
+      expect(validator({children: [<Label key={1}/>, <Input key={2}/>]}, 'children', 'TextField'))
+        .toEqual(undefined);
+    });
+
+  });
+
+});

--- a/src/Composite/README.md
+++ b/src/Composite/README.md
@@ -1,0 +1,16 @@
+Using composite component validators, you can specify the `children` requirements.
+If some component is required, optional, ...
+
+```js
+class InputWithOptionalLabel extends Component {
+  static propTypes {
+    children: children(optional(Label), once(Input))
+  }
+}
+
+class InputWithRequiredLabel extends Component {
+  static propTypes: {
+    children: children(once(Label), once(Input))
+  }
+}
+```

--- a/stories/Composite/ExampleComposite.js
+++ b/stories/Composite/ExampleComposite.js
@@ -1,0 +1,28 @@
+import React, {Component, Children} from 'react';
+
+import {children, optional, once} from '../../src/Composite/CompositeValidation';
+
+const Label = () => (<div>Label</div>);
+const Input = () => (<div>Input</div>);
+
+const TextField = ({ children }) => {
+  const [label, input] = Children.toArray(children);
+  return (
+    <div>
+      <div>{input}</div>
+      <div>{label}</div>
+    </div>
+  );
+};
+
+TextField.propTypes = {
+  children: children(once(Label), once(Input))
+};
+
+export default () =>
+  <div>
+    <TextField>
+      <Label/>
+      <Input/>
+    </TextField>
+  </div>;

--- a/stories/Composite/index.js
+++ b/stories/Composite/index.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import {storiesOf} from '@kadira/storybook';
+
+import CodeExample from '../utils/Components/CodeExample';
+import Markdown from '../utils/Components/Markdown';
+
+import Readme from '../../src/Composite/README.md';
+
+import ExampleComposite from './ExampleComposite';
+import ExampleCompositeRaw from '!raw!./ExampleComposite';
+
+storiesOf('6. Common', module)
+  .add('6.2 Composites', () => (
+    <div>
+      <h1>Composites</h1>
+      <Markdown source={Readme}/>
+      <CodeExample title="Example" code={ExampleCompositeRaw}>
+        <p>Require both Label and Input and change the order when rendering</p>
+        <ExampleComposite/>
+      </CodeExample>
+    </div>
+  ));


### PR DESCRIPTION
Added composite component validators. From now you will be able to create a custom composite component like:

```js
propTypes = {
   children: children(optional(Input), multiple(Separator), once(Input))
}
```

Pending stuff:  
- Make validator work only in development mode. No need for it in production code.
