### PR TITLE
Update title and subtitle text in page header driver to return the…

### DIFF
--- a/src/PageHeader/PageHeader.driver.js
+++ b/src/PageHeader/PageHeader.driver.js
@@ -9,9 +9,9 @@ const actionBarElement = element => element.querySelector('[data-hook="page-head
 const backButtonElement = element => element.querySelector('[data-hook="page-header-backbutton"]');
 
 export default ({element}) => ({
-  titleText: () => titleElement(element).innerHTML,
+  titleText: () => titleElement(element).textContent,
   isTitleExists: () => !!titleElement(element),
-  subtitleText: () => subtitleElement(element).innerHTML,
+  subtitleText: () => subtitleElement(element).textContent,
   isSubtitleExists: () => !!subtitleElement(element),
   isBreadcrumbsExists: () => !!breadcrumbsElement(element),
   isActionBarExists: () => !!actionBarElement(element),

--- a/src/PageHeader/PageHeader.spec.js
+++ b/src/PageHeader/PageHeader.spec.js
@@ -49,6 +49,14 @@ describe('PageHeader', () => {
     expect(driver.isBreadcrumbsExists()).toBeFalsy();
   });
 
+  it('should initialize component with title and subtitle with a special character', () => {
+    const someTextWithSpecialCharachters = 'tom & jerry';
+    const pageHeader = <PageHeader title={someTextWithSpecialCharachters} subtitle={someTextWithSpecialCharachters}/>;
+    const driver = createDriver(pageHeader);
+    expect(driver.titleText()).toEqual(someTextWithSpecialCharachters);
+    expect(driver.subtitleText()).toEqual(someTextWithSpecialCharachters);
+  });
+
   it('should initialize component with minimized title and subtitle', () => {
     const pageHeader = <PageHeader minimized title={title} subtitle={subtitle}/>;
     const driver = createDriver(pageHeader);


### PR DESCRIPTION
… rendered text

What changed:
the `titleText` and `subtitleText` methods return the rendered text now instead of the HTML content of the titles

Why it changed:
in case there are special characters in the titles, for example - `'hey & hey'` the driver methods would return `'hey &amp; hey'` and you would have to deal with that in your tests
