### PR TITLE
fix(PopoverMenu): pass the tooltip  zIndex prop

### DIFF
--- a/src/PopoverMenu/PopoverMenu.js
+++ b/src/PopoverMenu/PopoverMenu.js
@@ -15,7 +15,8 @@ class PopoverMenu extends WixComponent {
     buttonHeight: Button.propTypes.height,
     maxWidth: Tooltip.propTypes.maxWidth,
     appendToParent: Tooltip.propTypes.appendToParent,
-    appendTo: Tooltip.propTypes.appendTo
+    appendTo: Tooltip.propTypes.appendTo,
+    zIndex: Tooltip.propTypes.zIndex
   };
 
   static defaultProps = {
@@ -95,6 +96,7 @@ class PopoverMenu extends WixComponent {
         shouldCloseOnClickOutside
         appendTo={this.props.appendTo}
         appendToParent={this.props.appendToParent}
+        zIndex={this.props.zIndex}
         >
         <Button
           type="button"


### PR DESCRIPTION
### What changed
pass the Tooltip's zIndex prop to the popover menu

### Why it changed
adding zIndex control of the popover
