### PR TITLE
fix(wix-style-react): #1630: Fix Multiselect size

### DIFF
--- a/src/MultiSelect/InputWithTags.js
+++ b/src/MultiSelect/InputWithTags.js
@@ -92,29 +92,31 @@ class InputWithTags extends React.Component {
         onMouseOut={() => this.handleHover()}
         data-hook={this.props.dataHook}
         >
-        {tags.map(({label, ...rest}) => <Tag key={rest.id} disabled={disabled} onRemove={onRemoveTag} {...rest}>{label}</Tag>)}
-        <span className={styles.input} data-hook="inner-input-with-tags">
-          <div className={styles.hiddenDiv} style={{fontSize}}>
-            {this.state.inputValue}
-          </div>
+        <div className={styles.contentWrapper}>
+          {tags.map(({label, ...rest}) => <Tag key={rest.id} disabled={disabled} onRemove={onRemoveTag} {...rest}>{label}</Tag>)}
+          <span className={styles.input} data-hook="inner-input-with-tags">
+            <div className={styles.hiddenDiv} style={{fontSize}}>
+              {this.state.inputValue}
+            </div>
 
-          <Input
-            width={this.props.width}
-            ref={input => this.input = input}
-            onFocus={() => this.handleInputFocus()}
-            onBlur={() => this.handleInputBlur()}
-            placeholder={tags.length === 0 ? placeholder : ''}
-            {...desiredProps}
-            dataHook="inputWithTags-input"
-            disabled={disabled}
-            onChange={e => {
-              if (!delimiters.includes(e.target.value)) {
-                this.setState({inputValue: e.target.value});
-                desiredProps.onChange && desiredProps.onChange(e);
-              }
-            }}
-            />
-        </span>
+            <Input
+              width={this.props.width}
+              ref={input => this.input = input}
+              onFocus={() => this.handleInputFocus()}
+              onBlur={() => this.handleInputBlur()}
+              placeholder={tags.length === 0 ? placeholder : ''}
+              {...desiredProps}
+              dataHook="inputWithTags-input"
+              disabled={disabled}
+              onChange={e => {
+                if (!delimiters.includes(e.target.value)) {
+                  this.setState({inputValue: e.target.value});
+                  desiredProps.onChange && desiredProps.onChange(e);
+                }
+              }}
+              />
+          </span>
+        </div>
       </div>
     );
   }

--- a/src/MultiSelect/InputWithTags.scss
+++ b/src/MultiSelect/InputWithTags.scss
@@ -13,10 +13,14 @@
 }
 
 .tagsContainer {
-  width: 100%;
-  @include FontThin();
   border: 1px solid $B30;
   border-radius: 6px;
+}
+
+.contentWrapper {
+  margin: -1px;
+  width: 100%;
+  @include FontThin();
   display: flex;
   flex-wrap: wrap;
   align-items: center;

--- a/src/MultiSelect/MultiSelect.driver.js
+++ b/src/MultiSelect/MultiSelect.driver.js
@@ -11,7 +11,9 @@ const multiSelectDriverFactory = ({element, wrapper, component}) => {
 
   const inputWrapper = driver.inputWrapper().childNodes[0];
 
-  const tags = initial(inputWrapper.childNodes);
+  const contentWrapper = inputWrapper.childNodes[0];
+
+  const tags = initial(contentWrapper.childNodes);
 
   const multiSelectDriver = Object.assign(driver, {
     getMaxHeight: () => inputWrapper.style.maxHeight,

--- a/src/MultiSelect/MultiSelect.e2e.js
+++ b/src/MultiSelect/MultiSelect.e2e.js
@@ -20,7 +20,7 @@ describe('MultiSelect', () => {
   });
 
   eyes.it('should break to new line when needed', () => {
-    const ELEMENT_HEIGHT_SINGLE_LINE = 38;
+    const ELEMENT_HEIGHT_SINGLE_LINE = 36;
 
     waitForVisibilityOf(driver.element(), 'Cannot find <MultiSelect/>')
       .then(() => {


### PR DESCRIPTION
The previous PR had a failing E2E test after merging https://github.com/wix/wix-style-react/pull/1663.
I reverted the merge and opened the PR again

```
[17:30:29][MultiSelect] should break to new line when needed (6s)
[17:30:35]
[should break to new line when needed] [Test Output]
[protractor] F
[17:30:35][should break to new line when needed] Expected 72 to be 38.
[17:30:35]
[should break to new line when needed] Error: Failed expectation
    at /home/builduser/agent00/work/f98de12c7057580b/src/MultiSelect/MultiSelect.e2e.js:32:24
    at ManagedPromise.invokeCallback_ (/home/builduser/agent00/work/f98de12c7057580b/node_modules/selenium-webdriver/lib/promise.js:1366:14)
    at TaskQueue.execute_ (/home/builduser/agent00/work/f98de12c7057580b/node_modules/selenium-webdriver/lib/promise.js:2970:14)
    at TaskQueue.executeNext_ (/home/builduser/agent00/work/f98de12c7057580b/node_modules/selenium-webdriver/lib/promise.js:2953:27)
    at asyncRun (/home/builduser/agent00/work/f98de12c7057580b/node_modules/selenium-webdriver/lib/promise.js:2813:27)
    at /home/builduser/agent00/work/f98de12c7057580b/node_modules/selenium-webdriver/lib/promise.js:676:7
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
```