### PR TITLE
WixComponent - add datahook only when an element exists

### DIFF
--- a/src/Toast/Toast.spec.js
+++ b/src/Toast/Toast.spec.js
@@ -75,5 +75,13 @@ describe('Toast', () => {
       const toastTestkit = enzymeToastTestkitFactory({wrapper, dataHook});
       expect(toastTestkit.exists()).toBeTruthy();
     });
+
+    it('should create new driver even when component is not shown', () => {
+      const dataHook = 'myDataHook';
+      const props = Object.assign({}, defaultProps, {show: false});
+      const wrapper = mount(<Toast dataHook={dataHook} {...props}/>);
+      const toastTestkit = enzymeToastTestkitFactory({wrapper, dataHook});
+      expect(toastTestkit.exists()).toBeFalsy();
+    });
   });
 });

--- a/src/WixComponent.js
+++ b/src/WixComponent.js
@@ -7,6 +7,7 @@ class WixComponent extends React.Component {
 
   constructor(params) {
     super(params);
+    this.dataHookIsSet = false;
     this._addDataHook = this._addDataHook.bind(this);
     this._supportOnClickOutside = this._supportOnClickOutside.bind(this);
     this._onMouseEventsHandler = this._onMouseEventsHandler.bind(this);
@@ -30,7 +31,13 @@ class WixComponent extends React.Component {
   }
 
   _addDataHook(dataHook) {
-    ReactDOM.findDOMNode(this).setAttribute('data-hook', dataHook);
+    if (!this.dataHookIsSet) {
+      const node = ReactDOM.findDOMNode(this);
+      if (node) {
+        node.setAttribute('data-hook', dataHook);
+        this.dataHookIsSet = true;
+      }
+    }
   }
 
   _supportOnClickOutside() {
@@ -39,6 +46,13 @@ class WixComponent extends React.Component {
     });
 
     this._boundEvents = MOUSE_EVENTS_SUPPORTED;
+  }
+
+  componentWillUpdate() {
+    const {dataHook} = this.props;
+    if (dataHook) {
+      this._addDataHook(dataHook);
+    }
   }
 
   componentDidMount() {


### PR DESCRIPTION
Fixes case when a component could return `null` and WixComponent failed to add a data-hook