### PR TITLE
Fix propType of item.title in Tabs

### DIFF
--- a/src/Tabs/README.md
+++ b/src/Tabs/README.md
@@ -17,5 +17,5 @@
 | propName | propType | defaultValue | isRequired | description |
 |----------|----------|--------------|------------|-------------|
 | id | string or number| - | + | Specifies the item id |
-| title | string | - | + | Text to be shown on tab |
+| title | node | - | + | Title to be shown on tab |
 | dataHook | string | - | - | Datahook |

--- a/src/Tabs/core/constants/tab-prop-types.js
+++ b/src/Tabs/core/constants/tab-prop-types.js
@@ -5,7 +5,7 @@ import TabTypes from './tab-types';
 
 const stringOrNumber = PropTypes.oneOfType([PropTypes.string, PropTypes.number]);
 
-export const item = PropTypes.shape({id: stringOrNumber, title: stringOrNumber, dataHook: PropTypes.string});
+export const item = PropTypes.shape({id: stringOrNumber, title: PropTypes.node, dataHook: PropTypes.string});
 
 export const items = PropTypes.arrayOf(item);
 


### PR DESCRIPTION
## Before you request a review, please make sure to check the following boxes:

- [+] Explain what has changed.
Tab item's title should be PropType.node, not string

- [+] Explain why the change is needed.
Cause node is ok to be passed as item's title (it is rendered as is lately)

- [ ] Added tests.
Don't need tests

- [+] Update documentation.
- [+] Merge master with no conflicts.
- [ ] Make sure the build is passing on ci.(https://wix.slack.com/messages/@benb).



