### PR TITLE
Fail test after errors inside

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "setupFiles": [
       "<rootDir>/node_modules/babel-polyfill"
     ],
+    "setupTestFrameworkScriptFile": "<rootDir>/testkit/setup-jest",
     "moduleNameMapper": {
       "\\.(css|less|scss)$": "identity-obj-proxy"
     },

--- a/testkit/setup-jest.js
+++ b/testkit/setup-jest.js
@@ -1,0 +1,18 @@
+const originConsoleError = console.error;
+let errorsCount = 0;
+
+console.error = function(...args) {
+  errorsCount = errorsCount + 1;
+
+  originConsoleError.apply(console, args);
+};
+
+beforeEach(() => {
+  errorsCount = 0;
+});
+
+afterEach(() => {
+  if (errorsCount) {
+    throw new Error('Test has an Unhandled Errors');
+  }
+});


### PR DESCRIPTION
I want to prevent incorrect using of props in my project, and for that I need to have valid using of prop types in my dependencies.

Also it will help to avoid potential issues with API changing. 

**Before we will merge this PR, we need to fix all errors**