### PR TITLE
feat(Selector): align to center the image

### DIFF
--- a/src/Selector/Selector.scss
+++ b/src/Selector/Selector.scss
@@ -26,6 +26,8 @@
   overflow: hidden;
   margin: 0 8px 0 20px;
   flex: 0 0 auto;
+  display: flex;
+  align-items: center;
 
   &.tiny {
     width: 24px;


### PR DESCRIPTION
no reason not to align to center the image for each `Selector`

example (first selector aligned, the second one don't):
![image](https://user-images.githubusercontent.com/32840800/36945468-400ec5bc-1fb7-11e8-93f4-4501770526bf.png)
