### PR TITLE
Radio group enhancement

### DIFF
--- a/src/RadioGroup/README.md
+++ b/src/RadioGroup/README.md
@@ -10,7 +10,7 @@
 | onChange | func | - | - | Callback function when user selects a different value |
 | disabledRadios | arrayOf(number, string) | [] | - | the values of the disabled radio buttons |
 | vAlign | top, center | top | - | Positioning of the radio bottom compared to the label |
-| direction | vertical or horizontal | horizontal | - | Display direction of the radios |
+| direction | vertical or horizontal | vertical | - | Display direction of the radios |
 | id | string | - | - | An identifier of the component |
 
 

--- a/src/RadioGroup/README.md
+++ b/src/RadioGroup/README.md
@@ -10,6 +10,7 @@
 | onChange | func | - | - | Callback function when user selects a different value |
 | disabledRadios | arrayOf(number, string) | [] | - | the values of the disabled radio buttons |
 | vAlign | top, center | top | - | Positioning of the radio bottom compared to the label |
+| direction | vertical or horizontal | horizontal | - | Display direction of the radios |
 | id | string | - | - | An identifier of the component |
 
 

--- a/src/RadioGroup/RadioButton.js
+++ b/src/RadioGroup/RadioButton.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {PropTypes} from 'react';
 import uniqueId from 'lodash.uniqueid';
 import styles from './RadioGroup.scss';
 import classNames from 'classnames';
@@ -24,7 +24,7 @@ class RadioButton extends React.Component {
     });
 
     return (
-      <div className={styles.wrapper}>
+      <div className={styles.radioWrapper}>
         <input
           type="radio"
           name={name}
@@ -45,16 +45,16 @@ class RadioButton extends React.Component {
   }
 }
 
-RadioButton.displayName = 'RadioGroup.Button';
-
 RadioButton.propTypes = {
-  value: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number]),
-  vAlign: React.PropTypes.oneOf(['center', 'top']),
-  name: React.PropTypes.string,
-  onChange: React.PropTypes.func,
-  checked: React.PropTypes.bool,
-  disabled: React.PropTypes.bool,
-  children: React.PropTypes.any
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  vAlign: PropTypes.oneOf(['center', 'top']),
+  name: PropTypes.string,
+  onChange: PropTypes.func,
+  checked: PropTypes.bool,
+  disabled: PropTypes.bool,
+  children: PropTypes.any
 };
+
+RadioButton.displayName = 'RadioGroup.Button';
 
 export default RadioButton;

