### PR TITLE
Remove padding from Button no-border theme

### DIFF
--- a/src/ButtonLayout/ButtonLayout.scss
+++ b/src/ButtonLayout/ButtonLayout.scss
@@ -861,6 +861,7 @@ $base-transition: all 100ms linear;
   background: transparent;
   color: $D10;
   border: none;
+  padding: 0;
   @extend .t1_2;
 
   &:hover {


### PR DESCRIPTION
### What changed
remove padding from the button `no-border` theme
...

### Why it changed
useless padding for text only button, making blank place be clickable
...