### PR TITLE
DataTable - render newly received data on infinite scroll properly

### DIFF
--- a/src/DataTable/DataTable.e2e.js
+++ b/src/DataTable/DataTable.e2e.js
@@ -26,4 +26,19 @@ describe('Data Table', () => {
           });
       });
   });
+
+  eyes.it('display new data when received', async () => {
+    const dataHook = 'story-data-table-infinite-scroll';
+    const driver = dataTableTestkitFactory({dataHook});
+
+    browser.get(storyUrl);
+
+    await waitForVisibilityOf(driver.element(), 'Cant find Data Table Component');
+    const initialItems = 20;
+    const itemsAfterLoad = 40;
+    driver.scrollToRowByIdx(initialItems - 1);
+
+    await browser.wait(async () => await driver.rowsCount() === itemsAfterLoad, 10000, 'New data wasnt loaded :(');
+    expect(driver.rowsCount()).toEqual(itemsAfterLoad);
+  });
 });

--- a/src/DataTable/DataTable.js
+++ b/src/DataTable/DataTable.js
@@ -37,7 +37,10 @@ class DataTable extends WixComponent {
           return nextProps.data.length > index && nextProps.data[index] === elem;
         })) {
           isLoadingMore = true;
-          this.setState({lastPage: this.calcLastPage(nextProps)});
+          const lastPage = this.calcLastPage(nextProps);
+          const currentPage =
+            this.state.currentPage < lastPage ? this.state.currentPage + 1 : this.state.currentPage;
+          this.setState({lastPage, currentPage});
         }
       }
       if (!isLoadingMore) {

--- a/src/DataTable/DataTable.protractor.driver.js
+++ b/src/DataTable/DataTable.protractor.driver.js
@@ -1,7 +1,18 @@
 
+
+const rowSelector = 'tbody tr';
+const rowByIdx = (component, index) => component.$$(rowSelector).get(index);
+const scrollIntoView = el => {
+  return browser.executeScript(element => {
+    element.scrollIntoView();
+  }, el.getWebElement());
+};
+
 const dataTableDriverFactory = component => ({
-  clickRowByIndex: index => component.$$('tbody tr').get(index).click(),
-  getRowTextByIndex: index => component.$$('tbody tr').get(index).getText(),
+  rowsCount: () => component.$$(rowSelector).count(),
+  clickRowByIndex: index => rowByIdx(component, index).click(),
+  getRowTextByIndex: index => rowByIdx(component, index).getText(),
+  scrollToRowByIdx: index => scrollIntoView(rowByIdx(component, index)),
   element: () => component
 });
 

--- a/stories/DataTable/ExampleCallingServer.js
+++ b/stories/DataTable/ExampleCallingServer.js
@@ -43,6 +43,7 @@ class DataTableExample extends React.Component {
     return (
       <div style={style}>
         <DataTable
+          dataHook="story-data-table-infinite-scroll"
           data={generateData(this.state.count)}
           onRowClick={(row, rowNum) => {
             /*eslint-disable no-alert*/


### PR DESCRIPTION
What changed:
the current page is updated when the new data is received instead when only trying to load more data (on scroll). this renders the new data instantly instead of waiting for additional scroll to invoke the re-render.

Why it changed:
when working with infinite scroll, the table only displays the data up to the current page. the current page was updated only when trying to load more data. after receiving more data, to actually see it in the page you would have to scroll a bit just to trigger another loading, that in turn updates the current page to display the data you already have.
