### PR TITLE
[checkbox] align label appearance according to design system

### DIFF
--- a/src/Checkbox/Checkbox.js
+++ b/src/Checkbox/Checkbox.js
@@ -40,7 +40,7 @@ class Checkbox extends WixComponent {
     return (
       <div className={classname} >
         <input type="checkbox" id={id} checked={checked} disabled={disabled} onChange={disabled ? null : onChange}/>
-        <Label for={id} appearance="T3.1">
+        <Label for={id} appearance="T1.1">
           <div className={styles.checkbox}>
             <div className={styles.inner}>
               {checkedSymbol}


### PR DESCRIPTION
Label for checkbox component always uses color scheme: 

```
font-family: HelveticaNeueW01-45;
font-size: 16px;
```
So I think it is reasonable to set this value by default.

TBD: 
1. do we want to have this property as part of public API of `Checkbox` component? 
2. How to deal with `disabled` state? In zeplin text-color of `<Checkbox disabled/>` is `#cbd3dc;` in the other hand we don't have typography with this value, can we use `typography.t1_4` or not? 