### PR TITLE
feat(<CollapsedHeader/>) accept handler to be controlled, tests

### DIFF
--- a/src/Card/CollapsedHeader/AnimationPolyfill.js
+++ b/src/Card/CollapsedHeader/AnimationPolyfill.js
@@ -1,0 +1,29 @@
+export default function animationPolyfills(window, global) {
+  let lastTime = 0;
+  const vendors = ['ms', 'moz', 'webkit', 'o'];
+
+  for (let x = 0; x < vendors.length && !global.requestAnimationFrame; ++x) {
+    global.requestAnimationFrame = global[vendors[x] + 'RequestAnimationFrame'];
+    window.cancelAnimationFrame =
+      window[vendors[x] + 'CancelAnimationFrame'] ||
+      window[vendors[x] + 'CancelRequestAnimationFrame'];
+  }
+
+  if (!global.requestAnimationFrame) {
+    global.requestAnimationFrame = function (callback) {
+      const currTime = new Date().getTime();
+      const timeToCall = Math.max(0, 16 - (currTime - lastTime));
+      const id = window.setTimeout(() => {
+        callback(currTime + timeToCall);
+      }, timeToCall);
+      lastTime = currTime + timeToCall;
+      return id;
+    };
+  }
+
+  if (!window.cancelAnimationFrame) {
+    window.cancelAnimationFrame = function (id) {
+      clearTimeout(id);
+    };
+  }
+}

--- a/src/Card/CollapsedHeader/CollapsedHeader.driver.js
+++ b/src/Card/CollapsedHeader/CollapsedHeader.driver.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-
+import ReactTestUtils from 'react-dom/test-utils';
 const CollapsedHeaderDriverFactory = ({element, wrapper, component}) => {
-
   const title = element.querySelector('[data-hook="title"]');
   const subtitle = element.querySelector('[data-hook="subtitle"]');
 
@@ -11,9 +10,15 @@ const CollapsedHeaderDriverFactory = ({element, wrapper, component}) => {
     title: () => title && title.innerHTML,
     subtitle: () => subtitle && subtitle.innerHTML,
     element: () => element,
+    click: () => ReactTestUtils.Simulate.click(title),
+    findByDatahook: dataHook => element.querySelector(`[data-hook="${dataHook}"]`),
     setProps: props => {
-      const ClonedWithProps = React.cloneElement(component, Object.assign({}, component.props, props), ...(component.props.children || []));
-      ReactDOM.render(<div ref={r => element = r}>{ClonedWithProps}</div>, wrapper);
+      const ClonedWithProps = React.cloneElement(
+        component,
+        Object.assign({}, component.props, props),
+        ...(component.props.children || [])
+      );
+      ReactDOM.render(<div ref={r => (element = r)}>{ClonedWithProps}</div>, wrapper);
     }
   };
 };