--- a/src/RadioGroup/RadioGroup.driver.js
+++ b/src/RadioGroup/RadioGroup.driver.js
@@ -10,7 +10,9 @@ const radioGroupDriverFactory = component => ({
   radioAt: index => component.find('input').at(index),
   labelAt: index => component.childAt(index).find('label'),
   allRadios: () => component.children().find('input'),
-  getClassOfLabelAt: index => component.childAt(index).find('label').node.className
+  getClassOfLabelAt: index => component.childAt(index).find('label').node.className,
+  isVerticalDisplay: () => component.find('.vertical').length > 0,
+  isHorizontalDisplay: () => component.find('.horizontal').length > 0
 });
 
 const componentFactory = options => {

--- a/src/RadioGroup/RadioGroup.js
+++ b/src/RadioGroup/RadioGroup.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {PropTypes} from 'react';
 import uniqueId from 'lodash.uniqueid';
 import RadioButton from './RadioButton';
 import styles from './RadioGroup.scss';
@@ -6,7 +6,7 @@ import styles from './RadioGroup.scss';
 class RadioGroup extends React.Component {
   constructor(props) {
     super(props);
-    this.name = uniqueId();
+    this.name = uniqueId('RadioGroup_');
 
     if (props.children.some(child => child.type.name !== 'RadioButton')) {
       throw new Error(
@@ -16,10 +16,10 @@ class RadioGroup extends React.Component {
   }
 
   render() {
-    const {onChange, disabledRadios, value, vAlign, id} = this.props;
+    const {onChange, disabledRadios, value, vAlign, display, id} = this.props;
 
     return (
-      <div className={styles.wrapper} id={id}>
+      <div className={styles[display]} id={id}>
         {React.Children.map(this.props.children, radio => (
           <RadioGroup.Radio
             value={radio.props.value}
@@ -38,12 +38,13 @@ class RadioGroup extends React.Component {
 }
 
 RadioGroup.propTypes = {
-  onChange: React.PropTypes.func,
-  value: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number]),
-  disabledRadios: React.PropTypes.arrayOf(React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number])),
-  vAlign: React.PropTypes.oneOf(['center', 'top']),
-  id: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number]),
-  children: React.PropTypes.arrayOf((propValue, key) => {
+  onChange: PropTypes.func,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  disabledRadios: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
+  vAlign: PropTypes.oneOf(['center', 'top']),
+  display: PropTypes.oneOf(['vertical', 'horizontal']),
+  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  children: PropTypes.arrayOf((propValue, key) => {
     if (propValue[key].type.name !== 'RadioButton') {
       return new Error(`InputWithOptions: Invalid Prop children was given. Validation failed on child number ${key}`);
     }
@@ -54,7 +55,8 @@ RadioGroup.defaultProps = {
   disabledRadios: [],
   onChange: () => {},
   value: '',
-  vAlign: 'center'
+  vAlign: 'center',
+  display: 'vertical'
 };
 
 RadioGroup.Radio = RadioButton;

--- a/src/RadioGroup/RadioGroup.scss
+++ b/src/RadioGroup/RadioGroup.scss
@@ -1,37 +1,73 @@
 @import '../common.scss';
 
-.wrapper, .wrapper > *
+.vertical
+{
+  display: flex;
+  flex-direction: column;
+}
+
+.horizontal
+{
+  display: flex;
+}
+
+.horizontal .radio-wrapper > label, :global(.ltr) .horizontal .radio-wrapper > label
+{
+  margin-right: 20px;
+}
+
+:global(.rtl) .horizontal .radio-wrapper > label
+{
+  margin-left: 20px;
+}
+
+.vertical .radio-wrapper
+{
+  margin-bottom: 12px;
+}
+
+.radio-wrapper
+{
+  display: flex;
+}
+
+.radio-wrapper, .radio-wrapper > *
 {
     cursor:pointer;
     box-sizing:border-box;
 }
 
-.wrapper > input
+.radio-wrapper > input
 {
     display: none;
 }
 
-.wrapper > label
+.radio-wrapper > label
 {
     display: flex;
 }
 
-:global(.ltr) .wrapper > label {
+:global(.ltr) .radio-wrapper > label {
     flex-direction: row;
 }
 
-:global(.rtl) .wrapper > label {
+:global(.rtl) .radio-wrapper > label {
     flex-direction: row-reverse;
 }
 
-.wrapper > label.vcenter
+.radio-wrapper > label.vcenter
 {
     align-items: center;
 }
 
-.wrapper > label.vtop
+.radio-wrapper > label.vtop
 {
     align-items: top;
+}
+
+.horizontal .children, :global(.ltr) .horizontal .children
+{
+    padding-left: 6px;
 }
 
 .children, :global(.ltr) .children
@@ -70,7 +106,7 @@
 
 .radio:hover
 {
-    background-color: $B50;
+  background-color: $B50;
 }
 
 .radio.disabled

--- a/src/RadioGroup/RadioGroup.spec.js
+++ b/src/RadioGroup/RadioGroup.spec.js
@@ -101,4 +101,24 @@ describe('RadioGroup', () => {
     expect(driver.getClassOfLabelAt(0)).toEqual('vtop');
     expect(driver.getClassOfLabelAt(1)).toEqual('vtop');
   });
+
+  it('should have a vertical class by default', () => {
+    const options = [{value: 0}, {value: 1}];
+    const {createMount} = componentFactory(options);
+
+    const component = createMount({});
+    const driver = radioGroupDriverFactory(component);
+
+    expect(driver.isVerticalDisplay()).toBeTruthy();
+  });
+
+  it('should have a horizontal class', () => {
+    const options = [{value: 0}, {value: 1}];
+    const {createMount} = componentFactory(options);
+
+    const component = createMount({display: 'horizontal'});
+    const driver = radioGroupDriverFactory(component);
+
+    expect(driver.isHorizontalDisplay()).toBeTruthy();
+  });
 });

--- a/stories/RadioGroup/ExampleHorizontal.js
+++ b/stories/RadioGroup/ExampleHorizontal.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import RadioGroup from 'wix-style-react/RadioGroup';
+
+const style = {
+  display: 'inline-block',
+  padding: '0 5px',
+  width: '400px',
+  lineHeight: '22px',
+  marginBottom: '30px'
+};
+
+export default () =>
+  <div className="ltr" style={style}>
+    <RadioGroup value={1} display="horizontal">
+      <RadioGroup.Radio value={1}>Option 1</RadioGroup.Radio>
+      <RadioGroup.Radio value={2}>Option 2</RadioGroup.Radio>
+      <RadioGroup.Radio value={3}>Option 3</RadioGroup.Radio>
+      <RadioGroup.Radio value={4}>Option 4</RadioGroup.Radio>
+    </RadioGroup>
+  </div>;

--- a/stories/RadioGroup/index.js
+++ b/stories/RadioGroup/index.js
@@ -10,6 +10,9 @@ import ExampleStandardRaw from '!raw!./ExampleStandard';
 import ExamplevAlign from './ExamplevAlign';
 import ExamplevAlignRaw from '!raw!./ExamplevAlign';
 
+import ExampleHorizontal from './ExampleHorizontal';
+import ExampleHorizontalRaw from '!raw!./ExampleHorizontal';
+
 import ExampleControlled from './ExampleControlled';
 import ExampleControlledRaw from '!raw!./ExampleControlled';
 
@@ -26,6 +29,10 @@ storiesOf('2. Switches', module)
 
       <CodeExample title="vAlign" code={ExamplevAlignRaw}>
         <ExamplevAlign/>
+      </CodeExample>
+
+      <CodeExample title="Horizontal" code={ExampleHorizontalRaw}>
+        <ExampleHorizontal/>
       </CodeExample>
 
       <CodeExample title="Controlled input" code={ExampleControlledRaw}>


### PR DESCRIPTION
Today the testkit concept scares people off so we end up with a lot of untested components.
After writing three testkits I noticed that there is a lot of code duplication among the different testkits.

Instead of requiring each component to have a testkit, we will have a test-common file which will capture all the similar code.

This will save a lot of time and effort from the components’ developers, but there must be some basic ground rules in order for this concept to work:

1. Each component must have component.driverFactory file which will contain the implementation of it’s driverFactory.

2. Each component must have an id attribute place on it’s most external layer.

3. In component.spec.js file we will need to import 
	-  componentDriverFactory from ‘./component.driverFactory' 
	-  {createDriverWrapper} from './../test-common';

	Then use them use them as follow:
	  const createDriver = createDriverWrapper(componentDriverFactory);

	That’s it. now every ‘it’ block will call createDriver:
		
```
import React from 'react';
import InputDriverFactory from ‘./Input.driverFactory';
import {createDriverWrapper} from './../utils';
import Input from ‘./Input’;

describe('Input', () => {

  const createDriver = createDriverWrapper(inputDriverFactory);

  it('should check that the unit text if passed', () => {
      const unit = '$';

      const driver = createDriver(<Input unit={unit}/>);
      expect(driver.getUnit()).toEqual(unit);
    });
```

**This PR affects only Input and ButtonSelection, but only in the tests that uses their driverFactory.**