### PR TITLE
fix(Notification): include the padding as part of the width

### DIFF
--- a/src/Notification/Notification.scss
+++ b/src/Notification/Notification.scss
@@ -5,6 +5,7 @@
 }
 
 .notification {
+  box-sizing: border-box;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
added border-box for the notification wrapper to count the notification inner padding
as part of it's width, since it was exceeding the container width

Example:
![image](https://user-images.githubusercontent.com/19532384/37242889-351506b4-2479-11e8-9e78-8d552ac4a143.png)

After fix:
![image](https://user-images.githubusercontent.com/19532384/37242893-52d962ee-2479-11e8-8489-cd27cd955bef.png)

