### PR TITLE
tooltip location => set from props

### DIFF
--- a/src/Input/InputErrorSuffix.js
+++ b/src/Input/InputErrorSuffix.js
@@ -11,7 +11,7 @@ class InputErrorSuffix extends React.Component {
       <Tooltip
         dataHook="input-tooltip"
         disabled={this.props.errorMessage.length === 0}
-        placement="top"
+        placement={this.props.tooltipPlacement}
         alignment="center"
         textAlign="left"
         content={this.props.errorMessage}
@@ -30,7 +30,8 @@ class InputErrorSuffix extends React.Component {
 InputErrorSuffix.propTypes = {
   theme: PropTypes.oneOf(['normal', 'paneltitle', 'material', 'amaterial']),
   errorMessage: PropTypes.string.isRequired,
-  focused: PropTypes.bool
+  focused: PropTypes.bool,
+  tooltipPlacement: PropTypes.string
 };
 
 export default InputErrorSuffix;


### PR DESCRIPTION
### What changed
input => for some reason index calls InputErrorSuffix
So I've updated InputErrorSuffix to send this prop too
...

### Why it changed
placement="top" => placement={this.props.tooltipPlacement}
...

---

- [ ] Change is tested
- [ ] Change is documented
- [ ] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
