### PR TITLE
fix(wix-style-react): #1641: fixed padding of next element related to header

### DIFF
--- a/src/Card/ButtonHeader/ButtonHeader.js
+++ b/src/Card/ButtonHeader/ButtonHeader.js
@@ -37,7 +37,8 @@ class ButtonHeader extends WixComponent {
     const headerClasses = classNames({
       [styles.headerOnlyTitle]: !subtitle,
       [styles.headerTitleSubtitle]: subtitle,
-      [styles.withDivider]: !withoutDivider
+      [styles.withDivider]: !withoutDivider,
+      [styles.withoutDivider]: !!withoutDivider
     });
 
     const buttonClass = classNames({

--- a/src/Card/CollapsedHeader/CollapsedHeader.js
+++ b/src/Card/CollapsedHeader/CollapsedHeader.js
@@ -75,7 +75,8 @@ class CollapsedHeader extends WixComponent {
     const headerClasses = classNames({
       [styles.headerOnlyTitle]: !subtitle,
       [styles.headerTitleSubtitle]: subtitle,
-      [styles.withDivider]: !withoutDivider
+      [styles.withDivider]: !withoutDivider,
+      [styles.withoutDivider]: !!withoutDivider
     });
 
     const switchElement = (

--- a/src/Card/Header/Header.js
+++ b/src/Card/Header/Header.js
@@ -24,7 +24,8 @@ class Header extends WixComponent {
 
     const headerClasses = classNames({
       [styles.header]: true,
-      [styles.withDivider]: !withoutDivider
+      [styles.withDivider]: !withoutDivider,
+      [styles.withoutDivider]: !!withoutDivider
     });
 
     const titleElement = (

--- a/src/Card/Header/Header.scss
+++ b/src/Card/Header/Header.scss
@@ -11,6 +11,10 @@ $header-padding: 27px 30px 26px;
     border-bottom: 1px solid $D60;
   }
 
+  &:not(.with-divider) + * {
+    padding-top: 0;
+  }
+
   .container {
     flex-grow: 1;
     display: flex;

--- a/src/Card/Header/Header.scss
+++ b/src/Card/Header/Header.scss
@@ -11,7 +11,7 @@ $header-padding: 27px 30px 26px;
     border-bottom: 1px solid $D60;
   }
 
-  &:not(.with-divider) + * {
+  &.without-divider + * {
     padding-top: 0;
   }
 

--- a/src/Card/LinkHeader/LinkHeader.js
+++ b/src/Card/LinkHeader/LinkHeader.js
@@ -28,7 +28,8 @@ class LinkHeader extends WixComponent {
     const headerClasses = classNames({
       [styles.headerOnlyTitle]: !subtitle,
       [styles.headerTitleSubtitle]: subtitle,
-      [styles.withDivider]: !withoutDivider
+      [styles.withDivider]: !withoutDivider,
+      [styles.withoutDivider]: !!withoutDivider
     });
 
     const linkElement = (

--- a/stories/GridWithCardLayout/ExampleGridActionHeaders.js
+++ b/stories/GridWithCardLayout/ExampleGridActionHeaders.js
@@ -142,7 +142,36 @@ export default () =>
           <Card>
             <Card.ButtonHeader
               tooltip={<Tooltip placement="top" alignment="center" content="Hi there!"/>}
-              title="Card header no content"
+              buttonOnClick={() => {
+                alert('Clicked!');
+              }}
+              title="Card header"
+              buttonPrefix={<Plus/>}
+              buttonTitle="Tooltip button!"
+              />
+          </Card>
+        </Col>
+        <Col span={6}>
+          <Card>
+            <Card.ButtonHeader
+              withoutDivider
+              title="Card header"
+              buttonOnClick={() => {
+                alert('Clicked!');
+              }}
+              buttonPrefix={<Plus/>}
+              buttonTitle="Tooltip button!"
+              />
+          </Card>
+        </Col>
+      </Row>
+      <Row>
+        <Col span={6}>
+          <Card>
+            <Card.ButtonHeader
+              tooltip={<Tooltip placement="top" alignment="center" content="Hi there!"/>}
+              title="Card header"
+              subtitle="Card subtitle"
               buttonOnClick={() => {
                 alert('Clicked!');
               }}
@@ -154,10 +183,102 @@ export default () =>
         <Col span={6}>
           <Card>
             <Card.ButtonHeader
-              withoutDivider title="Card header no content" subtitle="No divider" buttonOnClick={() => {
+              withoutDivider
+              title="Card header"
+              subtitle="Card subtitle"
+              buttonOnClick={() => {
                 alert('Clicked!');
-              }} buttonPrefix={<ArrowDownThin/>} buttonTitle="Click Me!"
-                                                 />
+              }}
+              buttonPrefix={<Plus/>}
+              buttonTitle="Tooltip button!"
+              />
+          </Card>
+        </Col>
+      </Row>
+
+      <Row>
+        <Col span={6}>
+          <Card>
+            <Card.ButtonHeader
+              tooltip={<Tooltip placement="top" alignment="center" content="Hi there!"/>}
+              title="Card header"
+              buttonOnClick={() => {
+                alert('Clicked!');
+              }}
+              buttonPrefix={<Plus/>}
+              buttonTitle="Tooltip button!"
+              />
+            <Card.Content>
+              <Row>
+                <Col span={6}>
+                  {renderStandardInput()}
+                </Col>
+              </Row>
+            </Card.Content>
+          </Card>
+        </Col>
+        <Col span={6}>
+          <Card>
+            <Card.ButtonHeader
+              withoutDivider
+              tooltip={<Tooltip placement="top" alignment="center" content="Hi there!"/>}
+              title="Card header"
+              buttonOnClick={() => {
+                alert('Clicked!');
+              }}
+              buttonPrefix={<Plus/>}
+              buttonTitle="Tooltip button!"
+              />
+            <Card.Content>
+              <Row>
+                <Col span={6}>
+                  {renderStandardInput()}
+                </Col>
+              </Row>
+            </Card.Content>
+          </Card>
+        </Col>
+      </Row>
+      <Row>
+        <Col span={6}>
+          <Card>
+            <Card.ButtonHeader
+              title="Card header"
+              subtitle="Card subtitle"
+              buttonOnClick={() => {
+                alert('Clicked!');
+              }}
+              buttonPrefix={<Plus/>}
+              buttonTitle="Tooltip button!"
+              />
+            <Card.Content>
+              <Row>
+                <Col span={6}>
+                  {renderStandardInput()}
+                </Col>
+              </Row>
+            </Card.Content>
+          </Card>
+        </Col>
+        <Col span={6}>
+          <Card>
+            <Card.ButtonHeader
+              withoutDivider
+              title="Card header"
+              subtitle="Card subtitle"
+              buttonOnClick={() => {
+                alert('Clicked!');
+              }}
+              buttonPrefix={<Plus/>}
+              buttonTitle="Tooltip button!"
+              />
+            <Card.Content>
+              <Row>
+                <Col span={6}>
+                  {renderStandardInput()}
+                </Col>
+              </Row>
+            </Card.Content>
           </Card>
         </Col>
       </Row>


### PR DESCRIPTION
### What changed

Element next to Card.Header (it's a Card.Content) now has zero padding-top if there is no divider between header and content.

### Why it changed

Fixing https://github.com/wix/wix-style-react/issues/1641
There is should be no double padding between header and content.

---

- [ ] Change is tested
- [ ] Change is documented
- [ ] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)