### PR TITLE
Adds Chromatic regression tests

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,5 +1,6 @@
 import {configure, storiesOf} from '@storybook/react';
 import {setOptions} from '@storybook/addon-options';
+import 'react-chromatic/storybook-addon';
 
 function loadStories() {
   if (global.self === global.top) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "storybook": "start-storybook -p 6006",
     "release": "node scripts/npm-release.js",
     "export-components": "import-path --path src",
-    "lint": "haste lint"
+    "lint": "haste lint",
+    "chromatic": "chromatic test --storybook-addon  --script-name=start --port=6006 --app-code=f9lbfi0h7x"
   },
   "yoshi": {
     "features": {
@@ -74,6 +75,7 @@
     "import-path": "^1.0.0",
     "jquery": "^1.12.4",
     "react": "^15.5.4",
+    "react-chromatic": "^0.7.10",
     "react-docgen": "^2.15.0",
     "react-dom": "^15.5.4",
     "react-element-to-jsx-string": "^13.0.0",


### PR DESCRIPTION
### What changed/Why it changed

Hi,

I’m one of the founders at [Chromatic](http://chromaticqa.com), a visual regression testing tool. We’ve been using Wix's Design System as a test case for Chromatic itself (we really like your design aesthetic too).  

As a token of our appreciation, I’d like to offer the design system project team Chromatic for free. We’ll also give you hands on support to make sure you have a smooth ride and can get the most out of the tool without taking up much of your time. I've made a small PR that adds visual regression tests. 

Chromatic will quickly and easily let you review any visual changes introduced by new code -- it’s especially handy for open source projects where it can be time consuming to evaluate PRs being opened out of the blue by unknown authors.

I’ve already run Chromatic on the project to establish a baseline for future tests (you can view the results [here](https://www.chromaticqa.com/build?appId=5a85fb601341780020097b55&number=4)). You can run additional tests anytime by calling `npm chromatic`. You could try running `npm chromatic` in this branch after changing a component to see an example of the review flow.

Chromatic really shines when you run the above command from within your CI system as it will then tag PRs with the result of the regression tests, like in the image below.

<img width="808" alt="screen shot 2018-02-23 at 4 42 52 pm" src="https://user-images.githubusercontent.com/81672/36623368-d725b786-18b8-11e8-83a3-d63bc19ded1e.png">

Let me know if you have any questions, once this PR is merged I can help get chromatic running in your CI builds too if you'd like.

---

- [ ] Change is tested
- [ ] Change is documented
- [ ] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
