### PR TITLE
[WIP] Update yoshi to 2.0 and allow to ship es modules.

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,7 +1,7 @@
 const merge = require('lodash/merge');
 const path = require('path');
 const genDefaultConfig = require('@storybook/react/dist/server/config/defaults/webpack.config.js');
-const wixStorybookConfig = require('haste-preset-yoshi/config/webpack.config.storybook');
+const wixStorybookConfig = require('yoshi/config/webpack.config.storybook');
 
 module.exports = (config, env) => {
   const newConfig = wixStorybookConfig(genDefaultConfig(config, env));

--- a/package.json
+++ b/package.json
@@ -188,7 +188,11 @@
         "error",
         "fdescribe",
         "fit"
-      ]
+      ],
+      "indent" : 0,
+      "indent-legacy": [2, 2, {
+        "SwitchCase": 1
+      }]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "wix-style-react",
   "version": "2.0.30",
   "main": "./dist/src/index.js",
+  "module": "./dist/es/src/index.js",
   "files": [
     "dist",
     "src",
@@ -14,15 +15,15 @@
     "start": "./scripts/npm-start.sh",
     "pretest": "npm run lint && ./scripts/ensure-dist.sh",
     "test": "npm run test:unit && npm run test:e2e",
-    "test:unit": "haste test --jest",
+    "test:unit": "yoshi test --jest",
     "pretest:e2e": "./scripts/ensure-dist.sh",
     "test:e2e": "concurrently 'npm run test:e2e-only' 'node scripts/e2e-server.js' --names 'protractor,e2e-server' --success first --kill-others",
-    "test:e2e-only": "NODE_ENV=production haste test --protractor",
-    "build": "npm run lint && svg2react-icon && haste build && build-storybook && npm run export-components",
+    "test:e2e-only": "NODE_ENV=production yoshi test --protractor",
+    "build": "npm run lint && svg2react-icon && yoshi build && build-storybook && npm run export-components",
     "storybook": "start-storybook -p 6006",
     "release": "node scripts/npm-release.js",
     "export-components": "import-path --path src",
-    "lint": "haste lint"
+    "lint": "yoshi lint"
   },
   "yoshi": {
     "features": {
@@ -68,7 +69,6 @@
     "eyes.it": "^2.0.0",
     "gh-pages-auto-release": "^1.1.2",
     "github-markdown-css": "^2.4.1",
-    "haste-preset-yoshi": "^1.0.19",
     "highlight.js": "^9.8.0",
     "identity-obj-proxy": "^3.0.0",
     "import-path": "^1.0.0",
@@ -84,7 +84,8 @@
     "sinon": "^1.17.6",
     "svg2react-icon": "^1.0.0",
     "wait-for-cond": "^1.0.3",
-    "wix-storybook-utils": "^1.0.0"
+    "wix-storybook-utils": "^1.0.0",
+    "yoshi": "^2.0.0-beta.0"
   },
   "peerDependencies": {
     "react": "^15.0.0",
@@ -139,11 +140,12 @@
   },
   "babel": {
     "presets": [
-      "es2015",
+      ["es2015", { "modules": false }],
       "react",
       "stage-2"
     ]
   },
+  "side-effects": false,
   "eslintConfig": {
     "extends": "wix/react",
     "env": {
@@ -182,8 +184,5 @@
         "fit"
       ]
     }
-  },
-  "haste": {
-    "preset": "yoshi"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,9 +4,11 @@
   "version": "2.0.30",
   "main": "./dist/src/index.js",
   "module": "./dist/es/src/index.js",
+  "sideEffects": false,
   "files": [
     "dist",
     "src",
+    "es",
     ".babelrc",
     "testkit",
     "*.js"
@@ -85,7 +87,7 @@
     "svg2react-icon": "^1.0.0",
     "wait-for-cond": "^1.0.3",
     "wix-storybook-utils": "^1.0.0",
-    "yoshi": "^2.0.0-beta.0"
+    "yoshi": "^2.0.0-beta.2"
   },
   "peerDependencies": {
     "react": "^15.0.0",
@@ -140,12 +142,16 @@
   },
   "babel": {
     "presets": [
-      ["es2015", { "modules": false }],
+      [
+        "es2015",
+        {
+          "modules": false
+        }
+      ],
       "react",
       "stage-2"
     ]
   },
-  "side-effects": false,
   "eslintConfig": {
     "extends": "wix/react",
     "env": {

--- a/src/AutoComplete/AutoComplete.e2e.js
+++ b/src/AutoComplete/AutoComplete.e2e.js
@@ -11,20 +11,20 @@ describe('AutoComplete', () => {
     browser.get(storyUrl);
 
     waitForVisibilityOf(driver.element(), 'Cannot find AutoComplete')
-    .then(() => {
-      expect(driver.getDropdown().isDisplayed()).toBe(false);
+      .then(() => {
+        expect(driver.getDropdown().isDisplayed()).toBe(false);
 
-      driver.click();
-      browser.sleep(500);// eslint-disable-line no-restricted-properties
+        driver.click();
+        browser.sleep(500);// eslint-disable-line no-restricted-properties
 
-      expect(driver.getDropdown().isDisplayed()).toBe(true);
-      expect(driver.getDropdownItemsCount()).toEqual(5);
+        expect(driver.getDropdown().isDisplayed()).toBe(true);
+        expect(driver.getDropdownItemsCount()).toEqual(5);
 
-      driver.getInput().sendKeys('first');
-      expect(driver.getDropdownItemsCount()).toEqual(1);
+        driver.getInput().sendKeys('first');
+        expect(driver.getDropdownItemsCount()).toEqual(1);
 
-      expect(driver.getDropdownItem(0)).toBe('First option');
-    });
+        expect(driver.getDropdownItem(0)).toBe('First option');
+      });
   });
 
   eyes.it('should choose one of autocomplete items', () => {
@@ -33,11 +33,11 @@ describe('AutoComplete', () => {
     browser.get(storyUrl);
 
     waitForVisibilityOf(driver.element(), 'Cannot find AutoComplete')
-    .then(() => {
-      driver.click();
-      driver.getDropdownItem(2).click();
+      .then(() => {
+        driver.click();
+        driver.getDropdownItem(2).click();
 
-      expect(driver.getInput().getAttribute('value')).toBe('Third option');
-    });
+        expect(driver.getInput().getAttribute('value')).toBe('Third option');
+      });
   });
 });

--- a/src/Backoffice/Tooltip/Tooltip.spec.js
+++ b/src/Backoffice/Tooltip/Tooltip.spec.js
@@ -123,13 +123,13 @@ describe('Tooltip', () => {
     return waitFor.assert(() => {
       expect(driver.isShown()).toBeTruthy();
     })
-    .then(() => {
-      driver.setProps({...props, active: false});
+      .then(() => {
+        driver.setProps({...props, active: false});
 
-      return waitFor.assert(() => {
-        expect(driver.isShown()).toBeFalsy();
+        return waitFor.assert(() => {
+          expect(driver.isShown()).toBeFalsy();
+        });
       });
-    });
   });
 
   it('should test inner component', () => {
@@ -145,10 +145,10 @@ describe('Tooltip', () => {
     expect(driver.isShown()).toBeFalsy();
 
     return waitFor.assert(() => expect(driver.isShown()).toBeTruthy())
-    .then(() => {
-      const buttonTestkit = buttonTestkitFactory({wrapper: driver.getTooltipWrapper(), dataHook});
-      expect(buttonTestkit.getButtonTextContent()).toBe('Button content');
-    });
+      .then(() => {
+        const buttonTestkit = buttonTestkitFactory({wrapper: driver.getTooltipWrapper(), dataHook});
+        expect(buttonTestkit.getButtonTextContent()).toBe('Button content');
+      });
   });
 
   it('should not override focus event', () => {
@@ -293,10 +293,10 @@ describe('Tooltip', () => {
       const driver = enzymeTooltipTestkitFactory({wrapper, dataHook});
       driver.mouseEnter();
       return waitFor.assert(() => expect(driver.isShown()).toBeTruthy())
-      .then(() => {
-        wrapper.unmount();
-        expect(driver.isShown()).toBeFalsy();
-      });
+        .then(() => {
+          wrapper.unmount();
+          expect(driver.isShown()).toBeFalsy();
+        });
     });
   });
 });

--- a/src/Badge/Badge.js
+++ b/src/Badge/Badge.js
@@ -24,7 +24,7 @@ class Badge extends WixComponent {
       styles[alignment],
       styles[shape],
       typography[convertFromUxLangToCss(appearance)
-        ]);
+      ]);
 
     return (
       <span className={className} data-hook={dataHook}>

--- a/src/Breadcrumbs/Breadcrumbs.e2e.js
+++ b/src/Breadcrumbs/Breadcrumbs.e2e.js
@@ -16,15 +16,15 @@ describe('Breadcrumbs', () => {
     const breadcrumbsLinkItems = ['Wix', 'Google', 'Yahoo'];
 
     waitForVisibilityOf([driverNoLinks.element(), driverWithLinks.element()], 'Cannot find Breadcrumbs')
-    .then(() => {
-      breadcrumbsItems.map((item, idx) =>
-        expect(driverNoLinks.breadcrumbContentAt(idx)).toBe(item)
-      );
+      .then(() => {
+        breadcrumbsItems.map((item, idx) =>
+          expect(driverNoLinks.breadcrumbContentAt(idx)).toBe(item)
+        );
 
-      breadcrumbsLinkItems.map((item, idx) =>
-        expect(driverWithLinks.breadcrumbContentAt(idx)).toBe(item)
-      );
-    });
+        breadcrumbsLinkItems.map((item, idx) =>
+          expect(driverWithLinks.breadcrumbContentAt(idx)).toBe(item)
+        );
+      });
   });
 
   eyes.it('should show active item once clicked upon', () => {
@@ -33,15 +33,15 @@ describe('Breadcrumbs', () => {
     const itemToSelect = 2;
 
     waitForVisibilityOf(driver.element(), 'Cannot find Breadcrumbs')
-    .then(() => {
-      breadcrumbsItems.map((item, idx) =>
-        expect(driver.breadcrumbContentAt(idx)).toBe(item)
-      );
+      .then(() => {
+        breadcrumbsItems.map((item, idx) =>
+          expect(driver.breadcrumbContentAt(idx)).toBe(item)
+        );
 
-      expect(driver.getActiveItemId()).toBe(-1);
-      driver.clickBreadcrumbAt(itemToSelect);
-      expect(driver.getActiveItemId()).toBe(itemToSelect);
-    });
+        expect(driver.getActiveItemId()).toBe(-1);
+        driver.clickBreadcrumbAt(itemToSelect);
+        expect(driver.getActiveItemId()).toBe(itemToSelect);
+      });
   });
 
   it('should call func on item click', () => {
@@ -50,18 +50,18 @@ describe('Breadcrumbs', () => {
     const idxToClick = 1;
 
     waitForVisibilityOf(driver.element(), 'Cannot find Breadcrumbs')
-    .then(() => {
-      breadcrumbsItems.map((item, idx) =>
-        expect(driver.breadcrumbContentAt(idx)).toBe(item)
-      );
+      .then(() => {
+        breadcrumbsItems.map((item, idx) =>
+          expect(driver.breadcrumbContentAt(idx)).toBe(item)
+        );
 
-      driver.clickBreadcrumbAt(idxToClick);
-      const EC = protractor.ExpectedConditions;
-      browser.wait(EC.alertIsPresent(), 10000, 'Alert is not getting present :(')
-        .then(() => {
-          expect(browser.switchTo().alert().getText()).toBe(`clicked element is: {"id":"${idxToClick + 1}","value":"${breadcrumbsItems[idxToClick]}"}`);
-          browser.switchTo().alert().accept();
-        });
-    });
+        driver.clickBreadcrumbAt(idxToClick);
+        const EC = protractor.ExpectedConditions;
+        browser.wait(EC.alertIsPresent(), 10000, 'Alert is not getting present :(')
+          .then(() => {
+            expect(browser.switchTo().alert().getText()).toBe(`clicked element is: {"id":"${idxToClick + 1}","value":"${breadcrumbsItems[idxToClick]}"}`);
+            browser.switchTo().alert().accept();
+          });
+      });
   });
 });

--- a/src/Card/ButtonHeader/ButtonHeader.js
+++ b/src/Card/ButtonHeader/ButtonHeader.js
@@ -64,8 +64,8 @@ class ButtonHeader extends WixComponent {
     );
 
     const tooltipElement = tooltip ? (
-        React.cloneElement(tooltip, {}, buttonElement)
-      ) : null;
+      React.cloneElement(tooltip, {}, buttonElement)
+    ) : null;
 
     const actionElement = tooltipElement ? tooltipElement : buttonElement;
 

--- a/src/Card/LinkHeader/LinkHeader.js
+++ b/src/Card/LinkHeader/LinkHeader.js
@@ -44,8 +44,8 @@ class LinkHeader extends WixComponent {
     );
 
     const tooltipElement = tooltip ? (
-        React.cloneElement(tooltip, {}, linkElement)
-      ) : null;
+      React.cloneElement(tooltip, {}, linkElement)
+    ) : null;
 
     const actionElement = tooltipElement ? tooltipElement : linkElement;
 

--- a/src/DataTable/DataTable.js
+++ b/src/DataTable/DataTable.js
@@ -91,7 +91,7 @@ class DataTable extends WixComponent {
       <div>
         <table id={this.props.id} style={style} className={s.table}>
           {!this.props.hideHeader &&
-          <TableHeader {...this.props}/>}
+            <TableHeader {...this.props}/>}
           {this.renderBody(rowsToRender)}
         </table>
       </div>);
@@ -185,14 +185,16 @@ class DataTable extends WixComponent {
     const classes = classNames({[s.important]: column.important});
     const width = rowNum === 0 && this.props.hideHeader ? column.width : undefined;
 
-    return (<td
-      style={column.style}
-      width={width}
-      className={classes}
-      key={colNum}
-      >
-      {column.render && column.render(rowData, rowNum)}
-    </td>);
+    return (
+      <td
+        style={column.style}
+        width={width}
+        className={classes}
+        key={colNum}
+        >
+        {column.render && column.render(rowData, rowNum)}
+      </td>
+    );
   };
 
   calcLastPage = ({data, itemsPerPage}) => Math.ceil(data.length / itemsPerPage) - 1;

--- a/src/DataTable/DataTable.spec.js
+++ b/src/DataTable/DataTable.spec.js
@@ -14,9 +14,9 @@ describe('Table', () => {
     id: 'id',
     data: [{a: 'value 1', b: 'value 2'}, {a: 'value 3', b: 'value 4'}],
     columns: [
-        {title: 'Row Num', render: (row, rowNum) => rowNum},
-        {title: 'A', render: row => row.a},
-        {title: 'B', render: row => row.b}
+      {title: 'Row Num', render: (row, rowNum) => rowNum},
+      {title: 'A', render: row => row.a},
+      {title: 'B', render: row => row.b}
     ],
     rowClass: 'class-name'
   };

--- a/src/EditableSelector/EditableSelector.e2e.js
+++ b/src/EditableSelector/EditableSelector.e2e.js
@@ -13,56 +13,56 @@ describe('EditableSelector', () => {
 
   eyes.it('should render a title', () => {
     waitForVisibilityOf(driver.element(), 'Cannot find EditableSelector')
-    .then(() => {
-      expect(driver.title().getText()).toBe('Type of Seeds');
-    });
+      .then(() => {
+        expect(driver.title().getText()).toBe('Type of Seeds');
+      });
   });
 
 
   eyes.it('should create a new option', () => {
     waitForVisibilityOf(driver.element(), 'Cannot find EditableSelector')
-    .then(() => {
-      const newOption = 'Shir';
-      driver.createNewRow(newOption);
-      driver.clickApprove();
-      expect(driver.item(2).getText()).toBe(newOption);
-    });
+      .then(() => {
+        const newOption = 'Shir';
+        driver.createNewRow(newOption);
+        driver.clickApprove();
+        expect(driver.item(2).getText()).toBe(newOption);
+      });
   });
 
   eyes.it('should not modify an option when edit is cancelled', () => {
     waitForVisibilityOf(driver.element(), 'Cannot find EditableSelector')
-    .then(() => {
-      const newOption = 'Shir';
-      driver.editRow(1, newOption);
-      driver.clickCancel();
-      expect(driver.item(1).getText()).not.toBe(newOption);
-    });
+      .then(() => {
+        const newOption = 'Shir';
+        driver.editRow(1, newOption);
+        driver.clickCancel();
+        expect(driver.item(1).getText()).not.toBe(newOption);
+      });
   });
 
   eyes.it('should save an option when edit is approved', () => {
     waitForVisibilityOf(driver.element(), 'Cannot find EditableSelector')
-    .then(() => {
-      const newOption = 'Shir';
-      driver.editRow(1, newOption);
-      driver.clickApprove();
-      expect(driver.item(1).getText()).toBe(newOption);
-    });
+      .then(() => {
+        const newOption = 'Shir';
+        driver.editRow(1, newOption);
+        driver.clickApprove();
+        expect(driver.item(1).getText()).toBe(newOption);
+      });
   });
 
   eyes.it('should select an option when clicked', () => {
     waitForVisibilityOf(driver.element(), 'Cannot find EditableSelector')
-    .then(() => {
-      driver.toggleItem(0);
-      expect(driver.isSelected(0)).toBe(true);
-    });
+      .then(() => {
+        driver.toggleItem(0);
+        expect(driver.isSelected(0)).toBe(true);
+      });
   });
 
   eyes.it('should delete an option', () => {
     waitForVisibilityOf(driver.element(), 'Cannot find EditableSelector')
-    .then(() => {
-      driver.deleteRow(1);
-      expect(driver.items().count()).toBe(1);
-    });
+      .then(() => {
+        driver.deleteRow(1);
+        expect(driver.items().count()).toBe(1);
+      });
   });
 
 });

--- a/src/EditableSelector/EditableSelector.js
+++ b/src/EditableSelector/EditableSelector.js
@@ -93,25 +93,25 @@ class EditableSelector extends WixComponent {
         {title && <div className={styles.title} data-hook="editable-selector-title"><Text appearance="T2">{title}</Text></div>}
         <div>
           {options.map((option, index) =>
-          this.state.editingRow === index ? this.renderInput(option.title, index) :
-          <div data-hook="editable-selector-row" className={styles.row} key={index}>
-            <Selector
-              dataHook="editable-selector-item"
-              id={index}
-              title={option.title}
-              isSelected={option.isSelected}
-              toggleType={toggleType}
-              onToggle={id => this.onOptionToggle(id)}
-              />
-            <div className={styles.optionMenu}>
-              <ButtonWithOptions.Button onClick={() => this.deleteItem(index)} dataHook="delete-item" type="button" height="small" theme="icon-greybackground">
-                <Trash3 size="15px"/>
-              </ButtonWithOptions.Button>
-              <ButtonWithOptions.Button onClick={() => this.editItem(index)} dataHook="edit-item" height="small" theme="fullblue">
-                {editButtonText}
-              </ButtonWithOptions.Button>
+            this.state.editingRow === index ? this.renderInput(option.title, index) :
+            <div data-hook="editable-selector-row" className={styles.row} key={index}>
+              <Selector
+                dataHook="editable-selector-item"
+                id={index}
+                title={option.title}
+                isSelected={option.isSelected}
+                toggleType={toggleType}
+                onToggle={id => this.onOptionToggle(id)}
+                />
+              <div className={styles.optionMenu}>
+                <ButtonWithOptions.Button onClick={() => this.deleteItem(index)} dataHook="delete-item" type="button" height="small" theme="icon-greybackground">
+                  <Trash3 size="15px"/>
+                </ButtonWithOptions.Button>
+                <ButtonWithOptions.Button onClick={() => this.editItem(index)} dataHook="edit-item" height="small" theme="fullblue">
+                  {editButtonText}
+                </ButtonWithOptions.Button>
+              </div>
             </div>
-          </div>
           )}
         </div>
         {this.state.addingNewRow && this.renderInput()}

--- a/src/FilePicker/FilePicker.e2e.js
+++ b/src/FilePicker/FilePicker.e2e.js
@@ -11,14 +11,14 @@ describe('FilePicker', () => {
 
     browser.get(storyUrl);
     waitForVisibilityOf(driver.element(), 'Cannot find FilePicker')
-    .then(() => {
-      const imagePath = '../../test/assets/surf-musa.png';
-      const absolutePath = path.resolve(__dirname, imagePath);
+      .then(() => {
+        const imagePath = '../../test/assets/surf-musa.png';
+        const absolutePath = path.resolve(__dirname, imagePath);
 
-      expect(driver.getSubLabel()).toBe('No file chosen (Max size 5 MB)');
+        expect(driver.getSubLabel()).toBe('No file chosen (Max size 5 MB)');
 
-      driver.getInput().sendKeys(absolutePath);
-      expect(driver.getSubLabel()).toBe('surf-musa.png');
-    });
+        driver.getInput().sendKeys(absolutePath);
+        expect(driver.getSubLabel()).toBe('surf-musa.png');
+      });
   });
 });

--- a/src/FilePicker/FilePicker.js
+++ b/src/FilePicker/FilePicker.js
@@ -56,7 +56,7 @@ FilePicker.defaultProps = {
   onChange: () => {},
   supportedFormats: '*',
   errorMessage: '',
-  maxSize: 5000000  //5MB
+  maxSize: 5000000 //5MB
 };
 
 FilePicker.propTypes = {

--- a/src/IconWithOptions/IconWithOptions.e2e.js
+++ b/src/IconWithOptions/IconWithOptions.e2e.js
@@ -10,14 +10,14 @@ describe('IconWithOptions', () => {
     const driver = iconWithOptionsTestkitFactory({dataHook});
 
     waitForVisibilityOf(driver.element(), 'Cannot find iconWithOptions')
-    .then(() => {
-      driver.mouseEnter();
-      driver.getDropdownItem(1).click();
+      .then(() => {
+        driver.mouseEnter();
+        driver.getDropdownItem(1).click();
 
-      driver.mouseLeave();
-      driver.mouseEnter();
-      driver.getDropdownItem(1).click();
-      expect(driver.getDropdown().isDisplayed()).toBe(true);
-    });
+        driver.mouseLeave();
+        driver.mouseEnter();
+        driver.getDropdownItem(1).click();
+        expect(driver.getDropdown().isDisplayed()).toBe(true);
+      });
   });
 });

--- a/src/Input/InputSuffix.js
+++ b/src/Input/InputSuffix.js
@@ -23,14 +23,14 @@ const suffixRules = {
 };
 
 const getVisibleSuffixCount = args =>
-   Object.keys(suffixRules).map(key => suffixRules[key])
+  Object.keys(suffixRules).map(key => suffixRules[key])
     .map(fn => fn(args))
     .filter(x => x)
     .length;
 
 const InputSuffix = ({theme, errorMessage, error, disabled, help, helpMessage, onIconClicked,
-      magnifyingGlass, isClearButtonVisible, onClear, menuArrow, unit, suffix, focused,
-      tooltipPlacement, onTooltipShow
+  magnifyingGlass, isClearButtonVisible, onClear, menuArrow, unit, suffix, focused,
+  tooltipPlacement, onTooltipShow
 }) => {
 
   const suffixes = [

--- a/src/InputArea/InputArea.e2e.js
+++ b/src/InputArea/InputArea.e2e.js
@@ -10,7 +10,7 @@ describe('input area page', () => {
     browser.get(storyUrl);
   });
 
-  beforeEach(async() => {
+  beforeEach(async () => {
     await autoExampleDriver.reset();
     await waitForVisibilityOf(inputAreaTestkit.element());
   });

--- a/src/InputWithOptions/InputWithOptions.spec.js
+++ b/src/InputWithOptions/InputWithOptions.spec.js
@@ -121,7 +121,7 @@ const runInputWithOptionsTest = driverFactory => {
           );
 
           driver.inputDriver.trigger('keyDown', {
-            key: 37  // <Left Arrow> key code
+            key: 37 // <Left Arrow> key code
           });
           expect(driver.dropdownLayoutDriver.isShown()).toBe(false);
         });

--- a/src/MessageBox/index.js
+++ b/src/MessageBox/index.js
@@ -4,10 +4,10 @@ import HeaderLayout from './HeaderLayout';
 import FooterLayout from './FooterLayout';
 
 export {
-    MessageBoxMarketerialLayout,
-    MessageBoxMarketerialLayout as MessageBoxLayout1,
-    HeaderLayout, HeaderLayout as HeaderLayout1,
-    FooterLayout, FooterLayout as FooterLayout1,
-    MessageBoxFunctionalLayout, MessageBoxFunctionalLayout as MessageBoxLayout2
+  MessageBoxMarketerialLayout,
+  MessageBoxMarketerialLayout as MessageBoxLayout1,
+  HeaderLayout, HeaderLayout as HeaderLayout1,
+  FooterLayout, FooterLayout as FooterLayout1,
+  MessageBoxFunctionalLayout, MessageBoxFunctionalLayout as MessageBoxLayout2
 };
 

--- a/src/ModalSelectorLayout/ModalSelectorLayout.js
+++ b/src/ModalSelectorLayout/ModalSelectorLayout.js
@@ -262,7 +262,7 @@ export default class ModalSelectorLayout extends WixComponent {
             isSelected(item) ?
               selectedItems.filter(({id}) => item.id !== id) :
               selectedItems.concat(item) :
-           [item]
+            [item]
       });
 
     if (items.length > 0) {

--- a/src/PopoverMenu/PopoverMenu.js
+++ b/src/PopoverMenu/PopoverMenu.js
@@ -62,7 +62,7 @@ class PopoverMenu extends WixComponent {
           [styles.placementTop]: this.props.placement === 'top',
           [styles.placementBottom]: this.props.placement === 'bottom'
         }
-        )}
+      )}
       >
       {this.menuItems(this.props.children)}
     </ul>

