### PR TITLE
fix(wix-style-react): #1630: Fix Multiselect size

### DIFF
--- a/src/MultiSelect/InputWithTags.js
+++ b/src/MultiSelect/InputWithTags.js
@@ -92,29 +92,31 @@ class InputWithTags extends React.Component {
         onMouseOut={() => this.handleHover()}
         data-hook={this.props.dataHook}
         >
-        {tags.map(({label, ...rest}) => <Tag key={rest.id} disabled={disabled} onRemove={onRemoveTag} {...rest}>{label}</Tag>)}
-        <span className={styles.input} data-hook="inner-input-with-tags">
-          <div className={styles.hiddenDiv} style={{fontSize}}>
-            {this.state.inputValue}
-          </div>
+        <div className={styles.contentWrapper}>
+          {tags.map(({label, ...rest}) => <Tag key={rest.id} disabled={disabled} onRemove={onRemoveTag} {...rest}>{label}</Tag>)}
+          <span className={styles.input} data-hook="inner-input-with-tags">
+            <div className={styles.hiddenDiv} style={{fontSize}}>
+              {this.state.inputValue}
+            </div>
 
-          <Input
-            width={this.props.width}
-            ref={input => this.input = input}
-            onFocus={() => this.handleInputFocus()}
-            onBlur={() => this.handleInputBlur()}
-            placeholder={tags.length === 0 ? placeholder : ''}
-            {...desiredProps}
-            dataHook="inputWithTags-input"
-            disabled={disabled}
-            onChange={e => {
-              if (!delimiters.includes(e.target.value)) {
-                this.setState({inputValue: e.target.value});
-                desiredProps.onChange && desiredProps.onChange(e);
-              }
-            }}
-            />
-        </span>
+            <Input
+              width={this.props.width}
+              ref={input => this.input = input}
+              onFocus={() => this.handleInputFocus()}
+              onBlur={() => this.handleInputBlur()}
+              placeholder={tags.length === 0 ? placeholder : ''}
+              {...desiredProps}
+              dataHook="inputWithTags-input"
+              disabled={disabled}
+              onChange={e => {
+                if (!delimiters.includes(e.target.value)) {
+                  this.setState({inputValue: e.target.value});
+                  desiredProps.onChange && desiredProps.onChange(e);
+                }
+              }}
+              />
+          </span>
+        </div>
       </div>
     );
   }

--- a/src/MultiSelect/InputWithTags.scss
+++ b/src/MultiSelect/InputWithTags.scss
@@ -13,10 +13,14 @@
 }
 
 .tagsContainer {
-  width: 100%;
-  @include FontThin();
   border: 1px solid $B30;
   border-radius: 6px;
+}
+
+.contentWrapper {
+  margin: -1px;
+  width: 100%;
+  @include FontThin();
   display: flex;
   flex-wrap: wrap;
   align-items: center;

--- a/src/MultiSelect/MultiSelect.driver.js
+++ b/src/MultiSelect/MultiSelect.driver.js
@@ -11,7 +11,9 @@ const multiSelectDriverFactory = ({element, wrapper, component}) => {
 
   const inputWrapper = driver.inputWrapper().childNodes[0];
 
-  const tags = initial(inputWrapper.childNodes);
+  const contentWrapper = inputWrapper.childNodes[0];
+
+  const tags = initial(contentWrapper.childNodes);
 
   const multiSelectDriver = Object.assign(driver, {
     getMaxHeight: () => inputWrapper.style.maxHeight,


### PR DESCRIPTION
### What changed

Wrapper for input and tags in multiselect was added. It provides a negative margin which decrease a size of inputWithTags wrapper, which draws border around multiline.

### Why it changed

It was made because multiline contains input 36px (with hidden border) and tags, so this content influences on multiline height. inputWithTags wrapper draws a border around component, so component receives 36 + 2 = 38px. Simple override of content's height in multiline style is not an option because we need to cover all use cases with input size (normal, small, large) and in case that sizes will be changed, we will need to change them in multiline style too. So, this fix provides an independent from other styles solution which handle all use cases and don't influence on calculations of height.

---

- [ ] Change is tested
- [ ] Change is documented
- [ ] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)