### PR TITLE
fix: call onManuallyInput after delimiter key is pressed

### DIFF
--- a/src/Input/Input.driver.js
+++ b/src/Input/Input.driver.js
@@ -11,6 +11,7 @@ const inputDriverFactory = ({element, wrapper, component}) => {
     trigger: (trigger, event) => ReactTestUtils.Simulate[trigger](input, event),
     focus: () => input.focus(),
     blur: () => ReactTestUtils.Simulate.blur(input),
+    keyDown: key => ReactTestUtils.Simulate.keyDown(input, {key}),
     clickClear: () => ReactTestUtils.Simulate.click(clearButton),
     enterText: text => ReactTestUtils.Simulate.change(input, {target: {value: text}}),
     getValue: () => input.value,

--- a/src/MultiSelect/MultiSelect.driver.js
+++ b/src/MultiSelect/MultiSelect.driver.js
@@ -17,6 +17,7 @@ const multiSelectDriverFactory = ({element, wrapper, component}) => {
     inputWrapperHasFocus: () => inputWrapper.classList.contains('hasFocus'),
     numberOfTags: () => tags.length,
     getTagLabelAt: index => tags[index].textContent,
+    pressCommaKey: () => inputDriver.keyDown(','),
     setProps: props => {
       const ClonedWithProps = React.cloneElement(component, Object.assign({}, component.props, props), ...(component.props.children || []));
       ReactDOM.render(<div ref={r => element = r}>{ClonedWithProps}</div>, wrapper);

--- a/src/MultiSelect/MultiSelect.js
+++ b/src/MultiSelect/MultiSelect.js
@@ -101,6 +101,7 @@ class MultiSelect extends InputWithOptions {
     }
 
     if (event.key === 'Enter' || event.key === 'Tab' || delimiters.includes(event.key)) {
+      this._onManuallyInput(this.state.inputValue);
       if (this.props.value.trim()) {
         const unselectedOptions = this.getUnselectedOptions();
         const visibleOptions = unselectedOptions.filter(this.props.predicate);

--- a/src/MultiSelect/MultiSelect.spec.js
+++ b/src/MultiSelect/MultiSelect.spec.js
@@ -177,6 +177,18 @@ describe('multiSelect', () => {
     ]);
   });
 
+  it('should call onManuallyInput after delimiter is pressed and input is not empty', () => {
+    const onManuallyInput = jest.fn();
+    const {driver, inputDriver} = createDriver(<MultiSelect options={options} onManuallyInput={onManuallyInput} value="custom value"/>);
+
+    driver.focus();
+    inputDriver.enterText('custom value');
+    driver.pressCommaKey();
+
+    expect(onManuallyInput).toHaveBeenCalled();
+    expect(onManuallyInput.mock.calls[0][0]).toBe('custom value');
+  });
+
   describe('testkit', () => {
     it('should exist', () => {
       const div = document.createElement('div');


### PR DESCRIPTION
> Wix Videos reported that tag creation on hit 'Enter' or ',' (comma) doesn't work properly, while in Reactbook it works fine