### PR TITLE
fix changing collapsed state while rendering if collapsed=true was set

### DIFF
--- a/src/Card/CollapsedHeader/CollapsedHeader.js
+++ b/src/Card/CollapsedHeader/CollapsedHeader.js
@@ -41,7 +41,7 @@ class CollapsedHeader extends WixComponent {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.collapsed && nextProps.collapsed !== this.state.isCollapsed) {
+    if (this.props.collapsed !== nextProps.collapsed && nextProps.collapsed !== this.state.isCollapsed) {
       this.setState({isCollapsed: nextProps.collapsed});
     }
   }


### PR DESCRIPTION
<Card.CollapsedHeader collapsed>
initial state and state after user toggle it and  will be renderd as expected

but if parent component will be rendered, then card will collapse