### PR TITLE
feat: add getInfoTooltipTestKit to TextFieldTestKit

### DIFF
--- a/src/Composite/InputAreaWithLabelComposite/InputAreaWithLabelComposite.driver.js
+++ b/src/Composite/InputAreaWithLabelComposite/InputAreaWithLabelComposite.driver.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import $ from 'jquery';
+import fieldLabelAttributesDriverFactory from '../../FieldLabelAttributes/FieldLabelAttributes.driver';
 
 const inputAreaWithLabelCompositeDriverFactory = ({element, wrapper, component}) => {
   const label = element.childNodes[0].childNodes[0];
@@ -10,6 +11,7 @@ const inputAreaWithLabelCompositeDriverFactory = ({element, wrapper, component})
     hasLabel: () => label.tagName.toLowerCase() === 'label',
     getAttr: attrName => element.getAttribute(attrName),
     getNumberOfChildren: () => element.childElementCount,
+    getInfoTooltipTestKit: () => fieldLabelAttributesDriverFactory({wrapper, element: $(element).find('[data-hook="field-label-attributes"]')}).getTooltipTestKit(),
     hasFieldLabelAttributes: () => !!$(element).find('[data-hook="field-label-attributes"]').length,
     setProps: props => {
       const ClonedWithProps = React.cloneElement(component, Object.assign({}, component.props, props), ...(component.props.children || []));

--- a/src/FieldLabelAttributes/FieldLabelAttributes.driver.js
+++ b/src/FieldLabelAttributes/FieldLabelAttributes.driver.js
@@ -1,8 +1,10 @@
 import $ from 'jquery';
+import tooltipDriverFactory from '../../src/Tooltip/Tooltip.driver';
 
-const fieldLabelAttributesDriverFactory = ({element}) => {
+const fieldLabelAttributesDriverFactory = ({element, wrapper}) => {
   return {
     exists: () => !!element,
+    getTooltipTestKit: () => tooltipDriverFactory({wrapper, element: $(element).find('[data-hook="info"]')}),
     hasRequired: () => !!$(element).find('[data-hook="required"]').length,
     hasInfo: () => !!$(element).find('[data-hook="info"]').length
   };


### PR DESCRIPTION
closes #746

- Explain what has changed: added getInfoTooltipTestKit to the InputAreaWithLabelComposite also to TextField
- It was requested by issue 746 https://github.com/wix/wix-style-react/issues/746