--- a/src/RadioGroup/RadioButton/RadioButton.js
+++ b/src/RadioGroup/RadioButton/RadioButton.js
@@ -23,7 +23,7 @@ class RadioButton extends WixComponent {
     type: PropTypes.oneOf(['default', 'button']),
     lineHeight: PropTypes.string,
 
-  /** optional node to be rendered under label. Clicking it will not trigger `onChange` */
+    /** optional node to be rendered under label. Clicking it will not trigger `onChange` */
     content: PropTypes.node
   };
 

--- a/src/RadioGroup/RadioGroup.e2e.js
+++ b/src/RadioGroup/RadioGroup.e2e.js
@@ -45,22 +45,22 @@ describe('RadioGroup', () => {
 
     eyes.it('should focus on first item (not-selected)', () => {
       waitForVisibilityOf(radioGroupDriver.element(), 'Cannot find RadioGroup')
-      .then(async () => {
-        expect(radioGroupDriver.isRadioFocused(0)).toBe(false);
-        await pressTab();
-        expect(radioGroupDriver.isRadioFocused(0)).toBe(true);
-      });
+        .then(async () => {
+          expect(radioGroupDriver.isRadioFocused(0)).toBe(false);
+          await pressTab();
+          expect(radioGroupDriver.isRadioFocused(0)).toBe(true);
+        });
     });
 
     eyes.it('should focus on first item (selected)', () => {
       autoExampleDriver.setProps({value: 1});
       waitForVisibilityOf(radioGroupDriver.element(), 'Cannot find RadioGroup')
-      .then(async () => {
-        expect(radioGroupDriver.isRadioChecked(0)).toBe(true);
-        expect(radioGroupDriver.isRadioFocused(0)).toBe(false);
-        await pressTab();
-        expect(radioGroupDriver.isRadioFocused(0)).toBe(true);
-      });
+        .then(async () => {
+          expect(radioGroupDriver.isRadioChecked(0)).toBe(true);
+          expect(radioGroupDriver.isRadioFocused(0)).toBe(false);
+          await pressTab();
+          expect(radioGroupDriver.isRadioFocused(0)).toBe(true);
+        });
     });
   });
 });

