### PR TITLE
Fix `Row` CSS styles

### DIFF
--- a/src/Grid/Grid.scss
+++ b/src/Grid/Grid.scss
@@ -83,3 +83,12 @@ $grid-row-margin-bottom: 30px;
 @media (min-width: $screen-lg-min) {
 	@include rtl-float-grid-columns(lg);
 }
+
+.row {
+	display: flex;
+
+	&:before,
+	&:after {
+		content: none;
+	}
+}


### PR DESCRIPTION
CSS bug in the `before`, `after` with `display: table` in `Row` component

Gist:
https://gist.github.com/adavidof/30ebdb1e2fd5e3c21621ea6fef7ef2a9.js

Video:
https://screencast.com/t/drjRurfv
https://screencast.com/t/Z6VIskG0Ol