### PR TITLE
modal(dev): make close icon more accurate

### DIFF
--- a/src/MessageBox/HeaderLayout.scss
+++ b/src/MessageBox/HeaderLayout.scss
@@ -29,6 +29,7 @@
     border           : none;
     background-color : rgba(red($D10), green($D10), blue($D10), 0.2);
     cursor           : pointer;
+    font-size        : 11px;
 }
 
 .close:hover, .close:focus {


### PR DESCRIPTION
The size of the X button icon is determined by the font-size, which should be 11px. sometimes projects defines other font sizes such as 100% and then it catches this value. Adding 11px makes it more accurate and solve bugs we encountered in our project