### PR TITLE
fix(tooltip): break words by default if they dont fit into the tooltip

### DIFF
--- a/src/Tooltip/TooltipContent.scss
+++ b/src/Tooltip/TooltipContent.scss
@@ -25,6 +25,7 @@ $shadow: 0 0 11px 0 $shadow-color;
   line-height: $line-height;
   opacity: $opacity;
   box-shadow: $shadow;
+  word-break: break-all;
   -webkit-font-smoothing: antialiased;
   &.light {
     color: $D10;


### PR DESCRIPTION
otherwise the content gets overflown