### PR TITLE
chore(Typography): update examples to use `<Text/>`

### DIFF
--- a/src/Typography/README.md
+++ b/src/Typography/README.md
@@ -1,0 +1,20 @@
+# Typography
+
+The supported way to type text Wix style:
+
+1. Load Wix fonts from CDN:
+
+```html
+<link rel="stylesheet" href="//static.parastorage.com/services/third-party/fonts/Helvetica/fontFace.css">
+```
+
+2. Use `<Text>` component with appropriate `appearance`:
+```js
+import { Text } from 'wix-style-react';
+
+export default () =>
+  <div>
+    <Text appearance="H0">Big Heading</Text>
+    <Text>Anything goes...</Text>
+  </div>;
+```

--- a/stories/Common/ExampleHeadersTypography.js
+++ b/stories/Common/ExampleHeadersTypography.js
@@ -1,15 +1,16 @@
 import React from 'react';
-import classNames from 'classnames';
 
-import typography from '../../src/Typography';
+import {Text} from 'wix-style-react';
 
 export default () =>
-  <ul className="ltr style-list">
-    <li className={typography.h0}>H0 - Helvetica_25 /48px</li>
-    <li className={typography.h1}>H1 - Helvetica_35 /36px</li>
-    <li className={typography.h2}>H2 - Helvetica_45 /20px</li>
-    <li className={classNames(typography.h2_1, 'inverted')}>H2.1 - Helvetica_45 /20px</li>
-    <li className={typography.h3}>H3 - Helvetica_45 /13px</li>
-    <li className={typography.h4}>H4 - Helvetica_55 /10px</li>
-  </ul>
-;
+  <div>
+    <Text appearance="H0">H0 - Helvetica_25 / 48 px</Text>
+    <Text appearance="H1">H1 - Helvetica_35 / 36px</Text>
+    <Text appearance="H2">H2 - Helvetica_45 / 20px</Text>
+    <div className="inverted">
+      <Text appearance="H2.1">H2.1 - Helvetica_45 / 20px</Text>
+    </div>
+    <Text appearance="H3">H3 - Helvetica_45 / 13px</Text>
+    <Text appearance="H4">H4 - Helvetica_55 / 10px</Text>
+  </div>;
+

--- a/stories/Common/ExampleTextTypography.js
+++ b/stories/Common/ExampleTextTypography.js
@@ -1,52 +1,56 @@
 import React from 'react';
-import typography from '../../src/Typography';
-import classNames from 'classnames';
+
+import {Text} from 'wix-style-react';
 
 export default () =>
