### PR TITLE
added icon button styles for `heightlarge`

### DIFF
--- a/src/ButtonLayout/ButtonLayout.scss
+++ b/src/ButtonLayout/ButtonLayout.scss
@@ -80,6 +80,13 @@ $base-transition: all 100ms linear;
         padding: 0px 30px;
     }
 
+    &.icon-greybackground, &.icon-standard, &.icon-standardsecondary, &.icon-white, &.icon-whitesecondary {
+      width: $height;
+      height: $height;
+      border-radius: $height / 2;
+      padding: 0;
+    }
+
     &.close-standard, &.close-dark, &.close-transparent {
         $closeHeight: 24px;
         height: $closeHeight;


### PR DESCRIPTION
Added support for large height (height={'large'}) for icon buttons.

I needed that change since my project's design requires an icon button to be of that size.

I did that by changing the .heightlarge class in ButtonLayout.scss to address icon-button as well, similarly to how it was done with .heightsmall.

Since the change was purely in css, no new tests were added.