### PR TITLE
Grid Row and Column: RTL support.

### DIFF
--- a/src/Grid/Grid.js
+++ b/src/Grid/Grid.js
@@ -1,6 +1,7 @@
 import React, {Component} from 'react';
 import styles from './Grid.scss';
 import Card from '../Card';
+import classNames from 'classnames';
 
 class Container extends Component {
 
@@ -20,12 +21,17 @@ class Container extends Component {
 class Row extends Component {
 
   static propTypes = {
-    children: React.PropTypes.node
+    children: React.PropTypes.node,
+    rtl: React.PropTypes.bool
   };
 
   render() {
+    const rowClasses = classNames(styles.row, {
+      [styles.rtl]: this.props.rtl
+    });
+
     return (
-      <div className={styles.row}>
+      <div className={rowClasses}>
         {this.props.children}
       </div>
     );
@@ -55,14 +61,19 @@ class Col extends Component {
 
   static propTypes = {
     children: React.PropTypes.node,
-    span: React.PropTypes.number.isRequired
+    span: React.PropTypes.number.isRequired,
+    rtl: React.PropTypes.bool
   };
 
   render() {
-    const className = styles[`colXs${this.props.span}`];
+    const columnClasses = classNames(
+      styles.column,
+      styles[`colXs${this.props.span}`], {
+        [styles.rtl]: this.props.rtl
+      });
 
     return (
-      <div className={className}>
+      <div className={columnClasses}>
         {this.props.children}
       </div>
     );

--- a/src/Grid/Grid.scss
+++ b/src/Grid/Grid.scss
@@ -28,3 +28,6 @@ $grid-row-margin-bottom: 30px;
 	max-width: $main-container-max-width;
 }
 
+.rtl .column, .column.rtl {
+    float: right;
+}

--- a/src/Grid/README.md
+++ b/src/Grid/README.md
@@ -53,7 +53,11 @@ The card is a container component of a rounded corner layout
 
 #### Row
 
-A simple row according to the bootstrap docs
+A simple row according to the bootstrap docs.
+
+| propName | propType | defaultValue | isRequired | description |
+|----------|----------|--------------|------------|-------------|
+| rtl | bool | - | - | Reverses the columns ordering |
 
 #### AutoAdjustedRow
 
@@ -68,3 +72,4 @@ A simple column according to the bootstrap docs
 | propName | propType | defaultValue | isRequired | description |
 |----------|----------|--------------|------------|-------------|
 | span | number | - | + | The columns span of this column |
+| rtl | bool | - | - | Causing the column to float right |

--- a/stories/GridWithCardLayout/ExampleGrid.js
+++ b/stories/GridWithCardLayout/ExampleGrid.js
@@ -323,5 +323,23 @@ export default () =>
           </Card>
         </Col>
       </Row>
+      <Card>
+          <Card.Header title='Grid Row - RTL support'>
+              Row RTL support
+          </Card.Header>
+          <Card.Content>
+              <Row rtl>
+                  <Col span={4}>
+                      אחת
+                  </Col>
+                  <Col span={4}>
+                      שתיים
+                  </Col>
+                  <Col span={4}>
+                      שלוש
+                  </Col>
+              </Row>
+          </Card.Content>
+      </Card>
     </Container>
   </div>;


### PR DESCRIPTION
Passing the RTL prop to a Row reverses its child cols ordering.
Passing the RTL prop to a Column makes it float right instead of left.