### PR TITLE
fix: InputWithOptions blur firing too many times (fixes #668)

### DIFF
--- a/src/Input/Input.driver.js
+++ b/src/Input/Input.driver.js
@@ -9,8 +9,14 @@ const inputDriverFactory = ({element, wrapper, component}) => {
 
   return {
     trigger: (trigger, event) => ReactTestUtils.Simulate[trigger](input, event),
-    focus: () => input.focus(),
-    blur: () => ReactTestUtils.Simulate.blur(input),
+    focus: () => {
+      input.focus();
+      ReactTestUtils.Simulate.focus(input);
+    },
+    blur: () => {
+      input.blur();
+      ReactTestUtils.Simulate.blur(input);
+    },
     keyDown: key => ReactTestUtils.Simulate.keyDown(input, {key}),
     clickClear: () => ReactTestUtils.Simulate.click(clearButton),
     enterText: text => ReactTestUtils.Simulate.change(input, {target: {value: text}}),

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -147,8 +147,10 @@ class Input extends Component {
   };
 
   blur = () => {
-    this._onBlur();
-    this.input && this.input.blur();
+    if (document.activeElement === this.input) {
+      this._onBlur();
+      this.input && this.input.blur();
+    }
   };
 
   select = () => {
@@ -169,7 +171,9 @@ class Input extends Component {
 
   _onBlur = e => {
     this.setState({focus: false});
-    this.props.onBlur && this.props.onBlur(e);
+    if (this.props.onBlur) {
+      this.props.onBlur(e);
+    }
   };
 
   _onClick = e => {

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -65,6 +65,7 @@ class Input extends Component {
 
     const onIconClicked = () => {
       if (!disabled) {
+        this.input.focus();
         this._onFocus();
       }
     };
@@ -147,10 +148,7 @@ class Input extends Component {
   };
 
   blur = () => {
-    if (document.activeElement === this.input) {
-      this._onBlur();
-      this.input && this.input.blur();
-    }
+    this.input && this.input.blur();
   };
 
   select = () => {

--- a/src/InputWithOptions/InputWithOptions.driver.js
+++ b/src/InputWithOptions/InputWithOptions.driver.js
@@ -21,7 +21,7 @@ const inputWithOptionsDriverFactory = ({element, wrapper, component}) => {
     pressEnterKey: () => ReactTestUtils.Simulate.keyDown(inputWrapper, {key: 'Enter'}),
     pressTabKey: () => ReactTestUtils.Simulate.keyDown(inputWrapper, {key: 'Tab'}),
     pressEscKey: () => ReactTestUtils.Simulate.keyDown(inputWrapper, {key: 'Escape'}),
-    outsideClick: () => ReactTestUtils.Simulate.click(element),
+    outsideClick: () => document.body.dispatchEvent(new Event('click', {cancelable: true})),
     setProps: props => {
       const ClonedWithProps = React.cloneElement(component, Object.assign({}, component.props, props), ...(component.props.children || []));
       ReactDOM.render(<div ref={r => element = r}>{ClonedWithProps}</div>, wrapper);

--- a/src/InputWithOptions/InputWithOptions.driver.js
+++ b/src/InputWithOptions/InputWithOptions.driver.js
@@ -13,7 +13,7 @@ const inputWithOptionsDriverFactory = ({element, wrapper, component}) => {
   const driver = {
     exists: () => !!element,
     inputWrapper: () => inputWrapper,
-    focus: () => ReactTestUtils.Simulate.focus(inputWrapper),
+    focus: () => inputDriver.focus(),
     blur: () => dropdownLayoutDriver.mouseClickOutside(),
     pressDownKey: () => ReactTestUtils.Simulate.keyDown(inputWrapper, {key: 'ArrowDown'}),
     pressUpKey: () => ReactTestUtils.Simulate.keyDown(inputWrapper, {key: 'ArrowUp'}),

--- a/src/InputWithOptions/InputWithOptions.js
+++ b/src/InputWithOptions/InputWithOptions.js
@@ -43,7 +43,7 @@ class InputWithOptions extends WixComponent {
   }
 
   onClickOutside() {
-    this.hideOptions();
+    this.setState({showOptions: false});
   }
 
   renderInput() {

--- a/src/InputWithOptions/InputWithOptions.js
+++ b/src/InputWithOptions/InputWithOptions.js
@@ -24,6 +24,7 @@ class InputWithOptions extends WixComponent {
 
     this._onSelect = this._onSelect.bind(this);
     this._onFocus = this._onFocus.bind(this);
+    this._onBlur = this._onBlur.bind(this);
     this._onChange = this._onChange.bind(this);
     this._onKeyDown = this._onKeyDown.bind(this);
     this.focus = this.focus.bind(this);
@@ -43,7 +44,7 @@ class InputWithOptions extends WixComponent {
   }
 
   onClickOutside() {
-    this.setState({showOptions: false});
+    this.hideOptions();
   }
 
   renderInput() {
@@ -56,7 +57,8 @@ class InputWithOptions extends WixComponent {
       theme: this.props.theme,
       onChange: this._onChange,
       onInputClicked: this._onInputClicked,
-      onFocus: this.showOptions,
+      onFocus: this._onFocus,
+      onBlur: this._onBlur,
       onCompositionChange: this.onCompositionChange,
     });
   }
@@ -88,7 +90,7 @@ class InputWithOptions extends WixComponent {
     return (
       <div>
         {dropDirectionUp ? this._renderDropdownLayout() : null}
-        <div onKeyDown={this._onKeyDown} onFocus={this._onFocus} className={this.inputClasses()}>
+        <div onKeyDown={this._onKeyDown} className={this.inputClasses()}>
           {this.renderInput()}
         </div>
         {!dropDirectionUp ? this._renderDropdownLayout() : null}
@@ -97,8 +99,12 @@ class InputWithOptions extends WixComponent {
   }
 
   hideOptions() {
-    this.setState({showOptions: false});
-    this.input.blur();
+    if (this.state.showOptions) {
+      this.setState({showOptions: false});
+      if (this._focused) {
+        this.input.blur();
+      }
+    }
   }
 
   showOptions() {
@@ -165,10 +171,18 @@ class InputWithOptions extends WixComponent {
     if (this.props.disabled) {
       return;
     }
+    this._focused = true;
     this.setState({isEditing: false});
     this.showOptions();
     if (this.props.onFocus) {
       this.props.onFocus();
+    }
+  }
+
+  _onBlur(e) {
+    this._focused = false;
+    if (this.props.onBlur) {
+      this.props.onBlur(e);
     }
   }
 

--- a/src/InputWithOptions/InputWithOptions.spec.js
+++ b/src/InputWithOptions/InputWithOptions.spec.js
@@ -183,6 +183,13 @@ const runInputWithOptionsTest = driverFactory => {
       expect(onFocus).toBeCalled();
     });
 
+    it('should not call onBlur if clicked outside input and inner input is not focused', () => {
+      const onBlur = jest.fn();
+      const {driver} = createDriver(<InputWithOptions options={options} onBlur={onBlur}/>);
+      driver.outsideClick();
+      expect(onBlur).not.toBeCalled();
+    });
+
     it('should not call onManuallyInput when composing text via external means', () => {
       const onManualInput = jest.fn();
       const {driver, inputDriver} = createDriver(<InputWithOptions options={options} onManuallyInput={onManualInput}/>);

--- a/src/InputWithOptions/InputWithOptions.spec.js
+++ b/src/InputWithOptions/InputWithOptions.spec.js
@@ -183,11 +183,15 @@ const runInputWithOptionsTest = driverFactory => {
       expect(onFocus).toBeCalled();
     });
 
-    it('should not call onBlur if clicked outside input and inner input is not focused', () => {
+    it('should call onBlur if clicked outside and input is focused', () => {
       const onBlur = jest.fn();
-      const {driver} = createDriver(<InputWithOptions options={options} onBlur={onBlur}/>);
+      const {driver, inputDriver} = createDriver(<InputWithOptions options={options} onBlur={onBlur}/>);
       driver.outsideClick();
       expect(onBlur).not.toBeCalled();
+      driver.focus();
+      driver.outsideClick();
+      inputDriver.blur(); // apparently, jsdom does not fire onBlur after input.blur() is called
+      expect(onBlur).toBeCalled();
     });
 
     it('should not call onManuallyInput when composing text via external means', () => {


### PR DESCRIPTION
Fixed a bug where InputWithOptions fired onBlur event too many times - for example when clicking anywhere outside input even though it was not focused. This was caused by using WixComponent onClickOutside callback for blurring the component but without checking whether it's actually focused.

There's also a potential issue with testing blur/focus, as jsdom apparently doesn't fire onFocus/onBlur after calling input.focus()/input.blur(). 

Fixes #668 

