### PR TITLE
right margin only if more then one button

### DIFF
--- a/src/MessageBox/FooterLayout.scss
+++ b/src/MessageBox/FooterLayout.scss
@@ -25,6 +25,6 @@
   margin-left: auto;
 }
 
-.footerbuttons > button:first-of-type:not(:last-of-type) {
+.footerbuttons > :first-of-type:not(:last-of-type) {
   margin-right: 12px;
 }

--- a/src/MessageBox/FooterLayout.scss
+++ b/src/MessageBox/FooterLayout.scss
@@ -25,6 +25,6 @@
   margin-left: auto;
 }
 
-.footerbuttons > button:first-of-type {
+.footerbuttons > button:first-of-type:not(:last-of-type) {
   margin-right: 12px;
 }


### PR DESCRIPTION
### What changed

MessageBox/Footer/Layout.scss:28 button class

### Why it changed

When having two buttons there should be a margin on the right of the first button, but when cancelText is empty and there is only one button on the message - there shouldn't be a space on the right..

---

- [ ] Change is tested
- [ ] Change is documented
- [ ] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
