### PR TITLE
Add ability to show tooltip and required attributes without label com…

### DIFF
--- a/src/Composite/InputAreaWithLabelComposite/InputAreaWithLabelComposite.js
+++ b/src/Composite/InputAreaWithLabelComposite/InputAreaWithLabelComposite.js
@@ -6,6 +6,10 @@ import styles from './InputAreaWithLabelComposite.scss';
 import FieldLabelAttributes from '../../FieldLabelAttributes/FieldLabelAttributes';
 
 class InputAreaWithLabelComposite extends WixComponent {
+  getFieldLabelAttributesComponent() {
+    return <FieldLabelAttributes appendToParent={this.props.appendToParent} required={this.props.required} info={this.props.info}/>;
+  }
+
   render() {
     const children = Children.toArray(this.props.children);
     return (
@@ -13,10 +17,21 @@ class InputAreaWithLabelComposite extends WixComponent {
         { children.length === 2 ?
           <div className={styles.label}>
             {children[0]}
-            { this.props.required || this.props.info ? <FieldLabelAttributes appendToParent={this.props.appendToParent} required={this.props.required} info={this.props.info}/> : null }
+            { this.props.required || this.props.info ? this.getFieldLabelAttributesComponent() : null }
           </div> : null
         }
-        { last(children) }
+        { children.length === 1 && (this.props.required || this.props.info) ?
+          (
+            <div className={styles.withLabelAttributes}>
+              <div className={styles.inputWrapper}>
+                { last(children) }
+              </div>
+              {this.getFieldLabelAttributesComponent()}
+            </div>
+          ) : (
+            last(children)
+          )
+        }
       </div>
     );
   }

--- a/src/Composite/InputAreaWithLabelComposite/InputAreaWithLabelComposite.scss
+++ b/src/Composite/InputAreaWithLabelComposite/InputAreaWithLabelComposite.scss
@@ -3,3 +3,12 @@
 .label {
 	margin-bottom: 6px;
 }
+
+.withLabelAttributes {
+	display: flex;
+	align-items: center;
+}
+
+.inputWrapper {
+	flex: 1;
+}

--- a/src/Composite/InputAreaWithLabelComposite/InputAreaWithLabelComposite.spec.js
+++ b/src/Composite/InputAreaWithLabelComposite/InputAreaWithLabelComposite.spec.js
@@ -52,8 +52,20 @@ describe('InputAreaWithLabelComposite', () => {
       expect(driver.hasFieldLabelAttributes()).toBe(true);
     });
 
+    it('should FieldLabelAttributes exists if required and with one child', () => {
+      const driver = createAutoCompleteDriver(<InputAreaWithLabelComposite required><InputArea/></InputAreaWithLabelComposite>);
+
+      expect(driver.hasFieldLabelAttributes()).toBe(true);
+    });
+
     it('should FieldLabelAttributes exists if info', () => {
       const driver = createAutoCompleteDriver(<InputAreaWithLabelComposite info="info"><Label>label</Label><InputArea/></InputAreaWithLabelComposite>);
+
+      expect(driver.hasFieldLabelAttributes()).toBe(true);
+    });
+
+    it('should FieldLabelAttributes exists if info and with one child', () => {
+      const driver = createAutoCompleteDriver(<InputAreaWithLabelComposite info="info"><InputArea/></InputAreaWithLabelComposite>);
 
       expect(driver.hasFieldLabelAttributes()).toBe(true);
     });


### PR DESCRIPTION
- Support required and info icon props when a label was not provided
- Fix for https://github.com/wix/wix-style-react/issues/988