### PR TITLE
Adding ID to Dropdown element if provided, for enzyme testing

### DIFF
--- a/src/InputWithOptions/InputWithOptions.js
+++ b/src/InputWithOptions/InputWithOptions.js
@@ -60,7 +60,7 @@ class InputWithOptions extends React.Component {
     const dropdownProps = Object.assign(omit(this.props, Object.keys(Input.propTypes)), this.dropdownAdditionalProps());
 
     return (
-      <div onBlur={this._onBlur}>
+      <div id={this.props.id} onBlur={this._onBlur}>
         <div onKeyDown={this._onKeyDown} onFocus={this._onFocus} className={this.inputClasses()}>
           {this.renderInput()}
         </div>


### PR DESCRIPTION
When creating a `<Dropdown/>` component, the wrapping DOM element does not get any ID even if provided as a prop, and thus the enzyme test kit does not work.

The test kit (`Dropdown.enzyme.js`) requires the id: ```const component = wrapper.find(`#${id}`);```