### PR TITLE
Input/InputArea: (scss) Remove redundant&invalid fade() function call

### DIFF
--- a/src/Input/Input.scss
+++ b/src/Input/Input.scss
@@ -103,8 +103,8 @@ $material-gap: 8px;
   &-normal {
     @include ThemeDefault($color: $D10, $borderColor: $B30, $backgroundColor: $D80);
     @include ThemeHover($backgroundColor: $B50);
-    @include ThemeFocus($borderColor: $B20, $boxShadow: inset 0px 0px 5px 0px fade($B10, 60%));
-    @include ThemeError($borderColor: $paletteR1, $boxShadow: inset 0px 0px 5px 0px fade($R10, 60%));
+    @include ThemeFocus($borderColor: $B20);
+    @include ThemeError($borderColor: $paletteR1);
     @include ThemeDisable($color: $D55, $borderColor: $D60, $backgroundColor: $D80);
     @include ThemeDisableHover($borderColor: $GR20);
   }
@@ -112,7 +112,7 @@ $material-gap: 8px;
     @include ThemeDefault($color: white, $borderColor: #c1e4fe, $backgroundColor: rgba(22,45,61,0.6));
     @include ThemeHover($backgroundColor: rgba(22,45,61,0.4));
     @include ThemeFocusPanelTile($borderColor: #4eb7f5, $boxShadow: inset 0 0 5px 0 rgba(56,153,236,0.6));
-    @include ThemeError($borderColor: $paletteR1, $boxShadow: inset 0px 0px 5px 0px fade($R10, 60%));
+    @include ThemeError($borderColor: $paletteR1);
     @include ThemeDisable($color: white, $borderColor: $GR40, $backgroundColor: rgba(22,45,61,0.6));
   }
   &-amaterial {

--- a/src/InputArea/InputArea.scss
+++ b/src/InputArea/InputArea.scss
@@ -112,13 +112,13 @@ $gap: 6px;
         @include ThemeDefault($color: $D10, $borderColor: $B30, $backgroundColor: $D80);
         @include ThemeHover($backgroundColor: $B50);
         @include ThemeFocus;
-        @include ThemeError($borderColor: $paletteR1, $boxShadow: inset 0px 0px 5px 0px fade($R10, 60%));
+        @include ThemeError($borderColor: $paletteR1);
     }
     &-paneltitle {
         @include ThemeDefault($color: white, $borderColor: #c1e4fe, $backgroundColor: rgba(22,45,61,0.6));
         @include ThemeHover($backgroundColor: rgba(22,45,61,0.4));
         @include ThemeFocusPanelTile($borderColor: #4eb7f5, $boxShadow: inset 0 0 5px 0 rgba(56,153,236,0.6));
-        @include ThemeError($borderColor: $paletteR1, $boxShadow: inset 0px 0px 5px 0px fade($R10, 60%));
+        @include ThemeError($borderColor: $paletteR1);
     }
     &-amaterial {
         .inputArea {
@@ -128,7 +128,7 @@ $gap: 6px;
         }
         border-radius: 0;
         @include ThemeDefault($color: $D10, $borderColor: #e0e3e5, $backgroundColor: $D80);
-        @include ThemeError($borderColor: $paletteR1, $boxShadow: inset 0px 0px 5px 0px fade($R10, 60%));
+        @include ThemeError($borderColor: $paletteR1);
     }
     &-material {
         border-radius: 0;


### PR DESCRIPTION
There a a few calls to a non-existing function `fade()` in the `scss` of `Input` and `InputArea`.
It might be leftovers of the porting from `less` (since `less` has a `fade` function).

This inset shadow-box which used the `fade` function, was not visible (because of this error),
And catually, the visual specs did not include an `inset shadow-box`.
so this change does not change anything.
Only removing redundant code.