### PR TITLE
docs/autoexample-dropdown: use dropdow for oneOf props

### DIFF
--- a/stories/utils/Components/AutoExample/FormComponents/index.js
+++ b/stories/utils/Components/AutoExample/FormComponents/index.js
@@ -8,6 +8,7 @@ import {Container, Row, Col} from 'wix-style-react/Grid';
 import {default as WixInput} from 'wix-style-react/Input';
 import ToggleSwitch from 'wix-style-react/ToggleSwitch';
 import {default as WixRadioGroup} from 'wix-style-react/RadioGroup';
+import Dropdown from 'wix-style-react/Dropdown';
 import Text from 'wix-style-react/Text';
 
 import styles from './styles.scss';
@@ -88,25 +89,31 @@ Toggle.propTypes = {
 };
 
 
-const RadioGroup = ({value, options, onChange, ...props}) =>
-  <WixRadioGroup
-    value={value}
-    onChange={onChange}
-    {...props}
-    >
-    {options.map((option, i) =>
-      <WixRadioGroup.Radio
-        key={i}
-        value={option}
-        >
-        <Markdown source={`\`${option}\``}/>
-      </WixRadioGroup.Radio>
-    )}
-  </WixRadioGroup>;
+const List = ({value, values = [], onChange, ...props}) =>
+  values.length > 3 ?
+    <Dropdown
+      options={values.map(v => ({id: v, value: v}))}
+      selectedId={values.find((v => v.value === value))}
+      onSelect={({value}) => onChange(value)}
+      /> :
+    <WixRadioGroup
+      value={value}
+      onChange={onChange}
+      {...props}
+      >
+      {values.map((value, i) =>
+        <WixRadioGroup.Radio
+          key={i}
+          value={value}
+          >
+          <Markdown source={`\`${value}\``}/>
+        </WixRadioGroup.Radio>
+      )}
+    </WixRadioGroup>;
 
-RadioGroup.propTypes = {
+List.propTypes = {
   value: PropTypes.string,
-  options: PropTypes.arrayOf(PropTypes.string),
+  values: PropTypes.arrayOf(PropTypes.string),
   onChange: PropTypes.func
 };
 
@@ -143,6 +150,6 @@ export {
   Preview,
   Toggle,
   Input,
-  RadioGroup,
+  List,
   Code
 };

--- a/stories/utils/Components/AutoExample/index.js
+++ b/stories/utils/Components/AutoExample/index.js
@@ -12,9 +12,13 @@ import {
   Code,
   Toggle,
   Input,
-  RadioGroup
+  List
 } from './FormComponents';
 
+const stripQuotes = string => {
+  const quoted = string.match(/^['"](.*?)['"]$/);
+  return quoted ? quoted[1] : string;
+};
 
 /**
   * Create a playground for some component, which is suitable for storybook. Given raw `source`, component reference
@@ -144,12 +148,11 @@ export default class extends Component {
   controllableComponentGetters = {
     string: ({dataHook}) => <Input dataHook={dataHook}/>,
     bool: ({dataHook}) => <Toggle dataHook={dataHook}/>,
-    enum: ({dataHook, type}) => (
-      <RadioGroup
+    enum: ({dataHook, type}) =>
+      <List
         dataHook={dataHook}
-        options={type.value.map(v => v.value.substr(1, v.value.length - 2))}
+        values={type.value.map(({value}) => stripQuotes(value))}
         />
-    )
   }
 
   getPropControlComponent = (propKey, type) => {


### PR DESCRIPTION
when `values.length > 3`. otherwise display `<RadioGroup/>`.

to display long lists of `oneOf`s nicely