### PR TITLE
Fix default props for dropdownOffsetLeft

### DIFF
--- a/src/InputWithOptions/InputWithOptions.js
+++ b/src/InputWithOptions/InputWithOptions.js
@@ -177,7 +177,7 @@ InputWithOptions.defaultProps = {
   inputElement: <Input/>,
   valueParser: option => option.value,
   dropdownWidth: null,
-  dropdownOffsetLeft: 0
+  dropdownOffsetLeft: '0'
 };
 
 InputWithOptions.propTypes = {


### PR DESCRIPTION
Now I have warning for this case, propType for `dropdownOffsetLeft ` is `string`