### PR TITLE
WixComponent - fixed setting dataHook on null rendered components

### DIFF
--- a/src/WixComponent.js
+++ b/src/WixComponent.js
@@ -35,7 +35,10 @@ class WixComponent extends React.Component {
   }
 
   _addDataHook(dataHook) {
-    ReactDOM.findDOMNode(this).setAttribute('data-hook', dataHook);
+    const domNode = ReactDOM.findDOMNode(this);
+    if (domNode) {
+      domNode.setAttribute('data-hook', dataHook);
+    }
   }
 
   _supportOnClickOutside() {


### PR DESCRIPTION
There would be an error when a null rendered component (could be DataTable for example) will try to add the data-hook attribute