### PR TITLE
pass context to tooltip content

### DIFF
--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -8,6 +8,8 @@ import position from './TooltipPosition';
 
 import styles from './TooltipContent.scss';
 
+const renderSubtreeIntoContainer = ReactDOM.unstable_renderSubtreeIntoContainer;
+
 class Tooltip extends WixComponent {
 
   componentElements() {
@@ -123,7 +125,7 @@ class Tooltip extends WixComponent {
           {this.props.content}
         </TooltipContent>);
 
-      ReactDOM.render(tooltip, this._mountNode);
+      renderSubtreeIntoContainer(this, tooltip, this._mountNode);
     }
   }
 


### PR DESCRIPTION
enables the context to be available on a tooltips content component, instead of passing it manually