-  <ul className="ltr style-list">
-    <li>
-      <h3>Body</h3>
-      <ul className="ltr style-list">
-        <li className={typography.t1}>T1 - Helvetica_45 /16px /24px</li>
-        <li className={typography.t1_1}>T1.1 - Helvetica_45 /16px /24px</li>
-        <li className={classNames(typography.t1_2, 'inverted')}>T1.2 - Helvetica_45 /16px /24px</li>
-        <li className={typography.t1_3}>T1.3 - Helvetica_45 /16px /24px</li>
-        <li className={typography.t1_4}>T1.4 - Helvetica_45 /16px /24px</li>
-      </ul>
-    </li>
-    <li>
-      <h3>Body Bold</h3>
-      <ul className="ltr style-list">
-        <li className={typography.t2}>T2 - Helvetica_55 /16px /24px</li>
-        <li className={typography.t2_1}>T2.1 - Helvetica_55 /16px /24px</li>
-        <li className={classNames(typography.t2_2, 'inverted')}>T2.2 - Helvetica_55 /16px /24px</li>
-        <li className={typography.t2_3}>T2.3 - Helvetica_55 /16px /24px</li>
-      </ul>
-    </li>
-    <li>
-      <h3>Body Small</h3>
-      <ul className="ltr style-list">
-        <li className={typography.t3}>T3 - Helvetica_45 /14px /18px</li>
-        <li className={typography.t3_1}>T3.1 - Helvetica_45 /14px /18px</li>
-        <li className={classNames(typography.t3_2, 'inverted')}>T3.2 - Helvetica_45 /14px /18px</li>
-        <li className={typography.t3_3}>T3.3 - Helvetica_45 /14px /18px</li>
-        <li className={typography.t3_4}>T3.4 - Helvetica_45 /14px /18px</li>
-      </ul>
-    </li>
-    <li>
-      <h3>Body Small Bold</h3>
-      <ul className="ltr style-list">
-        <li className={typography.t4}>T4 - Helvetica_55 /14px /18px</li>
-        <li className={typography.t4_1}>T4.1 - Helvetica_55 /14px /18px</li>
-        <li className={classNames(typography.t4_2, 'inverted')}>T4.2 - Helvetica_55 /14px /18px</li>
-        <li className={typography.t4_3}>T4.3 - Helvetica_55 /14px /18px</li>
-      </ul>
-    </li>
-    <li>
-      <h3>Text on labels</h3>
-      <ul className="ltr style-list">
-        <li className={typography.t5}>T5 - Helvetica_65 /10px</li>
-        <li className={classNames(typography.t5_1, 'inverted')}>T5.1 - Helvetica_65 /10px</li>
-      </ul>
-    </li>
-  </ul>;
+  <div>
+    <h3>Body</h3>
+    <ul className="ltr style-list">
+      <li><Text appearance="T1">T1 - Helvetica_45 / 16px / 24px</Text></li>
+      <li><Text appearance="T1.1">T1.1 - Helvetica_45 / 16px / 24px</Text></li>
+      <li className="inverted">
+        <Text appearance="T1.2">T1.2 - Helvetica_45 / 16px / 24px</Text>
+      </li>
+      <li><Text appearance="T1.3">T1.3 - Helvetica_45 / 16px / 24px</Text></li>
+      <li><Text appearance="T1.4">T1.4 - Helvetica_45 / 16px / 24px</Text></li>
+    </ul>
+
+    <h3>Body Bold</h3>
+    <ul className="ltr style-list">
+      <li><Text appearance="T2">T2 - Helvetica_55 / 16px / 24px</Text></li>
+      <li><Text appearance="T2.1">T2.1 - Helvetica_55 / 16px / 24px</Text></li>
+      <li className="inverted">
+        <Text appearance="T2.2">T2.2 - Helvetica_55 / 16px / 24px</Text>
+      </li>
+      <li><Text appearance="T2.3">T2.3 - Helvetica_55 / 16px / 24px</Text></li>
+    </ul>
+
+    <h3>Body Small</h3>
+    <ul className="ltr style-list">
+      <li><Text appearance="T3">T3 - Helvetica_45 / 14px / 18px</Text></li>
+      <li><Text appearance="T3.1">T3.1 - Helvetica_45 / 14px / 18px</Text></li>
+      <li className="inverted">
+        <Text appearance="T3.2">T3.2 - Helvetica_45 / 14px / 18px</Text>
+      </li>
+      <li><Text appearance="T3.3">T3.3 - Helvetica_45 / 14px / 18px</Text></li>
+      <li><Text appearance="T3.4">T3.4 - Helvetica_45 / 14px / 18px</Text></li>
+    </ul>
+
+    <h3>Body Small Bold</h3>
+    <ul className="ltr style-list">
+      <li><Text appearance="T4">T4 - Helvetica_55 / 14px / 18px</Text></li>
+      <li><Text appearance="T4.1">T4.1 - Helvetica_55 / 14px / 18px</Text></li>
+      <li className="inverted">
+        <Text appearance="T4.2">T4.2 - Helvetica_55 / 14px / 18px</Text>
+      </li>
+      <li><Text appearance="T4.3">T4.3 - Helvetica_55 / 14px / 18px</Text></li>
+    </ul>
+
+    <h3>Text on labels</h3>
+    <ul className="ltr style-list">
+      <li><Text appearance="T5">T5 - Helvetica_65 / 10px</Text></li>
+      <li className="inverted">
+        <Text appearance="T5.1">T5.1 - Helvetica_65 / 10px</Text>
+      </li>
+    </ul>
+  </div>;

--- a/stories/Common/index.js
+++ b/stories/Common/index.js
@@ -1,19 +1,25 @@
 import React from 'react';
 import {storiesOf} from '@kadira/storybook';
 import CodeExample from '../utils/Components/CodeExample';
-import ExampleHeadersTypography from './ExampleHeadersTypography';
-import ExampleTextTypography from './ExampleTextTypography';
+import Markdown from '../utils/Components/Markdown';
 
+import Readme from '../../src/Typography/README.md';
+
+import ExampleHeadersTypography from './ExampleHeadersTypography';
 import ExampleHeaderTypographyRaw from '!raw!./ExampleHeadersTypography';
+
+import ExampleTextTypography from './ExampleTextTypography';
 import ExampleTextTypographyRaw from '!raw!./ExampleTextTypography';
 
 storiesOf('Common', module)
   .add('Typography', () => (
     <div>
-      <h1>Typography</h1>
+      <Markdown source={Readme}/>
+
       <CodeExample title="Headers" code={ExampleHeaderTypographyRaw}>
         <ExampleHeadersTypography/>
       </CodeExample>
+
       <CodeExample title="Text" code={ExampleTextTypographyRaw}>
         <ExampleTextTypography/>
       </CodeExample>


### PR DESCRIPTION
no more css classname imports