### PR TITLE
Migrate Button, Search, and Tag to wix-ui-icons-common

### DIFF
--- a/src/Backoffice/Button/Button.spec.js
+++ b/src/Backoffice/Button/Button.spec.js
@@ -6,7 +6,6 @@ import {createDriverFactory} from '../../test-common';
 import {buttonTestkitFactory} from '../../../testkit';
 import {buttonTestkitFactory as enzymeButtonTestkitFactory} from '../../../testkit/enzyme';
 import {mount} from 'enzyme';
-import {Close} from '../../Icons/dist';
 
 describe('Button', () => {
   const createDriver = createDriverFactory(buttonDriverFactory);
@@ -41,14 +40,14 @@ describe('Button', () => {
   });
 
   it('should have a prefixIcon', () => {
-    const driver = createDriver(<Button prefixIcon={<Close/>}/>);
+    const driver = createDriver(<Button prefixIcon={<div/>}/>);
 
     expect(driver.isSuffixIconExists()).toBeFalsy();
     expect(driver.isPrefixIconExists()).toBeTruthy();
   });
 
   it('should have a suffixIcon', () => {
-    const driver = createDriver(<Button suffixIcon={<Close/>}/>);
+    const driver = createDriver(<Button suffixIcon={<div/>}/>);
 
     expect(driver.isPrefixIconExists()).toBeFalsy();
     expect(driver.isSuffixIconExists()).toBeTruthy();

--- a/src/Search/Search.js
+++ b/src/Search/Search.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import InputWithOptions from '../InputWithOptions';
-import Search2 from '../Icons/dist/components/Search2';
+import SearchIcon from 'wix-ui-icons-common/Search';
 import WixComponent from '../BaseComponents/WixComponent';
 
 import styles from './Search.scss';
@@ -75,7 +75,7 @@ export default class Search extends WixComponent {
         {...this.props}
         ref="searchInput"
         roundInput
-        prefix={<div className={styles.leftIcon}><Search2/></div>}
+        prefix={<div className={styles.leftIcon}><SearchIcon/></div>}
         menuArrow={false}
         clearButton
         closeOnSelect

--- a/src/Search/Search.scss
+++ b/src/Search/Search.scss
@@ -1,11 +1,12 @@
 @import '../common';
 
 .leftIcon {
-    display: inline-flex;
-    width: 17px;
-    margin: 0 6px;
-
-    align-items: center;
-
+    margin: 0 4px 0 3px;
     color: $B10;
+
+    & > svg {
+        display: block;
+        width: 22px;
+        height: 22px;
+    }
 }

--- a/src/Tag/Tag.js
+++ b/src/Tag/Tag.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styles from './Tag.scss';
+import Close from 'wix-ui-icons-common/system/Close';
 import classNames from 'classnames';
+import styles from './Tag.scss';
 import WixComponent from '../BaseComponents/WixComponent';
 import Typography from '../Typography';
-import SmallX from '../Icons/dist/components/SmallX';
 
 /**
   * A Tag component
@@ -48,7 +48,7 @@ class Tag extends WixComponent {
             event.stopPropagation();
             onRemove(id);
           }}
-          ><SmallX/></a>}
+          ><Close/></a>}
       </span>
     );
   }


### PR DESCRIPTION
### What changed

* Button - icon in the test, replaced by an empty div
* Tag - close icon, same asset as before, only import path changed
* Search - magnifying glass icon, slightly different asset

---

- [x] Change is tested
- [x] Change is documented
- [x] Build is green
- [x] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)
