### PR TITLE
fix(modal): remove redundant transform translate positioning

### DIFF
--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -32,12 +32,6 @@ const Modal = props => {
     },
     content: {
       // Overriding defaults
-      position: 'fixed',
-      top: '50%',
-      left: '50%',
-      right: 'initial',
-      bottom: 'initial',
-      transform: null,
       border: 'none',
       overflow: 'initial',
       WebkitOverflowScrolling: 'touch',

--- a/src/Modal/Modal.scss
+++ b/src/Modal/Modal.scss
@@ -30,19 +30,19 @@
 
     .ReactModal__Content {
         opacity: 0.66;
-        transform: translateX(-50%) translateY(-50%) scale(0.93);
+        transform: scale(0.93);
     }
 
     .ReactModal__Content--after-open {
         opacity: 1;
-        transform: translateX(-50%) translateY(-50%) scale(1);
+        transform: scale(1);
         transition: opacity 0.35s $wix-modal-easeOutQuint, transform 0.35s $wix-modal-easeOutQuint;
     }    
 
     .ReactModal__Content--before-close {
         pointer-events: none;
         opacity: 0;
-        transform: translateX(-50%) translateY(-50%) scale(0.9);
+        transform: scale(0.9);
         transition: opacity 0.3s $wix-modal-easeOutQuint, transform 0.04s $wix-modal-easeOutQuint;
     }    
 }

--- a/stories/Modal/ExampleControlled.js
+++ b/stories/Modal/ExampleControlled.js
@@ -22,7 +22,7 @@ class ControlledModal extends Component {
     return (
       <div>
         <Button onClick={open} >Open Blue Modal</Button>
-        <Modal isOpen={this.state.isOpen} onRequestClose={close} contentLabel="Modal Example">
+        <Modal isOpen={this.state.isOpen} onRequestClose={close} contentLabel="Modal Example" verticalPosition="center">
           <MessageBoxLayout2 theme="blue" title="title" confirmText="OK" cancelText="Cancel" onOk={close} onCancel={close}>
               Hello blue world!
           </MessageBoxLayout2>


### PR DESCRIPTION
hi, this is a removal of `transform` positioning on modal contents in order to utilize `flex` and `align-items: center;` both of which are already implemented.

`transform: translate(-50%, -50%)` can cause significant bluriness of whole modal contents on some displays.

moreover, there seems no reason to position contents using `transform` since there's already `flex` positioning on parent element and already existing `verticalPosition` prop.

note that i changed story example and added `verticalPosition="center"`, cause default is `start`. I would change default to `center` in order to not break any projects but i'll leave this decision to you.

@koriguy @nirhart 