### PR TITLE
fix Tooltip bottom padding according to design

### DIFF
--- a/src/Tooltip/TooltipContent.scss
+++ b/src/Tooltip/TooltipContent.scss
@@ -3,7 +3,7 @@
 $zIndex: 2000;
 $font-size: 14px;
 $line-height: 1.29;
-$padding: 12px 24px 18px;
+$padding: 12px 24px;
 $border-radius: 8px;
 $shadow-color: rgba(0, 0, 0, 0.2);
 $shadow-color-arrow: rgba(0, 0, 0, .1);


### PR DESCRIPTION
![screen shot 2017-08-08 at 6 45 48 pm](https://user-images.githubusercontent.com/5727408/29081286-d9851908-7c6a-11e7-933c-b964e538d4c7.png)
![screen shot 2017-08-08 at 6 45 42 pm](https://user-images.githubusercontent.com/5727408/29081287-d99caa50-7c6a-11e7-95e9-6b6161bf2d95.png)

Probably 18px bottom was made by mistake 