--- a/src/Card/CollapsedHeader/CollapsedHeader.js
+++ b/src/Card/CollapsedHeader/CollapsedHeader.js
@@ -10,7 +10,6 @@ import ArrowDownThin from '../../../src/Icons/dist/components/ArrowDownThin';
 import ArrowUpThin from '../../../src/Icons/dist/components/ArrowUpThin';
 
 class CollapsedHeader extends WixComponent {
-
   static propTypes = {
     title: node.isRequired,
     subtitle: node,
@@ -20,7 +19,8 @@ class CollapsedHeader extends WixComponent {
     collapsed: bool,
     onCollapsedChange: func,
     buttonCollapseText: string,
-    buttonExpandText: string
+    buttonExpandText: string,
+    controlled: bool
   };
 
   static defaultProps = {
@@ -29,7 +29,8 @@ class CollapsedHeader extends WixComponent {
     toggleStyle: 'switch',
     withoutDivider: false,
     buttonCollapseText: 'Less',
-    buttonExpandText: 'More'
+    buttonExpandText: 'More',
+    controlled: false
   };
 
   constructor(props) {
@@ -41,7 +42,10 @@ class CollapsedHeader extends WixComponent {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (this.props.collapsed !== nextProps.collapsed && nextProps.collapsed !== this.state.isCollapsed) {
+    if (
+      this.props.collapsed !== nextProps.collapsed &&
+      nextProps.collapsed !== this.state.isCollapsed
+    ) {
       this.setState({isCollapsed: nextProps.collapsed});
     }
   }
@@ -50,11 +54,19 @@ class CollapsedHeader extends WixComponent {
     event.stopPropagation();
   }
 
-  toggleCollapsed = () => {
+  onCollapsedChange() {
     const {onCollapsedChange} = this.props;
-    const isCollapsed = !this.state.isCollapsed;
-    this.setState({isCollapsed});
-    onCollapsedChange && onCollapsedChange(isCollapsed);
+    onCollapsedChange && onCollapsedChange(this.state.isCollapsed);
+  }
+
+  onToggleChange = () => {
+    const {controlled} = this.props;
+
+    if (controlled) {
+      this.onCollapsedChange();
+    } else {
+      this.setState(({isCollapsed}) => ({isCollapsed: !isCollapsed}), this.onCollapsedChange);
+    }
   };
 
   render() {
@@ -68,7 +80,11 @@ class CollapsedHeader extends WixComponent {
 
     const switchElement = (
       <div className={styles.collapsedSwitch} onClick={this.stopPropagation}>
-        <Switch dataHook="switch" onChange={this.toggleCollapsed} checked={!this.state.isCollapsed}/>
+        <Switch
+          dataHook="switch"
+          onChange={this.onToggleChange}
+          checked={!this.state.isCollapsed}
+          />
       </div>
     );
 
@@ -78,7 +94,7 @@ class CollapsedHeader extends WixComponent {
           dataHook="button"
           height="medium"
           prefixIcon={this.state.isCollapsed ? <ArrowDownThin/> : <ArrowUpThin/>}
-          onClick={this.toggleCollapsed}
+          onClick={this.onToggleChange}
           theme="whiteblueprimary"
           type="button"
           >
@@ -103,16 +119,14 @@ class CollapsedHeader extends WixComponent {
 
     return (
       <div>
-        <div className={headerClasses} onClick={this.toggleCollapsed}>
+        <div className={headerClasses} onClick={this.onToggleChange}>
           <div>
             {titleElement}
             {subtitleElement}
           </div>
           {toggleElement}
         </div>
-        <Collapse isOpened={!this.state.isCollapsed}>
-          {this.props.children}
-        </Collapse>
+        <Collapse isOpened={!this.state.isCollapsed}>{this.props.children}</Collapse>
       </div>
     );
   }

--- a/src/Card/CollapsedHeader/CollapsedHeader.spec.js
+++ b/src/Card/CollapsedHeader/CollapsedHeader.spec.js
@@ -7,35 +7,138 @@ import {collapsedHeaderTestkitFactory} from '../../../testkit';
 import {collapsedHeaderTestkitFactory as enzymeCollapsedHeaderTestkitFactory} from '../../../testkit/enzyme';
 import {mount} from 'enzyme';
 
-describe('CollpasedHeader', () => {
+import animationPolyfills from './AnimationPolyfill';
+
+const dataHook = 'content';
+const content = <div data-hook={dataHook}>Some Content</div>;
+
+describe('CollapsedHeader', () => {
   const createDriver = createDriverFactory(collapsedHeaderDriverFactory);
+  animationPolyfills(window, global);
 
   it('should have a title', () => {
-    const driver = createDriver(<CollapsedHeader title="Header Title"><div/></CollapsedHeader>);
+    const driver = createDriver(
+      <CollapsedHeader title="Header Title">
+        <div/>
+      </CollapsedHeader>
+    );
     expect(driver.title()).toBe('Header Title');
   });
 
   it('should have a subtitle', () => {
-    const driver = createDriver(<CollapsedHeader title="Header Title" subtitle="Header Subtitle"><div/></CollapsedHeader>);
+    const driver = createDriver(
+      <CollapsedHeader title="Header Title" subtitle="Header Subtitle">
+        <div/>
+      </CollapsedHeader>
+    );
     expect(driver.subtitle()).toBe('Header Subtitle');
   });
 
-  describe('testkit', () => {
-    it('should exist', () => {
-      const div = document.createElement('div');
-      const dataHook = 'myDataHook';
-      const wrapper = div.appendChild(ReactTestUtils.renderIntoDocument(<div><CollapsedHeader title="Header Title" subtitle="Header Subtitle" dataHook={dataHook}><div/></CollapsedHeader></div>));
-      const collapsedHeaderTestkit = collapsedHeaderTestkitFactory({wrapper, dataHook});
-      expect(collapsedHeaderTestkit.exists()).toBeTruthy();
-    });
+  it('should show content', () => {
+    const driver = createDriver(<CollapsedHeader title="Header Title">{content}</CollapsedHeader>);
+
+    expect(driver.findByDatahook('content').innerHTML).toBe('Some Content');
   });
 
-  describe('enzyme testkit', () => {
-    it('should exist', () => {
-      const dataHook = 'myDataHook';
-      const wrapper = mount(<CollapsedHeader title="Header Title" subtitle="Header Subtitle" dataHook={dataHook}><div/></CollapsedHeader>);
-      const collapsedDriverTestkit = enzymeCollapsedHeaderTestkitFactory({wrapper, dataHook});
-      expect(collapsedDriverTestkit.exists()).toBeTruthy();
+  it('should hide content', () => {
+    const driver = createDriver(
+      <CollapsedHeader collapsed title="Header Title">
+        {content}
+      </CollapsedHeader>
+    );
+
+    expect(driver.findByDatahook(dataHook)).toBe(null);
+  });
+
+  it('should call with collapse status', () => {
+    const onCollapsedChange = jest.fn();
+    const driver = createDriver(
+      <CollapsedHeader title="Header Title" onCollapsedChange={onCollapsedChange}>
+        {content}
+      </CollapsedHeader>
+    );
+
+    driver.click();
+    expect(onCollapsedChange).toBeCalledWith(true);
+
+    driver.click();
+    expect(onCollapsedChange).toBeCalledWith(false);
+  });
+
+  it('should hide content on collapse', () => {
+    const driver = createDriver(<CollapsedHeader title="Header Title">{content}</CollapsedHeader>);
+
+    driver.click();
+
+    expect(driver.findByDatahook(dataHook)).toBe(null);
+  });
+
+  it('should show content on collapse', () => {
+    const driver = createDriver(
+      <CollapsedHeader collapsed title="Header Title">
+        {content}
+      </CollapsedHeader>
+    );
+
+    driver.click();
+
+    expect(driver.findByDatahook(dataHook).innerHTML).toBe('Some Content');
+  });
+
+  describe('controlled collapse', () => {
+    it('should call with collapsed status', () => {
+      const onCollapsedChange = jest.fn();
+      const driver = createDriver(
+        <CollapsedHeader title="Header Title" controlled onCollapsedChange={onCollapsedChange}>
+          {content}
+        </CollapsedHeader>
+      );
+
+      driver.click();
+      expect(onCollapsedChange).toBeCalledWith(false);
     });
+
+    it('should not hide content when controlled', () => {
+      const driver = createDriver(
+        <CollapsedHeader title="Header Title" controlled onCollapsedChange={jest.fn()}>
+          {content}
+        </CollapsedHeader>
+      );
+
+      driver.click();
+
+      expect(driver.findByDatahook(dataHook).innerHTML).toBe('Some Content');
+    });
+  });
+});
+
+describe('testkit', () => {
+  it('should exist', () => {
+    const div = document.createElement('div');
+    const dataHook = 'myDataHook';
+    const wrapper = div.appendChild(
+      ReactTestUtils.renderIntoDocument(
+        <div>
+          <CollapsedHeader title="Header Title" subtitle="Header Subtitle" dataHook={dataHook}>
+            <div/>
+          </CollapsedHeader>
+        </div>
+      )
+    );
+    const collapsedHeaderTestkit = collapsedHeaderTestkitFactory({wrapper, dataHook});
+    expect(collapsedHeaderTestkit.exists()).toBeTruthy();
+  });
+});
+
+describe('enzyme testkit', () => {
+  it('should exist', () => {
+    const dataHook = 'myDataHook';
+    const wrapper = mount(
+      <CollapsedHeader title="Header Title" subtitle="Header Subtitle" dataHook={dataHook}>
+        <div/>
+      </CollapsedHeader>
+    );
+    const collapsedDriverTestkit = enzymeCollapsedHeaderTestkitFactory({wrapper, dataHook});
+    expect(collapsedDriverTestkit.exists()).toBeTruthy();
   });
 });

--- a/src/Card/CollapsedHeader/README.TESTKIT.md
+++ b/src/Card/CollapsedHeader/README.TESTKIT.md
@@ -1,0 +1,71 @@
+# CollapsedHeader TestKits
+
+When testing CollapsedHeader you might see some errors with unknown functions, to fix it -
+
+```js
+import animationPolyFill from 'wix-style-react/dist/src/Card/CollapsedHeader/AnimationPolyfill';
+```
+
+Before the tests and after each jsdom cleanup -
+
+```js
+animationPolyFill(window, global);
+```
+
+## CollapsedHeader TestKit API
+
+## Unit testing
+
+### driver
+
+| method         | arguments | returned value | description                       |
+| -------------- | --------- | -------------- | --------------------------------- |
+| exists         | -         | bool           | checks if element does exist      |
+| title          |           | -              | string                            | returns title inner html |
+| subtitle       | -         | string         | returns subtitle inner html       |
+| element        | -         | element        | returns header element            |
+| click          | -         | -              | clicks the header                 |
+| findByDatahook | string    | element        | returns inner element by datahook |
+
+### Usage Example
+
+> Unit testing example
+
+```javascript
+  import React from 'react';
+  import {CollapsedHeaderTestkitFactory} from 'wix-style-react/testkit';
+  import {CollapsedHeaderTestkitFactory as enzymeCollapsedHeaderTestkitFactory} from 'wix-style-react/testkit/enzyme';
+
+  /***************
+   enzyme example
+  ***************/
+
+    const dataHook = 'myDataHook';
+    const wrapper = mount(
+      <CollapsedHeader title="Header Title" subtitle="Header Subtitle" dataHook={dataHook}>
+        <div/>
+      </CollapsedHeader>
+    );
+    const collapsedDriverTestkit = enzymeCollapsedHeaderTestkitFactory({wrapper, dataHook});
+  //Do tests
+    expect(collapsedDriverTestkit.exists()).toBeTruthy();
+
+  /**********************
+   ReactTestUtils example
+  **********************/
+it('should exist', () => {
+    const div = document.createElement('div');
+    const dataHook = 'myDataHook';
+    const wrapper = div.appendChild(
+      ReactTestUtils.renderIntoDocument(
+        <div>
+          <CollapsedHeader title="Header Title" subtitle="Header Subtitle" dataHook={dataHook}>
+            <div/>
+          </CollapsedHeader>
+        </div>
+      )
+    );
+    const collapsedHeaderTestkit = collapsedHeaderTestkitFactory({wrapper, dataHook});
+  //Do tests
+    expect(collapsedHeaderTestkit.exists()).toBeTruthy();
+```

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -45,6 +45,10 @@ The card is a container component of a rounded corner layout.
 |----------|----------|--------------|------------|-------------|
 | title | string | - | + | The title of the card |
 | subtitle | string | - | - | The subtitle of the card |
-| collapsed | bool | false | - | True when the card should be collapsed |
 | toggleSwitch | 'button' / 'switch' | 'switch' | - | The style of the collapsed card toggle |
 | withoutDivider | bool | false | - | Whether to show divider or not |
+| collapsed | bool | false | - | True when the card should be collapsed |
+| onCollapsedChange| func | - | - | Called with collapse status on change
+| controlled <sup> * </sup> | bool | false | - | Converts the component to be controlled
+
+* When controlled flag is passed, collapsed status will be changed only via `collapsed` prop

--- a/stories/GridWithCardLayout/ExampleGrid.scss
+++ b/stories/GridWithCardLayout/ExampleGrid.scss
@@ -1,12 +1,12 @@
 @import '../../src/common.scss';
 
 .columnn-content {
-	background: transparentize(#fac249, .2);
+  background: transparentize(#fac249, 0.2);
 }
 
 .example-container {
-	background: $D70;
-	padding: 30px 48px;
+  background: $D70;
+  padding: 30px 48px;
 
   .actions {
     margin-bottom: 20px;

--- a/stories/GridWithCardLayout/ExampleGridCollapsableHeaders.js
+++ b/stories/GridWithCardLayout/ExampleGridCollapsableHeaders.js
@@ -5,72 +5,125 @@ import styles from './ExampleGrid.scss';
 import TextField from '../../src/TextField';
 import Input from '../../src/Input';
 import Label from '../../src/Label';
+import Badge from '../../src/Badge';
+import Button from '../../src/Button';
 
 function renderStandardInput() {
   return (
     <TextField>
-      <Label
-        for="textField"
-        >
-        Text Field
-      </Label>
-      <Input
-        id="textField"
-        placeholder="Default text goes"
-        />
+      <Label for="textField">Text Field</Label>
+      <Input id="textField" placeholder="Default text goes"/>
     </TextField>
   );
 }
 
-export default () =>
-  <div data-hook="card-example" className={styles.exampleContainer}>
-    <Container>
+export default () => {
+  return (
+    <div data-hook="card-example" className={styles.exampleContainer}>
+      <Container>
+        <Row>
+          <Col span={12}>
+            <Row>
+              <Col span={6}>
+                <Card>
+                  <Card.CollapsedHeader title="Card with collapsed header">
+                    <Card.Content>
+                      <Row>
+                        <Col span={12}>{renderStandardInput()}</Col>
+                      </Row>
+                    </Card.Content>
+                  </Card.CollapsedHeader>
+                </Card>
+              </Col>
+              <Col span={6}>
+                <Card>
+                  <Card.CollapsedHeader
+                    title="Card with collapsed header"
+                    subtitle="and subtitle"
+                    toggleStyle="button"
+                    >
+                    <Card.Content>
+                      <Row>
+                        <Col span={6}>{renderStandardInput()}</Col>
+                      </Row>
+                    </Card.Content>
+                  </Card.CollapsedHeader>
+                </Card>
+              </Col>
+            </Row>
+            <Row>
+              <Col span={12}>
+                <Card>
+                  <Card.CollapsedHeader
+                    title="Card with collapsed header"
+                    subtitle="and subtitle, no divider"
+                    withoutDivider
+                    >
+                    <Card.Content>
+                      <Row>
+                        <Col span={12}>{renderStandardInput()}</Col>
+                      </Row>
+                    </Card.Content>
+                  </Card.CollapsedHeader>
+                </Card>
+              </Col>
+            </Row>
+            <ControlledExample/>
+          </Col>
+        </Row>
+      </Container>
+    </div>
+  );
+};
+
+class ControlledExample extends React.Component {
+  state = {
+    collapsed: false,
+    toggled: false
+  };
+
+  onCollapsedChange() {
+    this.setState({toggled: true});
+    setTimeout(() => this.setState({toggled: false}), 500);
+  }
+
+  render() {
+    const {collapsed} = this.state;
+    return (
       <Row>
-        <Col span={12}>
+        <Col span={8}>
+          <Card>
+            <Card.CollapsedHeader
+              collapsed={collapsed}
+              controlled
+              title="Card with controlled collapsed header"
+              onCollapsedChange={() => this.onCollapsedChange()}
+              >
+              <Card.Content>
+                <Row>
+                  <Col span={12}>{renderStandardInput()}</Col>
+                </Row>
+              </Card.Content>
+            </Card.CollapsedHeader>
+          </Card>
+        </Col>
+        <Col span={4}>
           <Row>
             <Col span={6}>
-              <Card>
-                <Card.CollapsedHeader title="Card with collpaed header">
-                  <Card.Content>
-                    <Row>
-                      <Col span={12}>
-                        {renderStandardInput()}
-                      </Col>
-                    </Row>
-                  </Card.Content>
-                </Card.CollapsedHeader>
-              </Card>
+              <Button
+                onClick={() => this.setState(({collapsed}) => ({collapsed: !collapsed}))}
+                height="large"
+                theme={collapsed ? 'fullred' : 'fullblue'}
+                >
+                {collapsed ? 'Collapsed' : 'Open'}
+              </Button>
             </Col>
-            <Col span={6}>
-              <Card>
-                <Card.CollapsedHeader title="Card with collpaed header" subtitle="and subtitle" toggleStyle="button">
-                  <Card.Content>
-                    <Row>
-                      <Col span={6}>
-                        {renderStandardInput()}
-                      </Col>
-                    </Row>
-                  </Card.Content>
-                </Card.CollapsedHeader>
-              </Card>
-            </Col>
-          </Row>
-          <Row>
-            <Col span={12}>
-              <Card>
-                <Card.CollapsedHeader title="Card with collpaed header" subtitle="and subtitle, no divider" withoutDivider>
-                  <Card.Content>
-                    <Row>
-                      <Col span={12}>
-                        {renderStandardInput()}
-                      </Col>
-                    </Row>
-                  </Card.Content>
-                </Card.CollapsedHeader>
-              </Card>
+            <Col span={2}>
+              <Badge skin={this.state.toggled ? 'success' : 'standard'}>Toggled</Badge>
             </Col>
           </Row>
         </Col>
       </Row>
-    </Container>
-  </div>;
+    );
+  }
+}


### PR DESCRIPTION
### What changed
- Added new prop to CollapsedHeader: handleToggle which lets user handle the collapse state on his own
- Added tests and driver functions to collapsedheader, documentation
- Added story example of the collapsedheader being controlled
- IMPORTANT: Moved animation polyfills out of DatePicker: Added a temp export instead to not introduce breaking changes

### Why it changed
- Need this functionality on Smart Actions Web

---

- [x] Change is tested
- [x] Change is documented
- [x] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
