### PR TITLE
deprecate old onSelect for single value

### DIFF
--- a/src/MultiSelect/MultiSelect.js
+++ b/src/MultiSelect/MultiSelect.js
@@ -12,8 +12,6 @@ class MultiSelect extends InputWithOptions {
     this.onKeyDown = this.onKeyDown.bind(this);
     this.onPaste = this.onPaste.bind(this);
     this.state = {pasteDetected: false};
-
-    console.warn('MultiSelect: onSelect signature should get an array of tags instead of single tag as parameter. Old signature will not be supported starting from 16/09/2017');
   }
 
   getUnselectedOptions() {
@@ -71,7 +69,7 @@ class MultiSelect extends InputWithOptions {
 
 
   _onSelect(option) {
-    this.onSelect(option);
+    this.onSelect([option]);
   }
 
   _onManuallyInput(inputValue) {
@@ -108,7 +106,7 @@ class MultiSelect extends InputWithOptions {
         const maybeNearestOption = visibleOptions[0];
 
         if (maybeNearestOption) {
-          this.onSelect(maybeNearestOption);
+          this.onSelect([maybeNearestOption]);
         }
 
         this.clearInput();
@@ -125,19 +123,11 @@ class MultiSelect extends InputWithOptions {
   }
 
   onSelect(options) {
-    if (!Array.isArray(options)) {
-      options = [options];
-    }
-
     this.clearInput();
 
     if (this.props.onSelect) {
       options = options.map(this.optionToTag);
-      if (options.length === 1) {
-        this.props.onSelect(options[0]);
-      } else {
-        this.props.onSelect(options);
-      }
+      this.props.onSelect(options);
     }
 
     this.input.focus();

--- a/src/MultiSelect/MultiSelect.spec.js
+++ b/src/MultiSelect/MultiSelect.spec.js
@@ -76,7 +76,7 @@ describe('multiSelect', () => {
     driver.focus();
     driver.pressDownKey();
     driver.pressTabKey();
-    expect(onSelect).toBeCalledWith({id: options[0].id, label: options[0].value});
+    expect(onSelect).toBeCalledWith([{id: options[0].id, label: options[0].value}]);
     expect(dropdownLayoutDriver.isShown()).toBeTruthy();
     expect(inputDriver.isFocus()).toBeTruthy();
   });
@@ -89,7 +89,7 @@ describe('multiSelect', () => {
     );
     driver.focus();
     inputDriver.trigger('keyDown', {key: ','});
-    expect(onSelect).toBeCalledWith({id: options[0].id, label: options[0].value});
+    expect(onSelect).toBeCalledWith([{id: options[0].id, label: options[0].value}]);
     expect(onChange).toBeCalledWith({target: {value: ''}});
     expect(dropdownLayoutDriver.isShown()).toBeTruthy();
     expect(inputDriver.isFocus()).toBeTruthy();
@@ -103,7 +103,7 @@ describe('multiSelect', () => {
     );
     driver.focus();
     inputDriver.trigger('keyDown', {key: ';'});
-    expect(onSelect).toBeCalledWith({id: options[0].id, label: options[0].value});
+    expect(onSelect).toBeCalledWith([{id: options[0].id, label: options[0].value}]);
     expect(onChange).toBeCalledWith({target: {value: ''}});
     expect(dropdownLayoutDriver.isShown()).toBeTruthy();
     expect(inputDriver.isFocus()).toBeTruthy();

--- a/src/MultiSelect/README.md
+++ b/src/MultiSelect/README.md
@@ -9,7 +9,7 @@
 | options | array of option | [] | - | Array of objects. Objects must have an Id and can can include *value* and *node*. If value is '-', a divider will be rendered instead. |
 | onChange | func | - | + | A callback function to be called when the input value changed|
 | value | string | - | - | The value of the current input |
-| onSelect | func | - | - | Callback function called whenever the user selects an option |
+| onSelect | func | - | - | Callback function called whenever the user selects a single option or multiple options (with copy paste). The function receives array of values as an argument. |
 | onManuallyInput | func | noop | - | Callback when the user pressed the Enter key or Tab key after he wrote in the Input field - meaning the user selected something not in the list |
 | onRemoveTag | func | - | + | A callback function to be called when a tag should be removed|
 | tags | array of objects | - | + | The tags. tags are just set of selected suggestions|


### PR DESCRIPTION
## Before you request a review, please make sure to check the following boxes:

- [x] Explain what has changed: Deprecate onSelect to support only array as argument.
- [x] Explain why the change is needed: Deprecated single value to support naturally copy paste of multiple values.
- [x] Added tests: Updated relevant tests.
- [x] Update documentation.
- [x] Merge master with no conflicts.
- [x] Make sure the build is passing on ci.
- [x] If this pr closes any issue, please add a github link to close it.
- [x] If you changed something in the product design/UX, you got the approval of [Ben Benhorin](https://wix.slack.com/messages/@benb).

**Should update on slack again that this is now deprecated**. 
Let me know when it is merged so i will right the message on Slack.

### Thanks for contributing :)


