### PR TITLE
Add stats widget example with no border filter

### DIFF
--- a/stories/StatsWidget/ExampleStatsWidgetStandard.js
+++ b/stories/StatsWidget/ExampleStatsWidgetStandard.js
@@ -17,5 +17,5 @@ const statistics = [{
 
 export default () =>
   <div data-hook="card-example" className={styles.statsWidgetWrapper}>
-    <StatsWidget title="Let's what going on with your store" statistics={statistics} dataHook="standard-stats-widget"/>
+    <StatsWidget title="Let's see what's going on with your store" statistics={statistics} dataHook="standard-stats-widget"/>
   </div>;

--- a/stories/StatsWidget/ExampleStatsWidgetStandard.js
+++ b/stories/StatsWidget/ExampleStatsWidgetStandard.js
@@ -3,7 +3,7 @@ import StatsWidget from '../../src/StatsWidget';
 import styles from './ExampleStatsWidget.scss';
 
 const statistics = [{
-  title: '10$',
+  title: '$10',
   subtitle: 'Revenue'
 },
 {
@@ -11,7 +11,7 @@ const statistics = [{
   subtitle: 'Products'
 },
 {
-  title: '1',
+  title: '$1',
   subtitle: 'Transactions'
 }];
 

--- a/stories/StatsWidget/ExampleStatsWidgetWithFilterWithNoBorder.js
+++ b/stories/StatsWidget/ExampleStatsWidgetWithFilterWithNoBorder.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import StatsWidget from '../../src/StatsWidget';
+import styles from './ExampleStatsWidget.scss';
+import random from 'lodash/random';
+
+const statistics = [{
+  title: `$${random(10, 999)}`,
+  subtitle: 'Revenue'
+},
+{
+  title: `${random(1, 9)}`,
+  subtitle: 'Products'
+},
+{
+  title: `${random(1, 9)}`,
+  subtitle: 'Transactions'
+},
+{
+  title: `+$${random(1, 9)}`,
+  subtitle: 'Profit'
+}];
+
+const dropdownOption = [{id: 1, value: 'Last week'}, {id: 2, value: 'This week'}];
+
+export default () =>
+  <div data-hook="card-example" className={styles.statsWidgetWrapper}>
+    <StatsWidget title="Let's see what's going on with your store" statistics={statistics}>
+      <StatsWidget.Filter selectedId={1} options={dropdownOption} noBorder/>
+    </StatsWidget>
+  </div>;

--- a/stories/StatsWidget/ExampleStatsWidgetWithFilters.js
+++ b/stories/StatsWidget/ExampleStatsWidgetWithFilters.js
@@ -3,7 +3,7 @@ import StatsWidget from '../../src/StatsWidget';
 import styles from './ExampleStatsWidget.scss';
 
 const statistics = [{
-  title: '10$',
+  title: '$10',
   subtitle: 'Revenue'
 },
 {
@@ -15,7 +15,7 @@ const statistics = [{
   subtitle: 'Transactions'
 },
 {
-  title: '5',
+  title: '$5',
   subtitle: 'Profit'
 }];
 

--- a/stories/StatsWidget/ExampleStatsWidgetWithFilters.js
+++ b/stories/StatsWidget/ExampleStatsWidgetWithFilters.js
@@ -29,7 +29,7 @@ const onFilterChange = () => {
 
 export default () =>
   <div data-hook="card-example" className={styles.statsWidgetWrapper}>
-    <StatsWidget title="Let's what going on with your store" statistics={statistics}>
+    <StatsWidget title="Let's see what's going on with your store" statistics={statistics}>
       <StatsWidget.Filter selectedId={1} options={dropdownOption} onSelect={onFilterChange}/>
       <StatsWidget.Filter selectedId={1} options={dropdownOption}/>
     </StatsWidget>

--- a/stories/StatsWidget/ExampleStatsWidgetWithPercents.js
+++ b/stories/StatsWidget/ExampleStatsWidgetWithPercents.js
@@ -3,7 +3,7 @@ import StatsWidget from '../../src/StatsWidget';
 import styles from './ExampleStatsWidget.scss';
 
 const statistics = [{
-  title: '10$',
+  title: '$10',
   subtitle: 'Revenue',
   percent: -15
 },
@@ -18,12 +18,12 @@ const statistics = [{
   percent: 0
 },
 {
-  title: '5',
+  title: '$5',
   subtitle: 'Profit',
   percent: 10
 },
 {
-  title: '15',
+  title: '456',
   subtitle: 'Music',
   percent: 15
 }];

--- a/stories/StatsWidget/ExampleStatsWidgetWithPercents.js
+++ b/stories/StatsWidget/ExampleStatsWidgetWithPercents.js
@@ -30,5 +30,5 @@ const statistics = [{
 
 export default () =>
   <div data-hook="card-example" className={styles.statsWidgetWrapper}>
-    <StatsWidget title="Let's what going on with your store" statistics={statistics}/>
+    <StatsWidget title="Let's see what's going on with your store" statistics={statistics}/>
   </div>;

--- a/stories/StatsWidget/index.js
+++ b/stories/StatsWidget/index.js
@@ -16,6 +16,10 @@ import ExampleStatsWidgetWithPercentsRaw from '!raw-loader!./ExampleStatsWidgetW
 
 import ExampleStatsWidgetWithFilters from './ExampleStatsWidgetWithFilters';
 import ExampleStatsWidgetWithFiltersRaw from '!raw-loader!./ExampleStatsWidgetWithFilters';
+
+import ExampleStatsWidgetWithFilterWithNoBorder from './ExampleStatsWidgetWithFilterWithNoBorder';
+import ExampleStatsWidgetWithFilterWithNoBorderRaw from '!raw-loader!./ExampleStatsWidgetWithFilterWithNoBorder';
+
 import ReadmeTestkit from '../../src/StatsWidget/README.TESTKIT.md';
 
 
@@ -36,6 +40,9 @@ storiesOf('Core', module)
         </CodeExample>
         <CodeExample title="Stats widget example with filters" code={ExampleStatsWidgetWithFiltersRaw}>
           <ExampleStatsWidgetWithFilters/>
+        </CodeExample>
+        <CodeExample title="Stats widget example with borderless filter" code={ExampleStatsWidgetWithFilterWithNoBorderRaw}>
+          <ExampleStatsWidgetWithFilterWithNoBorder/>
         </CodeExample>
       </div>
 


### PR DESCRIPTION
- [x] Explain what has changed.
Added an example in the storybook of how to create a stat's widget which has a filter which has no border.
<img width="1417" alt="screen shot 2018-01-02 at 15 50 57" src="https://user-images.githubusercontent.com/62937/34485738-c504b3de-efd4-11e7-89e4-6ba552340e59.png">

- [x] Explain why the change is needed.
This example both fixes: #1149 and proves that #1200 is done
- [x] Added tests.
Since this is a demo, no tests included
- [x] Update documentation.
Added the proper title to the new storybook section.
- [x] Merge master with no conflicts.
Ready to go
- [ ] Make sure the build is passing on ci.
- [ ] If this pr closes any issue, please add a github link to close it.
fixes: #1149 
fixes: #1200 
- [ ] If you changed something in the product design/UX, you got the approval of [Ben Benhorin](https://wix.slack.com/messages/@benb).
No changes made


