### PR TITLE
fix: add-image button size in RichTextArea

### DIFF
--- a/src/RichTextArea/RichTextAreaButton.js
+++ b/src/RichTextArea/RichTextAreaButton.js
@@ -45,7 +45,7 @@ const buttons = {
   image: {
     icon: Image,
     tooltipText: 'Image',
-    size: 30
+    size: 14
   }
 };
 


### PR DESCRIPTION
> 3.4 Icon of the image is 30px. Please update it to the right size 14px x 13px