### PR TITLE
chore(SideMenu): navigation link refactor

### DIFF
--- a/src/SideMenu/DrillView/DrillView.js
+++ b/src/SideMenu/DrillView/DrillView.js
@@ -61,11 +61,26 @@ class SideMenuDrill extends WixComponent {
     this.setState({currentMenuId: nextMenuId, previousMenuId, showMenuA, slideDirection});
   }
 
+  clickFirstClickableChild(item, event) {
+    let found = false;
+    if (item.props.onClick) {
+      item.props.onClick(event);
+      return true;
+    }
+
+    Children.forEach(item.props.children, child => {
+      if (!found && child.props) {
+        found = this.clickFirstClickableChild(child, event);
+      }
+    });
+    return found;
+  }
+
   selectFirstLinkChild(menu, event) {
     let found = false;
     Children.forEach(menu.props.children, child => {
       if (!found && child.type === SideMenuDrill.Link) {
-        child.props.onClick && child.props.onClick(event);
+        this.clickFirstClickableChild(child, event);
         found = true;
       }
 

--- a/src/SideMenu/DrillView/DrillView.spec.js
+++ b/src/SideMenu/DrillView/DrillView.spec.js
@@ -21,9 +21,11 @@ describe('DrillView', () => {
     const isLevelActive = activeLevel === level;
 
     return [...new Array(linksPerLevel)].map((_, i) => {
-      return <SideMenuDrill.Link key={`${level}_${i}`} isActive={isLevelActive && activeIndex === i}>
-        <a href="//wix.com" onClick={onClickSpy}>Link {i}</a>
-      </SideMenuDrill.Link>;
+      return (
+        <SideMenuDrill.Link key={`${level}_${i}`} isActive={isLevelActive && activeIndex === i}>
+          <a href="//wix.com" onClick={onClickSpy}>Link {i}</a>
+        </SideMenuDrill.Link>
+      );
     });
   }
 

--- a/src/SideMenu/DrillView/DrillView.spec.js
+++ b/src/SideMenu/DrillView/DrillView.spec.js
@@ -21,7 +21,9 @@ describe('DrillView', () => {
     const isLevelActive = activeLevel === level;
 
     return [...new Array(linksPerLevel)].map((_, i) => {
-      return <SideMenuDrill.Link key={`${level}_${i}`} isActive={isLevelActive && activeIndex === i} to="//wix.com" onClick={onClickSpy}>Link {i}</SideMenuDrill.Link>;
+      return <SideMenuDrill.Link key={`${level}_${i}`} isActive={isLevelActive && activeIndex === i}>
+        <a href="//wix.com" onClick={onClickSpy}>Link {i}</a>
+      </SideMenuDrill.Link>;
     });
   }
 
@@ -73,7 +75,7 @@ describe('DrillView', () => {
 
     expect(driver.getMenuDriver().headerContent()).toBe(getHeader(0));
     expect(driver.getMenuDriver().footerContent()).toBe(getFooter(0));
-    expect(driver.getMenuDriver().navigationLinks().length).toBe(linksPerLevel);
+    expect(driver.getMenuDriver().navigationInnerLinks().length).toBe(linksPerLevel);
   });
 
   it('should render a one level drill view with an active item', () => {
@@ -116,9 +118,12 @@ describe('DrillView', () => {
     expect(driver.getMenuDriver().footerContent()).toBe(getFooter(0));
     expect(driver.getMenuDriver().hasBackLink()).toBe(false);
 
-    driver.getMenuDriver().clickLinkByIndex(3);
+    // click the first sub menu
+    expect(onClickSpy.mock.calls.length).toBe(0);
+    driver.getMenuDriver().clickInnerLinkByIndex(3);
 
     expect(onClickSpy).toHaveBeenCalled();
+    expect(onClickSpy.mock.calls.length).toBe(1);
   });
 
   it('should navigate to a parent menu and sub menu link should be active', done => {

--- a/src/SideMenu/DrillView/Link.js
+++ b/src/SideMenu/DrillView/Link.js
@@ -2,10 +2,10 @@ import React from 'react';
 import {node, bool, string} from 'prop-types';
 import SideMenu from '../index';
 
-const Link = ({children, to, isActive, ...rest}) => (
-  <SideMenu.NavigationLink href={to} isActive={isActive} {...rest}>
+const Link = ({children, isActive, ...rest}) => (
+  <SideMenu.NavigationLinkLayout isActive={isActive} {...rest}>
     {children}
-  </SideMenu.NavigationLink>
+  </SideMenu.NavigationLinkLayout>
 );
 
 Link.defaultProps = {
@@ -13,7 +13,6 @@ Link.defaultProps = {
 };
 
 Link.propTypes = {
-  to: string.isRequired,
   children: node.isRequired,
   isActive: bool
 };

--- a/src/SideMenu/DrillView/Link.js
+++ b/src/SideMenu/DrillView/Link.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {node, bool, string} from 'prop-types';
+import {node, bool} from 'prop-types';
 import SideMenu from '../index';
 
 const Link = ({children, isActive, ...rest}) => (

--- a/src/SideMenu/DrillView/README.md
+++ b/src/SideMenu/DrillView/README.md
@@ -10,25 +10,25 @@ The menus are rendered using the SideMenu design.
   <SideMenu.Header>
     <h2>My Application</h2>
   </SideMenu.Header>
-  <SideMenuDrill.Link to="https://www.wix.com">Link #1</SideMenuDrill.Link>
-  <SideMenuDrill.Link to="https://www.wix.com">Link #2</SideMenuDrill.Link>
+  <SideMenuDrill.Link><a onClick={doSomething()}>Link #1</a></SideMenuDrill.Link>
+  <SideMenuDrill.Link><a href="//wix.com">Link #2</a></SideMenuDrill.Link>
   <SideMenuDrill.SubMenu menuKey="SUB_MENU_1" title="Sub Menu #1">
     <SideMenu.Header>
       <h2>My Internal Application</h2>
     </SideMenu.Header>
     <SideMenuDrill.Navigation>
-      <SideMenuDrill.Link to="https://www.wix.com">Link #3</SideMenuDrill.Link>
-      <SideMenuDrill.Link to="https://www.wix.com">Link #4</SideMenuDrill.Link>
+      <SideMenuDrill.Link><a onClick={doSomething()}>Link #3</a></SideMenuDrill.Link>
+      <SideMenuDrill.Link><a href="//wix.com">Link #4</a></SideMenuDrill.Link>
     </SideMenuDrill.Navigation>
   </SideMenuDrill.SubMenu>
   <SideMenuDrill.SubMenu menuKey="SUB_MENU_2" title="Sub Menu #2">
     <SideMenuDrill.Navigation>
-      <SideMenuDrill.Link to="https://www.wix.com">Link #5</SideMenuDrill.Link>
-      <SideMenuDrill.Link to="https://www.wix.com">Link #6</SideMenuDrill.Link>
+      <SideMenuDrill.Link><a onClick={doSomething()}>Link #5</a></SideMenuDrill.Link>
+      <SideMenuDrill.Link><a href="//wix.com">Link #6</a></SideMenuDrill.Link>
       <SideMenuDrill.SubMenu menuKey="SUB_MENU_3" title="Sub Menu #3">
         <SideMenuDrill.Navigation>
-          <SideMenuDrill.Link to="https://www.wix.com">Link #7</SideMenuDrill.Link>
-          <SideMenuDrill.Link to="https://www.wix.com">Link #8</SideMenuDrill.Link>
+          <SideMenuDrill.Link><a onClick={doSomething()}>Link #7</a></SideMenuDrill.Link>
+          <SideMenuDrill.Link><a href="//wix.com">Link #8</a></SideMenuDrill.Link>
         </SideMenuDrill.Navigation>
       </SideMenuDrill.SubMenu>
     </SideMenuDrill.Navigation>
@@ -56,17 +56,18 @@ Make sure you wrap the internal `Link`s and `SubMenu`s with a `Navigation` compo
 ### Link `<SideMenuDrill.Link/>`
 
 Main navigation item. Make sure you have zero or one Link active at all times.
+The children can be any node, but must contain an `anchor` element for the correct style to kick in.
 
 | propName          | propType | defaultValue | isRequired | description                                                                        |
 | -                 | -        | -            | -          | -                                                                                  |
-| to                | bool     | false        | -          | slightly different styling to indicate active link                                 |
 | isActive          | bool     | false        | -          | slightly different styling for hover (e.g. no background transition)               |
 | children          | node     | -            | -          | -                                                                                  |
 | ...rest           | *        | -            | -          | any other prop will be added to root element (e.g. `onClick`, `onMouseEnter` etc.) |
 
 ### SubMenu `<SideMenuDrill.SubMenu/>`
 
-A container of sub navigation items
+A container of sub navigation items.
+The first `Link` in a `Submenu` must have an `onClick` property (since clicking the submenu passes the click to the first child)
 
 | propName          | propType | defaultValue | isRequired | description                                                                                             |
 | -                 | -        | -            | -          | -                                                                                                       |

--- a/src/SideMenu/core/SideMenu.driver.js
+++ b/src/SideMenu/core/SideMenu.driver.js
@@ -5,6 +5,7 @@ const sideMenuDriverFactory = ({element}) => {
   const getHeader = () => element.querySelector('[data-hook=menu-header]');
   const getNavigation = () => element.querySelector('[data-hook=menu-navigation]');
   const getNavigationLinks = () => element.querySelectorAll('[data-hook=menu-navigation-link]');
+  const getNavigationLinkWrappers = () => element.querySelectorAll('[data-hook=menu-navigation-link-wrapper]');
   const getNavigationSeparators = () => element.querySelectorAll('[data-hook=menu-navigation-separator]');
   const getNavigationCategories = () => element.querySelectorAll('[data-hook=menu-navigation-category]');
   const getNavigationBackLink = () => element.querySelector('[data-hook=menu-navigation-back-link]');
@@ -20,11 +21,16 @@ const sideMenuDriverFactory = ({element}) => {
     hasBackLink: () => !!getNavigationBackLink(),
     headerContent: () => getHeader().textContent,
     navigationLinks: () => getNavigationLinks(),
-    isLinkActiveByIndex: index => getNavigationLinks()[index].classList.contains(navigationStyles.linkActive),
+    navigationInnerLinks: () => getNavigationLinkWrappers(),
+    isLinkActiveByIndex: index => getNavigationLinkWrappers()[index].classList.contains(navigationStyles.linkActive),
     navigationSeparators: () => getNavigationSeparators(),
     navigationCategories: () => getNavigationCategories(),
     navigationCategoryContent: index => getNavigationCategories()[index].textContent,
     clickLinkByIndex: index => ReactTestUtils.Simulate.click(getNavigationLinks()[index]),
+    clickInnerLinkByIndex: index => {
+      const innerLink = getNavigationLinkWrappers()[index].querySelector('a');
+      ReactTestUtils.Simulate.click(innerLink);
+    },
     clickBackLink: () => ReactTestUtils.Simulate.click(getNavigationBackLink()),
     promotionContent: () => getPromotion().textContent,
     footerContent: () => getFooter().textContent

--- a/src/SideMenu/core/navigation/Link.js
+++ b/src/SideMenu/core/navigation/Link.js
@@ -1,22 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
-import styles from './styles.scss';
-import {DataPickerArrow} from '../../../Icons/dist';
+import LinkLayout from './LinkLayout';
 
 const Link = ({children, isDiminishedHover, isActive, withArrow, ...rest}) =>
-  <a
-    className={classnames({
-      [styles.link]: true,
-      [styles.linkActive]: isActive,
-      [styles.linkDiminishedHover]: isDiminishedHover
-    })}
-    data-hook="menu-navigation-link"
-    {...rest}
-    >
-    {children}
-    {withArrow && <span className={styles.linkArrow}><DataPickerArrow/></span>}
-  </a>;
+  <LinkLayout isDiminishedHover={isDiminishedHover} isActive={isActive} withArrow={withArrow}>
+    <a data-hook="menu-navigation-link" {...rest}>
+      {children}
+    </a>
+  </LinkLayout>;
 
 Link.propTypes = {
   children: PropTypes.node,

--- a/src/SideMenu/core/navigation/LinkLayout.js
+++ b/src/SideMenu/core/navigation/LinkLayout.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import styles from './styles.scss';
+import {DataPickerArrow} from '../../../Icons/dist';
+
+const LinkLayout = ({children, isDiminishedHover, isActive, withArrow, ...rest}) =>
+  <span
+    className={classnames({
+      [styles.linkLayout]: true,
+      [styles.linkActive]: isActive,
+      [styles.linkDiminishedHover]: isDiminishedHover
+    })}
+    data-hook="menu-navigation-link-wrapper"
+    {...rest}
+  >
+    {children}
+    {withArrow && <span className={styles.linkArrow}><DataPickerArrow/></span>}
+  </span>;
+
+LinkLayout.propTypes = {
+  children: PropTypes.node,
+  isActive: PropTypes.bool,
+  withArrow: PropTypes.bool,
+  isDiminishedHover: PropTypes.bool
+};
+
+export default LinkLayout;

--- a/src/SideMenu/core/navigation/LinkLayout.js
+++ b/src/SideMenu/core/navigation/LinkLayout.js
@@ -13,7 +13,7 @@ const LinkLayout = ({children, isDiminishedHover, isActive, withArrow, ...rest})
     })}
     data-hook="menu-navigation-link-wrapper"
     {...rest}
-  >
+    >
     {children}
     {withArrow && <span className={styles.linkArrow}><DataPickerArrow/></span>}
   </span>;

--- a/src/SideMenu/core/navigation/styles.scss
+++ b/src/SideMenu/core/navigation/styles.scss
@@ -18,26 +18,11 @@ $padding-vertical: 14px;
   font-size: 14px;
   text-decoration: none;
   line-height: 14px;
-  position: relative;
 }
 
-.link {
-  @extend .link-base;
-  font-family: $FontRoman;
-
-  &:hover:not(.linkActive),
-  &:focus:not(.linkActive) {
-    background: #33566f;
-    color: #9fd8fc;
-    transition: 0.3s;
-  }
-
-  &.linkDiminishedHover:hover {
-    background: transparent;
-    color: $B20;
-  }
-
-  &.linkDiminishedHover:focus { background: transparent; }
+.link-layout {
+  position: relative;
+  display: block;
 
   &:hover,
   &:focus {
@@ -47,9 +32,38 @@ $padding-vertical: 14px;
       opacity: 100;
     }
   }
+
+  &:hover:not(.linkActive),
+  &:focus:not(.linkActive),
+  &:hover:not(.linkActive) a,
+  &:focus:not(.linkActive) a {
+    background: #33566f;
+    color: #9fd8fc;
+    transition: 0.3s;
+  }
+
+  &.linkDiminishedHover:hover,
+  &.linkDiminishedHover:hover a {
+    background: transparent;
+    color: $B20;
+  }
+
+  &.linkDiminishedHover:focus,
+  &.linkDiminishedHover:focus a {
+    background: transparent;
+  }
 }
 
-.linkActive {
+.link-layout, .link-layout a {
+  font-family: $FontRoman;
+  color: $D80;
+}
+
+.link-layout a {
+  @extend .link-base;
+}
+
+.linkActive a {
   color: #9fd8fc;
   background: #2A4F68;
   transition: 0.3s;

--- a/src/SideMenu/index.js
+++ b/src/SideMenu/index.js
@@ -3,6 +3,7 @@ import SideMenu from './core/SideMenu';
 import Header from './core/Header';
 import Navigation from './core/navigation';
 import NavigationLink from './core/navigation/Link';
+import NavigationLinkLayout from './core/navigation/LinkLayout';
 import NavigationBackLink from './core/navigation/BackLink';
 import NavigationSeparator from './core/navigation/Separator';
 import NavigationCategory from './core/navigation/Category';
@@ -15,6 +16,7 @@ SideMenu.Logo = Header;
 SideMenu.Header = Header;
 SideMenu.Navigation = Navigation;
 SideMenu.NavigationLink = NavigationLink;
+SideMenu.NavigationLinkLayout = NavigationLinkLayout;
 SideMenu.NavigationBackLink = NavigationBackLink;
 SideMenu.NavigationSeparator = NavigationSeparator;
 SideMenu.NavigationCategory = NavigationCategory;
@@ -24,4 +26,3 @@ SideMenu.FooterLink = FooterLink;
 SideMenu.FooterTinyLink = FooterTinyLink;
 
 export default SideMenu;
-

--- a/stories/SideMenu/ExampleSideMenuDrill.js
+++ b/stories/SideMenu/ExampleSideMenuDrill.js
@@ -60,8 +60,8 @@ class ExampleSideMenuDrill extends React.Component {
 
   renderLink(link) {
     return (
-      <SideMenuDrill.Link key={link.title} to={link.to} onClick={e => this.onMenuSelected(e, link)} isActive={link.isActive}>
-        {link.title}
+      <SideMenuDrill.Link key={link.title} isActive={link.isActive}>
+        <a href={link.to} onClick={e => this.onMenuSelected(e, link)}>{link.title}</a>
       </SideMenuDrill.Link>
     );
   }

--- a/stories/SideMenu/ExampleStandard.js
+++ b/stories/SideMenu/ExampleStandard.js
@@ -19,7 +19,7 @@ export default () =>
       </SideMenu.Header>
 
       <SideMenu.Navigation>
-        <SideMenu.NavigationLink onClick={() => console.log('#1 clicked')}>
+        <SideMenu.NavigationLink onClick={() => console.log('#1 clicked')} href="//wix.com">
           Link #1
         </SideMenu.NavigationLink>
         <SideMenu.NavigationLink withArrow onClick={() => console.log('#2 clicked')}>


### PR DESCRIPTION
1. Separate navigation link from its layout
2. Use only the layout for drill view

Backward compatible for SideMenu
Breaking changes for SideMenuDrill (which is only used in business-manager-sidebar)