--- a/src/RichTextArea/RichTextArea.driver.js
+++ b/src/RichTextArea/RichTextArea.driver.js
@@ -25,9 +25,9 @@ const richTextAreaDriverFactory = ({element, wrapper, component, componentInstan
     enterText: text => {
       const editorState = componentInstance.state.editorState;
       const newEditorState = editorState
-              .transform()
-              .insertText(text)
-              .apply();
+        .transform()
+        .insertText(text)
+        .apply();
 
       componentInstance.setEditorState(newEditorState);
     },

--- a/src/RichTextArea/RichTextArea.e2e.js
+++ b/src/RichTextArea/RichTextArea.e2e.js
@@ -14,7 +14,7 @@ describe('rich text area page', () => {
     browser.get(storyUrl);
   });
 
-  beforeEach(async() => {
+  beforeEach(async () => {
     await waitForVisibilityOf(richTextAreaTestkit.element());
   });
 

--- a/src/SectionHelper/SectionHelper.spec.js
+++ b/src/SectionHelper/SectionHelper.spec.js
@@ -34,7 +34,7 @@ describe('SectionHelper', () => {
           actionText: 'Muffins are the best!',
           onAction: () => {}
         }
-      ));
+        ));
 
       expect(driver.actionText()).toEqual('Muffins are the best!');
     });

