### PR TITLE
fix: InputWithOptions composition mode (fixes #555)

### DIFF
--- a/src/DropdownLayout/DropdownLayout.js
+++ b/src/DropdownLayout/DropdownLayout.js
@@ -79,7 +79,7 @@ class DropdownLayout extends WixComponent {
   }
 
   _onKeyDown(event) {
-    if (!this.props.visible) {
+    if (!this.props.visible || this.props.isComposing) {
       return false;
     }
 

--- a/src/DropdownLayout/DropdownLayout.spec.js
+++ b/src/DropdownLayout/DropdownLayout.spec.js
@@ -131,6 +131,13 @@ describe('DropdownLayout', () => {
     expect(onSelect).toBeCalledWith(options[5], false);
   });
 
+  it('should not call onSelect when composing text via external means', () => {
+    const onSelect = jest.fn();
+    const driver = createDriver(<DropdownLayout visible options={options} onSelect={onSelect}/>);
+    driver.pressEnterKey();
+    expect(onSelect).not.toBeCalled();
+  });
+
   it('should click an option by value', () => {
     const onSelect = jest.fn();
     const driver = createDriver(<DropdownLayout visible options={options} onSelect={onSelect}/>);

--- a/src/Input/Input.driver.js
+++ b/src/Input/Input.driver.js
@@ -52,6 +52,8 @@ const inputDriverFactory = ({element, wrapper, component}) => {
     isFocus: () => document.activeElement === input,
     exists: () => !!(element && element.querySelector('input')),
     hasIconLeft: () => !!element.querySelectorAll(`.${styles.prefix}`),
+    startComposing: () => ReactTestUtils.Simulate.compositionStart(input),
+    endComposing: () => ReactTestUtils.Simulate.compositionEnd(input),
     setProps: props => {
       const ClonedWithProps = React.cloneElement(component, Object.assign({}, component.props, props), ...(component.props.children || []));
       ReactDOM.render(<div ref={r => element = r}>{ClonedWithProps}</div>, wrapper);

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -22,6 +22,14 @@ class Input extends Component {
     this.props.autoFocus && this._onFocus();
   }
 
+  onCompositionChange = isComposing => {
+    if (this.props.onCompositionChange) {
+      this.props.onCompositionChange(isComposing);
+    }
+
+    this.isComposing = isComposing;
+  };
+
   render(props = {}) {
     const {
       id,
@@ -60,6 +68,7 @@ class Input extends Component {
         this._onFocus();
       }
     };
+
 
     const isClearButtonVisible = onClear && !error && !disabled && !!value;
 
@@ -101,6 +110,8 @@ class Input extends Component {
         readOnly={readOnly}
         type={type}
         autoComplete={autocomplete}
+        onCompositionStart={() => this.onCompositionChange(true)}
+        onCompositionEnd={() => this.onCompositionChange(false)}
         {...ariaAttribute}
         {...props}
         />);
@@ -166,6 +177,10 @@ class Input extends Component {
   };
 
   _onKeyDown = e => {
+    if (this.isComposing) {
+      return;
+    }
+
     this.props.onKeyDown && this.props.onKeyDown(e);
 
     if (e.keyCode === 13 /* enter */) {
@@ -249,6 +264,7 @@ Input.propTypes = {
   onTooltipShow: PropTypes.func,
   withSelection: PropTypes.bool,
   autocomplete: PropTypes.oneOf(['off', 'on']),
+  onCompositionChange: PropTypes.func,
 };
 
 export default Input;

--- a/src/InputWithOptions/InputWithOptions.js
+++ b/src/InputWithOptions/InputWithOptions.js
@@ -35,6 +35,11 @@ class InputWithOptions extends WixComponent {
     this._renderDropdownLayout = this._renderDropdownLayout.bind(this);
     this._onInputClicked = this._onInputClicked.bind(this);
     this.closeOnSelect = this.closeOnSelect.bind(this);
+    this.onCompositionChange = this.onCompositionChange.bind(this);
+  }
+
+  onCompositionChange(isComposing) {
+    this.setState({isComposing});
   }
 
   onClickOutside() {
@@ -51,7 +56,8 @@ class InputWithOptions extends WixComponent {
       theme: this.props.theme,
       onChange: this._onChange,
       onInputClicked: this._onInputClicked,
-      onFocus: this.showOptions
+      onFocus: this.showOptions,
+      onCompositionChange: this.onCompositionChange,
     });
   }
 
@@ -71,6 +77,7 @@ class InputWithOptions extends WixComponent {
           visible={this.state.showOptions}
           onClose={this.hideOptions}
           onSelect={this._onSelect}
+          isComposing={this.state.isComposing}
           />
       </div>
     );
@@ -103,6 +110,10 @@ class InputWithOptions extends WixComponent {
   }
 
   _onManuallyInput(inputValue) {
+    if (this.state.isComposing) {
+      return;
+    }
+
     inputValue = inputValue.trim();
     if (this.closeOnSelect()) {
       this.hideOptions();

--- a/src/InputWithOptions/InputWithOptions.spec.js
+++ b/src/InputWithOptions/InputWithOptions.spec.js
@@ -183,6 +183,17 @@ const runInputWithOptionsTest = driverFactory => {
       expect(onFocus).toBeCalled();
     });
 
+    it('should not call onManuallyInput when composing text via external means', () => {
+      const onManualInput = jest.fn();
+      const {driver, inputDriver} = createDriver(<InputWithOptions options={options} onManuallyInput={onManualInput}/>);
+      inputDriver.startComposing();
+      driver.pressEnterKey();
+      expect(onManualInput).not.toBeCalled();
+      inputDriver.endComposing();
+      driver.pressEnterKey();
+      expect(onManualInput).toBeCalled();
+    });
+
     describe('testkit', () => {
       it('should exist', () => {
         const div = document.createElement('div');


### PR DESCRIPTION
Fixed InputWithOptions to react to external compositor events (used with languages such as Japanese, Chinese etc). Fixes #555.


