### PR TITLE
Allow to pass suffix node to Card Header

### DIFF
--- a/src/Card/Header/Header.js
+++ b/src/Card/Header/Header.js
@@ -9,16 +9,18 @@ class Header extends WixComponent {
   static propTypes = {
     title: node.isRequired,
     subtitle: node,
-    withoutDivider: bool
+    withoutDivider: bool,
+    suffix: node
   };
 
   static defaultProps = {
     subtitle: null,
+    suffix: null,
     withoutDivider: false
   };
 
   render() {
-    const {title, subtitle, withoutDivider} = this.props;
+    const {title, subtitle, withoutDivider, suffix} = this.props;
 
     const headerClasses = classNames({
       [styles.header]: true,
@@ -33,14 +35,23 @@ class Header extends WixComponent {
 
     const subtitleElement = subtitle ? (
       <div data-hook="subtitle" className={styles.subtitle}>
-        {this.props.subtitle}
+        {subtitle}
+      </div>
+    ) : null;
+
+    const suffixElement = suffix ? (
+      <div data-hook="suffix">
+        {suffix}
       </div>
     ) : null;
 
     return (
       <div className={headerClasses}>
-        {titleElement}
-        {subtitleElement}
+        <div className={styles.container}>
+          {titleElement}
+          {subtitleElement}
+        </div>
+        {suffixElement}
       </div>
     );
   }

--- a/src/Card/Header/Header.scss
+++ b/src/Card/Header/Header.scss
@@ -3,11 +3,16 @@
 $header-padding: 27px 30px 26px;
 
 .header {
-
+  display: flex;
+  justify-content: space-between;
   padding: $header-padding;
 
   &.with-divider {
     border-bottom: 1px solid $D70;
+  }
+
+  .container {
+    flex-grow: 1;
   }
 
   .title {


### PR DESCRIPTION
I need to pass custom node to the right side:
http://dl4.joxi.net/drive/2017/07/13/0024/1666/1582722/22/5be2b37c5c.jpg
http://dl3.joxi.net/drive/2017/07/13/0024/1666/1582722/22/9eeabe8598.jpg

Will be better to use components with composition of existed instead of predefined types of huge components (LinkHeader, ButtonHeader)