--- a/src/SectionHelper/index.js
+++ b/src/SectionHelper/index.js
@@ -25,23 +25,23 @@ class SectionHelper extends WixComponent {
     return (
       <div className={classnames(styles.root, HELPER_APPEARANCE[this.props.appearance])}>
         { this.props.onClose &&
-          <div className={classnames(styles.close, {[styles.closeWithTitle]: this.props.title})}>
-            <Button
-              dataHook="sectionhelper-close-btn"
-              size="large"
-              theme="close-dark"
-              onClick={this.props.onClose}
-              children={<CloseIcon size="8px"/>}
-              />
-          </div>
+        <div className={classnames(styles.close, {[styles.closeWithTitle]: this.props.title})}>
+          <Button
+            dataHook="sectionhelper-close-btn"
+            size="large"
+            theme="close-dark"
+            onClick={this.props.onClose}
+            children={<CloseIcon size="8px"/>}
+            />
+        </div>
         }
 
         { this.props.title &&
-          <div className={styles.title}>
-            <Text dataHook="sectionhelper-title" appearance="T4">
-              {this.props.title}
-            </Text>
-          </div>
+        <div className={styles.title}>
+          <Text dataHook="sectionhelper-title" appearance="T4">
+            {this.props.title}
+          </Text>
+        </div>
         }
 
         <div className={styles.content}>
@@ -51,15 +51,15 @@ class SectionHelper extends WixComponent {
         </div>
 
         { this.props.onAction && this.props.actionText &&
-          <div className={styles.action}>
-            <Button
-              height="small"
-              theme="outlined"
-              onClick={this.props.onAction}
-              dataHook="sectionhelper-action-btn"
-              children={this.props.actionText}
-              />
-          </div>
+        <div className={styles.action}>
+          <Button
+            height="small"
+            theme="outlined"
+            onClick={this.props.onAction}
+            dataHook="sectionhelper-action-btn"
+            children={this.props.actionText}
+            />
+        </div>
         }
       </div>
     );

--- a/src/SideBar/Menu.js
+++ b/src/SideBar/Menu.js
@@ -49,7 +49,7 @@ class Menu extends React.Component {
     const selectedChild = findChildIndex([...children], selectedId);
     const selected = selectedId === id || selectedChild > -1;
 
-    const height = !selected ? 0 : ((children.length * 48) - 18);  /* 48 is item height, 18 is last item margin */
+    const height = !selected ? 0 : ((children.length * 48) - 18); /* 48 is item height, 18 is last item margin */
     const top = !selected ? 0 : (selectedChild * 42) || 0;
 
     const cn = classnames({

--- a/src/Slider/SliderHandle.js
+++ b/src/Slider/SliderHandle.js
@@ -61,9 +61,9 @@ export default class SliderHandle extends Component {
         style={{left: `${this.props.offset}%`}}
         >
         {this.state.showTooltip &&
-          <div className="slider-tooltip">
-            {this.props.value}
-          </div>}
+        <div className="slider-tooltip">
+          {this.props.value}
+        </div>}
         <div className="slider-handle-inner"/>
       </div>
     );

--- a/src/Text/Text.js
+++ b/src/Text/Text.js
@@ -49,13 +49,13 @@ export default class extends WixComponent {
   }
 
   getType = appearance =>
-     [
+    [
       {type: 'h1', candidates: ['H0']},
       {type: 'h2', candidates: ['H1', 'H1.1']},
       {type: 'h3', candidates: ['H2', 'H2.1']},
       {type: 'h4', candidates: ['H3']},
       {type: 'h5', candidates: ['H4']}
-     ]
+    ]
       .filter(({candidates}) => candidates.indexOf(appearance) !== -1)
       .reduceRight((acc, {type}) => type, 'span');
 
@@ -67,7 +67,7 @@ export default class extends WixComponent {
       .filter(({candidates}) => candidates.indexOf(appearance) !== -1)
       .reduce((acc, {className}) =>
         acc.concat(className),
-        [typography[convertFromUxLangToCss(appearance)]])
+      [typography[convertFromUxLangToCss(appearance)]])
       .join(' ');
 
   render() {

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -84,7 +84,7 @@ class Tooltip extends WixComponent {
     /** Allows changing the padding of the content */
     padding: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
-      /** Allows updating the tooltip position **/
+    /** Allows updating the tooltip position **/
     shouldUpdatePosition: PropTypes.bool
   };
 

--- a/src/index.js
+++ b/src/index.js
@@ -13,10 +13,10 @@ export {default as Checkbox} from './Checkbox';
 export {default as ToggleSwitch} from './ToggleSwitch';
 export {default as Modal} from './Modal';
 export {
-    MessageBoxMarketerialLayout, MessageBoxMarketerialLayout as MessageBoxLayout1,
-    MessageBoxFunctionalLayout, MessageBoxFunctionalLayout as MessageBoxLayout2,
-    HeaderLayout, HeaderLayout as HeaderLayout1,
-    FooterLayout, FooterLayout as FooterLayout1
+  MessageBoxMarketerialLayout, MessageBoxMarketerialLayout as MessageBoxLayout1,
+  MessageBoxFunctionalLayout, MessageBoxFunctionalLayout as MessageBoxLayout2,
+  HeaderLayout, HeaderLayout as HeaderLayout1,
+  FooterLayout, FooterLayout as FooterLayout1
 };
 export {default as RadioGroup} from './RadioGroup';
 export {default as Slider} from './Slider';

--- a/src/providers/WixStyleProvider/WixStyleProvider.spec.js
+++ b/src/providers/WixStyleProvider/WixStyleProvider.spec.js
@@ -28,7 +28,7 @@ describe('WixStyleProvider', () => {
       <WixStyleProvider theme={{color}}>
         <WrappedComponent/>
       </WixStyleProvider>
-      );
+    );
 
     expect(wrapper.html()).toBe(`<div id="component">${children}</div>`);
     expect(wrapper.text()).toBe(children);
@@ -41,7 +41,7 @@ describe('WixStyleProvider', () => {
       <WixStyleProvider>
         <WrappedComponent/>
       </WixStyleProvider>
-      );
+    );
 
     expect(wrapper.text()).toBe(`Theme is core and color is ${color}`);
   });

--- a/src/test-common.js
+++ b/src/test-common.js
@@ -1,9 +1,9 @@
 export {createDriverFactory} from 'wix-ui-test-utils/driver-factory';
 export {
-    getStoryUrl,
-    waitForVisibilityOf,
-    protractorTestkitFactoryCreator,
-    isFocused
+  getStoryUrl,
+  waitForVisibilityOf,
+  protractorTestkitFactoryCreator,
+  isFocused
 } from 'wix-ui-test-utils/protractor';
 export {enzymeTestkitFactoryCreator} from 'wix-ui-test-utils/enzyme';
 export {testkitFactoryCreator} from 'wix-ui-test-utils/vanilla';

--- a/stories/ButtonWithOptions/ExampleControlled.js
+++ b/stories/ButtonWithOptions/ExampleControlled.js
@@ -46,8 +46,8 @@ class ControlledInputWithOptions extends React.Component {
 
     const predicate = element =>
       this.state.value ?
-      element.value.toLowerCase().indexOf(this.state.value.toLowerCase()) !== -1 :
-      true;
+        element.value.toLowerCase().indexOf(this.state.value.toLowerCase()) !== -1 :
+        true;
 
     return (
       <ButtonWithOptions

--- a/stories/DataTable/Example.js
+++ b/stories/DataTable/Example.js
@@ -7,10 +7,10 @@ const style = {
 };
 
 const baseData = [
-    {firstName: 'Meghan', lastName: 'Bishop'},
-    {firstName: 'Sara', lastName: 'Porter'},
-    {firstName: 'Deborah', lastName: 'Rhodes'},
-    {firstName: 'Walter', lastName: 'Jenning'}
+  {firstName: 'Meghan', lastName: 'Bishop'},
+  {firstName: 'Sara', lastName: 'Porter'},
+  {firstName: 'Deborah', lastName: 'Rhodes'},
+  {firstName: 'Walter', lastName: 'Jenning'}
 ];
 
 const generateData = () => {
@@ -37,9 +37,9 @@ class DataTableExample extends React.Component {
           infiniteScroll
           itemsPerPage={20}
           columns={[
-              {title: 'Row Number', render: (row, rowNum) => '#' + (rowNum + 1), width: '20%', minWidth: '75px', important: true},
-              {title: 'First Name', render: row => <span>{row.firstName}</span>, width: '40%', minWidth: '100px'},
-              {title: 'Last Name', render: row => <span>{row.lastName}</span>, width: '40%', minWidth: '100px'}
+            {title: 'Row Number', render: (row, rowNum) => '#' + (rowNum + 1), width: '20%', minWidth: '75px', important: true},
+            {title: 'First Name', render: row => <span>{row.firstName}</span>, width: '40%', minWidth: '100px'},
+            {title: 'Last Name', render: row => <span>{row.lastName}</span>, width: '40%', minWidth: '100px'}
           ]}
           />
       </div>

--- a/stories/DataTable/ExampleCallingServer.js
+++ b/stories/DataTable/ExampleCallingServer.js
@@ -6,10 +6,10 @@ const style = {
 };
 
 const baseData = [
-    {firstName: 'Meghan', lastName: 'Bishop'},
-    {firstName: 'Sara', lastName: 'Porter'},
-    {firstName: 'Deborah', lastName: 'Rhodes'},
-    {firstName: 'Walter', lastName: 'Jenning'}
+  {firstName: 'Meghan', lastName: 'Bishop'},
+  {firstName: 'Sara', lastName: 'Porter'},
+  {firstName: 'Deborah', lastName: 'Rhodes'},
+  {firstName: 'Walter', lastName: 'Jenning'}
 ];
 
 const generateData = count => {
@@ -52,9 +52,9 @@ class DataTableExample extends React.Component {
           infiniteScroll
           itemsPerPage={20}
           columns={[
-              {title: 'Row Number', render: (row, rowNum) => '#' + (rowNum + 1), width: '20%', minWidth: '75px', important: true},
-              {title: 'First Name', render: row => <span>{row.firstName}</span>, width: '40%', minWidth: '100px'},
-              {title: 'Last Name', render: row => <span>{row.lastName}</span>, width: '40%', minWidth: '100px'}
+            {title: 'Row Number', render: (row, rowNum) => '#' + (rowNum + 1), width: '20%', minWidth: '75px', important: true},
+            {title: 'First Name', render: row => <span>{row.firstName}</span>, width: '40%', minWidth: '100px'},
+            {title: 'Last Name', render: row => <span>{row.lastName}</span>, width: '40%', minWidth: '100px'}
           ]}
           hasMore={this.state.hasMore}
           loadMore={this.loadMore}

--- a/stories/DataTable/ExampleWithoutHeader.js
+++ b/stories/DataTable/ExampleWithoutHeader.js
@@ -6,10 +6,10 @@ const style = {
 };
 
 const baseData = [
-    {firstName: 'Meghan', lastName: 'Bishop'},
-    {firstName: 'Sara', lastName: 'Porter'},
-    {firstName: 'Deborah', lastName: 'Rhodes'},
-    {firstName: 'Walter', lastName: 'Jenning'}
+  {firstName: 'Meghan', lastName: 'Bishop'},
+  {firstName: 'Sara', lastName: 'Porter'},
+  {firstName: 'Deborah', lastName: 'Rhodes'},
+  {firstName: 'Walter', lastName: 'Jenning'}
 ];
 
 class DataTableExampleWithoutHeader extends React.Component {
@@ -21,9 +21,9 @@ class DataTableExampleWithoutHeader extends React.Component {
           hideHeader
           data={baseData}
           columns={[
-              {title: 'Row Number', render: (row, rowNum) => '#' + (rowNum + 1), width: '20%', minWidth: '75px', important: true},
-              {title: 'First Name', render: row => <span>{row.firstName}</span>, width: '40%', minWidth: '100px'},
-              {title: 'Last Name', render: row => <span>{row.lastName}</span>, width: '40%', minWidth: '100px'}
+            {title: 'Row Number', render: (row, rowNum) => '#' + (rowNum + 1), width: '20%', minWidth: '75px', important: true},
+            {title: 'First Name', render: row => <span>{row.firstName}</span>, width: '40%', minWidth: '100px'},
+            {title: 'Last Name', render: row => <span>{row.lastName}</span>, width: '40%', minWidth: '100px'}
           ]}
           />
       </div>

--- a/stories/DropdownComposite/DropdownCompositeTemplate.js
+++ b/stories/DropdownComposite/DropdownCompositeTemplate.js
@@ -38,7 +38,7 @@ export default class Form extends Component {
           {...this.props.input}
           value={this.state.value}
           options={[{id: 0, value: 'Option 1'},
-                    {id: 1, value: 'Option 2'}]}
+            {id: 1, value: 'Option 2'}]}
           onChange={e => this.setState({value: e.target.value})}
           />
       </DropdownComposite>

--- a/stories/GridWithCardLayout/ExampleGridRTL.js
+++ b/stories/GridWithCardLayout/ExampleGridRTL.js
@@ -9,18 +9,18 @@ export default () =>
         <Card>
           <Card.Header title="Grid Columns - RTL support">
                 Row RTL support
-            </Card.Header>
+          </Card.Header>
           <Card.Content>
             <Row rtl>
               <Col span={4}>
                         אחת
-                    </Col>
+              </Col>
               <Col span={4}>
                         שתיים
-                    </Col>
+              </Col>
               <Col span={4}>
                         שלוש
-                    </Col>
+              </Col>
             </Row>
           </Card.Content>
         </Card>

--- a/stories/InputWithOptions/ExampleControlled.js
+++ b/stories/InputWithOptions/ExampleControlled.js
@@ -51,8 +51,8 @@ class ControlledInputWithOptions extends React.Component {
 
     const predicate = element =>
       this.state.value ?
-      element.value.toLowerCase().indexOf(this.state.value.toLowerCase()) !== -1 :
-      true;
+        element.value.toLowerCase().indexOf(this.state.value.toLowerCase()) !== -1 :
+        true;
 
     return (
       <InputWithOptions

--- a/stories/MessageBox/ExampleStandard.js
+++ b/stories/MessageBox/ExampleStandard.js
@@ -59,21 +59,21 @@ export default class ControlledMessageBoxes extends React.Component {
       <div>
         <div style={this.buttonsStyles}>
           { Object.keys(this.layouts).map(key =>
-              React.createElement(Button, {
-                key,
-                onClick: () => this.setState({layout: key}),
-                children: `Preview <${key}/>`
-              })
-            )
+            React.createElement(Button, {
+              key,
+              onClick: () => this.setState({layout: key}),
+              children: `Preview <${key}/>`
+            })
+          )
           }
         </div>
 
         { activeLayout ?
-            React.cloneElement(activeLayout, {
-              log: text => () => console.log(text),
-              onClose: () => this.setState({layout: ''})
-            }) :
-            null
+          React.cloneElement(activeLayout, {
+            log: text => () => console.log(text),
+            onClose: () => this.setState({layout: ''})
+          }) :
+          null
         }
       </div>
     );

--- a/stories/Notification/ExampleStandard.js
+++ b/stories/Notification/ExampleStandard.js
@@ -110,17 +110,17 @@ class ExampleStandard extends Component {
             (this.state.actionButton.type === 'none') ? null :
             <div>
               {
-                this.state.actionButton.type !== 'textLink' ? null :
-                <div className={styles.option}>
-                  <Label>Link</Label>
-                  <div className={styles.flex}>
-                    <Input
-                      value={this.state.actionButton.link} size="small"
-                      onChange={event => this.setComponentState('actionButton', {link: event.target.value})}
-                      />
+                  this.state.actionButton.type !== 'textLink' ? null :
+                  <div className={styles.option}>
+                    <Label>Link</Label>
+                    <div className={styles.flex}>
+                      <Input
+                        value={this.state.actionButton.link} size="small"
+                        onChange={event => this.setComponentState('actionButton', {link: event.target.value})}
+                        />
+                    </div>
                   </div>
-                </div>
-              }
+                }
               <div className={styles.option}>
                 <Label>Text</Label>
                 <div className={styles.flex}>

--- a/stories/Page/FullPageExample.js
+++ b/stories/Page/FullPageExample.js
@@ -88,5 +88,5 @@ if (displayAdditionalStories) {
     )
     .add('2.13 + Page Example with short content sidePadding and maxWidth', () =>
       <FullPageExample sidePadding={0} maxWidth={800} shortContent/>
-  );
+    );
 }

--- a/stories/Page/SomeContentComponent.js
+++ b/stories/Page/SomeContentComponent.js
@@ -21,22 +21,22 @@ export default class SomeContentComponent extends React.Component {
         {[...Array(this.props.shortContent ? 0 : 5)].map((x, i) =>
           <div key={i}>
                   Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam facilisis molestie magna vitae pellentesque. Ut elementum accumsan nibh, ut faucibus velit. Vestibulum at mollis justo. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; In sapien odio, hendrerit a iaculis ut, venenatis in ligula. Vestibulum suscipit egestas augue, nec mattis est mollis et. Curabitur id eleifend leo. Fusce tempor efficitur commodo.
-                  <br/>
+            <br/>
             <br/>
                   Cras porta augue non erat imperdiet ornare. Aliquam aliquam elit nec erat ultricies, ac blandit purus efficitur. Suspendisse sagittis id nibh eget pulvinar. Phasellus congue ultricies interdum. Mauris vel dolor at diam feugiat imperdiet feugiat varius eros. Aenean accumsan interdum massa vitae semper. Maecenas tincidunt ut lectus a fringilla. In eleifend ante in tellus consequat vestibulum. Fusce lacinia turpis quis turpis semper venenatis. Donec faucibus felis nisi, non maximus augue mattis ac. Ut erat sem, finibus vel gravida sed, hendrerit ac nibh. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam et egestas lectus. Ut vitae est maximus, viverra sem et, pharetra diam.
-                  <br/>
+            <br/>
             <br/>
                   Vivamus quis nunc maximus elit ullamcorper ullamcorper non sit amet metus. Mauris consequat tortor ac ante vestibulum lacinia. Vestibulum molestie risus purus, nec faucibus odio iaculis vitae. Integer erat magna, interdum et venenatis vel, aliquet id nunc. Vivamus nec pharetra dui. Nam sed quam ultricies, molestie dui a, tempus felis. Pellentesque tincidunt tortor eu tempus porttitor. Nam vitae dapibus lacus, a gravida ligula. Vestibulum eget pulvinar mauris. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; In hac habitasse platea dictumst. Sed ultrices bibendum urna, elementum condimentum est faucibus et. Aenean a hendrerit ipsum. Sed aliquam ligula sed magna commodo, sit amet fringilla urna scelerisque. Phasellus at felis sed neque euismod tincidunt vitae id leo.
-                  <br/>
+            <br/>
             <br/>
                   Donec vel felis id mauris iaculis posuere eget eu purus. Duis id libero dolor. Vivamus nec ornare nunc. Ut efficitur quis sem quis consectetur. Suspendisse et justo ac sem rhoncus posuere et eget quam. Phasellus sit amet viverra nulla, vel tincidunt ante. Duis nec commodo lorem.
-                  <br/>
+            <br/>
             <br/>
                   Proin orci nisl, facilisis ut efficitur sit amet, sollicitudin et metus. Nunc dictum laoreet convallis. Praesent iaculis consequat elit non consectetur. In risus ex, efficitur non tempor ac, suscipit ut nisi. Etiam vel vehicula eros. Sed molestie, metus sed tristique fringilla, tortor metus facilisis justo, sit amet blandit dolor urna eget diam. Etiam nec lorem cursus nisl finibus venenatis. Ut consequat dui non pharetra fringilla. Nulla facilisi.
-                  <br/>
+            <br/>
             <br/>
           </div>
-                  )}
+        )}
       </div>
     );
   }

--- a/stories/RichTextAreaComposite/RichTextAreaCompositeExample.js
+++ b/stories/RichTextAreaComposite/RichTextAreaCompositeExample.js
@@ -41,7 +41,7 @@ class RichTextAreaCompositeExample extends Component {
     this.setState(prevState => {
       prevState[componentName] = {...this.state[componentName], ...obj};
       Object.keys(prevState[componentName])
-          .forEach(k => !prevState[componentName][k] && delete prevState[componentName][k]);
+        .forEach(k => !prevState[componentName][k] && delete prevState[componentName][k]);
       return prevState;
     });
   }

--- a/stories/SideBar/ExampleStandard.js
+++ b/stories/SideBar/ExampleStandard.js
@@ -2,16 +2,16 @@ import React from 'react';
 import SideBar from 'wix-style-react/SideBar';
 
 const items = [
-    {title: 'Home', id: '1'},
+  {title: 'Home', id: '1'},
   {title: 'Submenu1', id: '2', children: [
-        {title: 'Submenu1.1', id: '2.1'},
-        {title: 'Submenu1.2', id: '2.2'},
-        {title: 'Submenu1.3', id: '2.3'}
+    {title: 'Submenu1.1', id: '2.1'},
+    {title: 'Submenu1.2', id: '2.2'},
+    {title: 'Submenu1.3', id: '2.3'}
   ]},
   {title: 'Submenu2', id: '3', children: [
-        {title: 'Submenu2.1', id: '3.1'},
-        {title: 'Submenu2.2', id: '3.2'},
-        {title: 'Submenu2.3', id: '3.3'}
+    {title: 'Submenu2.1', id: '3.1'},
+    {title: 'Submenu2.2', id: '3.2'},
+    {title: 'Submenu2.3', id: '3.3'}
   ]}
 ];
 

--- a/stories/Tooltip/Composite/CompositeStory.js
+++ b/stories/Tooltip/Composite/CompositeStory.js
@@ -65,27 +65,27 @@ storiesOf('7. Tooltips', module)
     </TabbedView>
   ))
 
-.add('7.2. Popover', () => (
-  <div>
-    <h1>Popover</h1>
-    <InteractiveCodeExample title="Customize a <Tooltip/>">
-      <ExamplePopover/>
-    </InteractiveCodeExample>
-  </div>
-))
-
-.add('7.3. Popover Menu', () => (
-  <TabbedView tabs={['Usage', 'Testkit']}>
+  .add('7.2. Popover', () => (
     <div>
-      <h1>Popover Menu</h1>
-      <InteractiveCodeExample title="Customize a <PopoverMenu/>">
-        <a href="?selectedKind=Core&selectedStory=PopoverMenu&full=0&down=0&left=1&panelRight=0">
-          Testkits API reference
-        </a>
-        <ExamplePopoverMenu/>
+      <h1>Popover</h1>
+      <InteractiveCodeExample title="Customize a <Tooltip/>">
+        <ExamplePopover/>
       </InteractiveCodeExample>
     </div>
+  ))
 
-    <Markdown source={PopoverReadmeTestKit}/>
-  </TabbedView>
-));
+  .add('7.3. Popover Menu', () => (
+    <TabbedView tabs={['Usage', 'Testkit']}>
+      <div>
+        <h1>Popover Menu</h1>
+        <InteractiveCodeExample title="Customize a <PopoverMenu/>">
+          <a href="?selectedKind=Core&selectedStory=PopoverMenu&full=0&down=0&left=1&panelRight=0">
+          Testkits API reference
+          </a>
+          <ExamplePopoverMenu/>
+        </InteractiveCodeExample>
+      </div>
+
+      <Markdown source={PopoverReadmeTestKit}/>
+    </TabbedView>
+  ));

--- a/stories/Tooltip/Composite/ExampleTooltip.js
+++ b/stories/Tooltip/Composite/ExampleTooltip.js
@@ -115,20 +115,20 @@ class ExampleTooltip extends Component {
             <Label>Move By</Label>
             <div className={styles.flex}>
               <Label>x
-              <Input
-                size="small"
-                value={this.state.moveBy.x}
-                type="number"
-                onChange={e => this.setState({moveBy: {...this.state.moveBy, x: Number(e.target.value)}})}
-                />
+                <Input
+                  size="small"
+                  value={this.state.moveBy.x}
+                  type="number"
+                  onChange={e => this.setState({moveBy: {...this.state.moveBy, x: Number(e.target.value)}})}
+                  />
               </Label>
               <Label>y
-              <Input
-                size="small"
-                value={this.state.moveBy.y}
-                type="number"
-                onChange={e => this.setState({moveBy: {...this.state.moveBy, y: Number(e.target.value)}})}
-                />
+                <Input
+                  size="small"
+                  value={this.state.moveBy.y}
+                  type="number"
+                  onChange={e => this.setState({moveBy: {...this.state.moveBy, y: Number(e.target.value)}})}
+                  />
               </Label>
             </div>
           </div>


### PR DESCRIPTION
### What changed
👋
[We've updated yoshi to 2.0](https://github.com/wix-private/fed-handbook/wiki/Yoshi-2.0). This update includes webpack@4 and eslint@4 support.
We didn't want to spread breaking changes, so it shouldn't affect most of the projects.

But to take advantage of webpack 4 migration, which supports `sideEffects ` option, I've created this PR which actually adds `sideEffects` and `module` fields to `package.json`.
This means that yoshi [will create `es` directory](https://github.com/wix-private/wix-haste/pull/178) with ES modules.

So instead of
```js
import Button from 'wix-style-react/Button';
import TextField from 'wix-style-react/TextField';
import DatePicker from 'wix-style-react/DatePicker';
```
we could just use:
```js
import { Button, TextField, DatePicker } from 'wix-style-react';
```
and the bundle size will be the same.

I've tested it with `npm link` for [guineapig2](https://github.com/wix-private/guineapig2):
<img width="1673" alt="screen shot 2018-03-20 at 8 55 00 pm" src="https://user-images.githubusercontent.com/1521229/37708960-4bc07b8c-2d11-11e8-82fc-a92b22345662.png">
and it works as expected.
The only thing consumers should do is to exclude `commonjs` transforms.

### Why it's WIP?
`@react/storybook` isn't supported webpack 4 yet, but they have [almost finished PR](https://github.com/storybooks/storybook/pull/3148) and it should be merged in the near future.

### Why so many changes?
We also updated eslint@4. It updates some of the rules, mostly indentation. It's auto-fixable and w/o conflicts, so we could just apply it.
