### PR TITLE
Dropdown Composite driver fix

### DIFF
--- a/src/DropdownComposite/DropdownComposite.driver.js
+++ b/src/DropdownComposite/DropdownComposite.driver.js
@@ -6,7 +6,7 @@ const dropdownCompositeDriverFactory = ({element, wrapper}) => {
 
   return {
     ...inputAreaWithLabelCompositeDriverFactory({element, wrapper}),
-    dropdownLayoutDriver: dropdownDriverFactory({element: dropdown, wrapper: dropdown}).dropdownLayoutDriver
+    ...dropdownDriverFactory({element: dropdown, wrapper: dropdown})
   };
 };
 


### PR DESCRIPTION
### What changed
Expose dropdown driver in composite driver
...

### Why it changed
Before, dropdown composite exposed only dropdownlayout driver, to test the selection on the input you'd need to also use inputWithOptions \ dropdown drivers seperately
...

---

- [ ] Change is tested
- [ ] Change is documented
- [x] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
