### PR TITLE
Apply ltr styles to option by default

### DIFF
--- a/src/DropdownLayout/DropdownLayout.scss
+++ b/src/DropdownLayout/DropdownLayout.scss
@@ -101,8 +101,11 @@ $top-arrow-size: 8px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  text-align: left;
 
   padding-top: 0;
+  padding-left: 24px;
+  padding-right: 20px;
   @include FontLight();
 
   font-size: 16px;
@@ -114,12 +117,6 @@ $top-arrow-size: 8px;
 
 .disabled {
   color: $D50;
-}
-
-:global(.ltr) .option {
-  text-align: left;
-  padding-left: 24px;
-  padding-right: 20px;
 }
 
 :global(.rtl) .option {


### PR DESCRIPTION
In other case, we need to use wrapper with ltr class.
rtl will override styles, like before