### PR TITLE
Deprecate `gh-pages-auto-release`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 `wix-style-react` is a collection of [React](https://facebook.github.io/react/) components that conform to Wix Style created by Wix UX guild.
 
-#### [Demo](https://wix.github.io/wix-style-react) | [Source](https://github.com/wix/wix-style-react)
+#### [Demo](https://wix-wix-style-react.surge.sh/) | [Source](https://github.com/wix/wix-style-react)
 
 ## Setup
 
@@ -39,7 +39,7 @@ const MyComponent = () =>
 
 ## Tips
 
-* Use [Yoshi](https://github.com/wix/yoshi) as build tool to avoid configuration. Otherwise follow [webpack setup instructions here](https://wix.github.io/wix-style-react/?selectedKind=Introduction&selectedStory=Usage%20Without%20Yoshi&full=0&down=0&left=1&panelRight=0)
+* Use [Yoshi](https://github.com/wix/yoshi) as build tool to avoid configuration. Otherwise follow [webpack setup instructions here](https://wix-wix-style-react.surge.sh/?selectedKind=Introduction&selectedStory=Usage%20Without%20Yoshi&full=0&down=0&left=1&panelRight=0)
 * Enable font smoothing with browser specific css properties, for example:
     ```css
     html {
@@ -47,13 +47,13 @@ const MyComponent = () =>
       -moz-osx-font-smoothing: grayscale;
     }
     ```
-* Use [demo pages](https://wix.github.io/wix-style-react) to find all available components with examples.
+* Use [demo pages](https://wix-wix-style-react.surge.sh/) to find all available components with examples.
 
 ## Contributing
-Please refer to the [Contribution page](https://wix.github.io/wix-style-react/?selectedKind=Introduction&selectedStory=Contribution&full=0&down=0&left=1&panelRight=0)
+Please refer to the [Contribution page](https://wix-wix-style-react.surge.sh/?selectedKind=Introduction&selectedStory=Contribution&full=0&down=0&left=1&panelRight=0)
 
 ## Tests
-Please refer to the [Testing page](https://wix.github.io/wix-style-react/?selectedKind=Introduction&selectedStory=Testing&full=0&down=0&left=1&panelRight=0)
+Please refer to the [Testing page](https://wix-wix-style-react.surge.sh/?selectedKind=Introduction&selectedStory=Testing&full=0&down=0&left=1&panelRight=0)
 
 ## License
 This project is offered under [MIT License](https://github.com/wix/wix-style-react/blob/master/LICENSE).

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -29,7 +29,7 @@ open localhost:6006
 
 * One component per file
 * All assets in `src/assets` folder
-* e2e & unit test as well as enzyme & protractor testkits. See [Testing](https://wix.github.io/wix-style-react/?selectedKind=Introduction&selectedStory=Testing&full=0&down=0&left=1&panelRight=0) for details.
+* e2e & unit test as well as enzyme & protractor testkits. See [Testing](https://wix-wix-style-react.surge.sh/?selectedKind=Introduction&selectedStory=Testing&full=0&down=0&left=1&panelRight=0) for details.
 * Prefer [controlled components](https://goshakkk.name/controlled-vs-uncontrolled-inputs-react/)
 * support `rtl` boolean prop to support right-to-left languages
 
@@ -57,8 +57,8 @@ open localhost:6006
     It's important since in a good case we are able to automatically parse the source and create API docs for your component.
 
 * design according to [Zeplin](https://app.zeplin.io/project/5864e02695b5754a69f56150) design created by UX guild.
-* follow [Documenting Components](https://wix.github.io/wix-style-react/?selectedKind=Introduction&selectedStory=Documenting%20components&full=0&down=0&left=1&panelRight=0) to configure and generate docs automatically.
-* add unit and e2e tests as well as testkits for enzyme and protractor. See [Testing](https://wix.github.io/wix-style-react/?selectedKind=Introduction&selectedStory=Testing&full=0&down=0&left=1&panelRight=0) for details.
+* follow [Documenting Components](https://wix-wix-style-react.surge.sh/?selectedKind=Introduction&selectedStory=Documenting%20components&full=0&down=0&left=1&panelRight=0) to configure and generate docs automatically.
+* add unit and e2e tests as well as testkits for enzyme and protractor. See [Testing](https://wix-wix-style-react.surge.sh/?selectedKind=Introduction&selectedStory=Testing&full=0&down=0&left=1&panelRight=0) for details.
 * export your `testkitFactory` from the following files:
     * `wix-style-react/testkit/index.js`
     * `wix-style-react/testkit/enzyme.js`

--- a/docs/adding-story.md
+++ b/docs/adding-story.md
@@ -1,6 +1,6 @@
 # Documenting Components
 
-All components exported by `wix-style-react` are documented and displayed on our [github page](wix.github.io/wix-style-react/) (you probably are looking at it now).
+All components exported by `wix-style-react` are documented and displayed on our [github page](wix-wix-style-react.surge.sh/) (you probably are looking at it now).
 
 It is rendered with [Storybook](https://storybook.js.org).
 

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "test:e2e-only": "NODE_ENV=production yoshi test --protractor",
     "build": "npm run lint && svg2react-icon && yoshi build && build-storybook && npm run export-components",
     "storybook": "start-storybook -p 6006",
-    "postpublish": "gh-pages-auto-release --dist=storybook-static && teamcity-surge-autorelease",
+    "postpublish": "teamcity-surge-autorelease --dist=storybook-static",
     "export-components": "import-path --path src",
     "lint": "yoshi lint",
-    "pr-release": "teamcity-surge-autorelease"
+    "pr-release": "teamcity-surge-autorelease --dist=storybook-static"
   },
   "yoshi": {
     "features": {

--- a/src/AutoComplete/README.TESTKIT.md
+++ b/src/AutoComplete/README.TESTKIT.md
@@ -2,4 +2,4 @@
 
 > Input with auto suggestions
 
-Autocomplete testkit is identical to [InputWithOptions](https://wix.github.io/wix-style-react/?selectedKind=Core&selectedStory=InputWithOptions&full=0&down=0&left=1&panelRight=0) test kit
+Autocomplete testkit is identical to [InputWithOptions](https://wix-wix-style-react.surge.sh/?selectedKind=Core&selectedStory=InputWithOptions&full=0&down=0&left=1&panelRight=0) test kit

--- a/src/ButtonWithOptions/README.TESTKIT.md
+++ b/src/ButtonWithOptions/README.TESTKIT.md
@@ -4,7 +4,7 @@
 
 ## ButtonWithOptions TestKit API
 
-### The ButtonWithOptions TestKit is exposing the [buttonDriver](https://wix.github.io/wix-style-react/?selectedKind=Core&selectedStory=Button&full=0&down=0&left=1&panelRight=0) and [dropdownLayoutDriver](https://wix.github.io/wix-style-react/?selectedKind=Core&selectedStory=DropdownLayout&full=0&down=0&left=1&panelRight=0) and adds its own driver, see examples below
+### The ButtonWithOptions TestKit is exposing the [buttonDriver](https://wix-wix-style-react.surge.sh/?selectedKind=Core&selectedStory=Button&full=0&down=0&left=1&panelRight=0) and [dropdownLayoutDriver](https://wix-wix-style-react.surge.sh/?selectedKind=Core&selectedStory=DropdownLayout&full=0&down=0&left=1&panelRight=0) and adds its own driver, see examples below
  
 #### Driver methods:
 

--- a/src/Checkbox/README.TESTKIT.md
+++ b/src/Checkbox/README.TESTKIT.md
@@ -8,7 +8,7 @@
 | -------------------------- | --------- | ---------------------------------------- | ---------------------------------------- |
 | getInput                   | -         | element                                  | returns checkbox input element           |
 | getLabel                   | -         | element                                  | returns checkbox label element           |
-| getLabelDriver             | -         | instance of [label driver](https://wix.github.io/wix-style-react/?selectedKind=Core&selectedStory=Label&full=0&down=0&left=1&panelRight=0) | label testkit instantiated with checkbox's inner label |
+| getLabelDriver             | -         | instance of [label driver](https://wix-wix-style-react.surge.sh/?selectedKind=Core&selectedStory=Label&full=0&down=0&left=1&panelRight=0) | label testkit instantiated with checkbox's inner label |
 | isChecked                  | -         | bool                                     | fulfilled if element has class '.checked' |
 | isDisabled                 | -         | bool                                     | fulfilled if element has class '.disabled' |
 | isIndeterminate            | -         | bool                                     | fulfilled if element has class '.indeterminate' |

--- a/src/DatePicker/README.TESTKIT.md
+++ b/src/DatePicker/README.TESTKIT.md
@@ -23,7 +23,7 @@ datePickerPolyfills(window, global);
 
 ### inputDriver
 
-[See Input component driver documentation](https://wix.github.io/wix-style-react/?selectedKind=Core&selectedStory=Input).
+[See Input component driver documentation](https://wix-wix-style-react.surge.sh/?selectedKind=Core&selectedStory=Input).
 
 ### calendarDriver
 

--- a/src/Dropdown/README.TESTKIT.md
+++ b/src/Dropdown/README.TESTKIT.md
@@ -4,7 +4,7 @@
 
 ## Dropdown TestKit API
 
-### Dropdown Enzyme/ReactTestUtils testkit is identical to [InputWithOptions](https://wix.github.io/wix-style-react/?selectedKind=Core&selectedStory=InputWithOptions&full=0&down=0&left=1&panelRight=0) test kit 
+### Dropdown Enzyme/ReactTestUtils testkit is identical to [InputWithOptions](https://wix-wix-style-react.surge.sh/?selectedKind=Core&selectedStory=InputWithOptions&full=0&down=0&left=1&panelRight=0) test kit 
 
 #### Protractor test kit:
 

--- a/src/Grid/README.md
+++ b/src/Grid/README.md
@@ -4,7 +4,7 @@ A grid container is based on rows with a 12 column layout.
 
 For full documentation read [Bootstrap docs](http://getbootstrap.com/css/#grid)
 
-For Card API [Card](https://wix.github.io/wix-style-react/?selectedKind=Common&selectedStory=Card&full=0&addons=0&stories=1&panelRight=0)
+For Card API [Card](https://wix-wix-style-react.surge.sh/?selectedKind=Common&selectedStory=Card&full=0&addons=0&stories=1&panelRight=0)
 
 ## wix-style-react additions to bootstrap
 

--- a/src/Icons/README.md
+++ b/src/Icons/README.md
@@ -1,6 +1,6 @@
 # Icons
 
-> SVG Icon base type. The list of existing icons can be found [here]('https://wix.github.io/wix-style-react/?selectedKind=6.%20Common&selectedStory=6.5%20Icons&full=0&down=0&left=1&panelRight=0') 
+> SVG Icon base type. The list of existing icons can be found [here]('https://wix-wix-style-react.surge.sh/?selectedKind=6.%20Common&selectedStory=6.5%20Icons&full=0&down=0&left=1&panelRight=0') 
 
 ## Properties
 

--- a/src/InputWithOptions/README.TESTKIT.md
+++ b/src/InputWithOptions/README.TESTKIT.md
@@ -4,7 +4,7 @@
 
 ## InputWithOptions TestKit API
 
-### The InputWithOptions TestKit is exposing the [inputDriver](https://wix.github.io/wix-style-react/?selectedKind=Core&selectedStory=Input&full=0&down=0&left=1&panelRight=0) and [dropdownLayoutDriver](https://wix.github.io/wix-style-react/?selectedKind=Core&selectedStory=DropdownLayout&full=0&down=0&left=1&panelRight=0) and adds its own driver, see examples below
+### The InputWithOptions TestKit is exposing the [inputDriver](https://wix-wix-style-react.surge.sh/?selectedKind=Core&selectedStory=Input&full=0&down=0&left=1&panelRight=0) and [dropdownLayoutDriver](https://wix-wix-style-react.surge.sh/?selectedKind=Core&selectedStory=DropdownLayout&full=0&down=0&left=1&panelRight=0) and adds its own driver, see examples below
  
 #### Driver methods:
 

--- a/src/LanguagePicker/README.TESTKIT.md
+++ b/src/LanguagePicker/README.TESTKIT.md
@@ -4,7 +4,7 @@
 
 ## LanguagePicker TestKit API
 
-### The LanguagePicker TestKit is exposing the [IconWithOptions](https://wix.github.io/wix-style-react/?selectedKind=4.%20Selection&selectedStory=4.5%20IconWithOptions&full=0&down=0&left=1&panelRight=0&downPanel=kadirahq%2Fstorybook-addon-actions%2Factions-panel)
+### The LanguagePicker TestKit is exposing the [IconWithOptions](https://wix-wix-style-react.surge.sh/?selectedKind=4.%20Selection&selectedStory=4.5%20IconWithOptions&full=0&down=0&left=1&panelRight=0&downPanel=kadirahq%2Fstorybook-addon-actions%2Factions-panel)
 
 ## Usage Example
 

--- a/src/ModalSelectorLayout/README.TESTKIT.md
+++ b/src/ModalSelectorLayout/README.TESTKIT.md
@@ -7,12 +7,12 @@
 | method                   | arguments | returned value                           | description                              |
 | ------------------------ | --------- | ---------------------------------------- | ---------------------------------------- |
 | exists                   | -         | boolean                                  | fulfilled if element in the DOM          |
-| mainLoaderDriver         | -         | [LoaderDriver](https://wix.github.io/wix-style-react/?selectedKind=Core&selectedStory=Loader&full=0&down=0&left=1&panelRight=0) | Main loader shown while the initial items are loading/being filtered |
-| nextPageLoaderDriver     | -         | [LoaderDriver](https://wix.github.io/wix-style-react/?selectedKind=Core&selectedStory=Loader&full=0&down=0&left=1&panelRight=0) | Loader shown at the bottom of the list while loading the next page |
-| cancelButtonDriver       | -         | [ButtonDriver](https://wix.github.io/wix-style-react/?selectedKind=Backoffice&selectedStory=Button&full=0&down=0&left=1&panelRight=0) | "Cancel" button                          |
-| okButtonDriver           | -         | [ButtonDriver](https://wix.github.io/wix-style-react/?selectedKind=Backoffice&selectedStory=Button&full=0&down=0&left=1&panelRight=0) | "OK" button                              |
-| searchDriver             | -         | [SearchDriver](https://wix.github.io/wix-style-react/?selectedKind=3.%20Inputs&selectedStory=3.9%20Search&full=0&down=0&left=1&panelRight=0) | Search input                             |
-| subtitleTextDriver       | -         | [TextDriver](https://wix.github.io/wix-style-react/?selectedKind=Core&selectedStory=Text&full=0&down=0&left=1&panelRight=0) | Subtitle of the modal                    |
+| mainLoaderDriver         | -         | [LoaderDriver](https://wix-wix-style-react.surge.sh/?selectedKind=Core&selectedStory=Loader&full=0&down=0&left=1&panelRight=0) | Main loader shown while the initial items are loading/being filtered |
+| nextPageLoaderDriver     | -         | [LoaderDriver](https://wix-wix-style-react.surge.sh/?selectedKind=Core&selectedStory=Loader&full=0&down=0&left=1&panelRight=0) | Loader shown at the bottom of the list while loading the next page |
+| cancelButtonDriver       | -         | [ButtonDriver](https://wix-wix-style-react.surge.sh/?selectedKind=Backoffice&selectedStory=Button&full=0&down=0&left=1&panelRight=0) | "Cancel" button                          |
+| okButtonDriver           | -         | [ButtonDriver](https://wix-wix-style-react.surge.sh/?selectedKind=Backoffice&selectedStory=Button&full=0&down=0&left=1&panelRight=0) | "OK" button                              |
+| searchDriver             | -         | [SearchDriver](https://wix-wix-style-react.surge.sh/?selectedKind=3.%20Inputs&selectedStory=3.9%20Search&full=0&down=0&left=1&panelRight=0) | Search input                             |
+| subtitleTextDriver       | -         | [TextDriver](https://wix-wix-style-react.surge.sh/?selectedKind=Core&selectedStory=Text&full=0&down=0&left=1&panelRight=0) | Subtitle of the modal                    |
 | getTitle                 | -         | string                                   | Title of the modal                       |
 | clickOnClose             | -         | -                                        | Click on "X" button of modal             |
 | showsEmptyState          | -         | boolean                                  | Whether the "emptyState" element is shown |
@@ -21,7 +21,7 @@
 | getNoResultsFoundState   | -         | Element                                  | Get the "noResultsFoundState" element    |
 | listExists               | -         | boolean                                  | If the list of items exists at all       |
 | numberOfItemsInList      | -         | number                                   | Number of rows currently rendered        |
-| getSelectorDriverAt      | number    | [SelectorDriver](https://wix.github.io/wix-style-react/?selectedKind=Core&selectedStory=Selector&full=0&down=0&left=1&panelRight=0) | Return the instance of selectorDriver for the row at the passed index |
+| getSelectorDriverAt      | number    | [SelectorDriver](https://wix-wix-style-react.surge.sh/?selectedKind=Core&selectedStory=Selector&full=0&down=0&left=1&panelRight=0) | Return the instance of selectorDriver for the row at the passed index |
 | scrollDown               | -         | -                                        | Triggers "scroll" event on the list, needed to trigger the infinite scroll |
 
 ## Protractor TestKit API
@@ -29,12 +29,12 @@
 | method                 | arguments | returned value                           | description                              |
 | ---------------------- | --------- | ---------------------------------------- | ---------------------------------------- |
 | element                | -         | element                                  | returns the driver element               |
-| mainLoaderDriver       | -         | [LoaderDriver](https://wix.github.io/wix-style-react/?selectedKind=Core&selectedStory=Loader&full=0&down=0&left=1&panelRight=0) | Main loader shown while the initial items are loading |
-| nextPageLoaderDriver   | -         | [LoaderDriver](https://wix.github.io/wix-style-react/?selectedKind=Core&selectedStory=Loader&full=0&down=0&left=1&panelRight=0) | Loader shown at the bottom of the list while loading more items |
-| cancelButtonDriver     | -         | [ButtonDriver](https://wix.github.io/wix-style-react/?selectedKind=Backoffice&selectedStory=Button&full=0&down=0&left=1&panelRight=0) | "Cancel" button                          |
-| okButtonDriver         | -         | [ButtonDriver](https://wix.github.io/wix-style-react/?selectedKind=Backoffice&selectedStory=Button&full=0&down=0&left=1&panelRight=0) | "OK" button                              |
-| searchDriver           | -         | [SearchDriver](https://wix.github.io/wix-style-react/?selectedKind=3.%20Inputs&selectedStory=3.9%20Search&full=0&down=0&left=1&panelRight=0) | Search input                             |
-| subtitleTextDriver     | -         | [TextDriver](https://wix.github.io/wix-style-react/?selectedKind=Core&selectedStory=Text&full=0&down=0&left=1&panelRight=0) | Subtitle of the modal                    |
+| mainLoaderDriver       | -         | [LoaderDriver](https://wix-wix-style-react.surge.sh/?selectedKind=Core&selectedStory=Loader&full=0&down=0&left=1&panelRight=0) | Main loader shown while the initial items are loading |
+| nextPageLoaderDriver   | -         | [LoaderDriver](https://wix-wix-style-react.surge.sh/?selectedKind=Core&selectedStory=Loader&full=0&down=0&left=1&panelRight=0) | Loader shown at the bottom of the list while loading more items |
+| cancelButtonDriver     | -         | [ButtonDriver](https://wix-wix-style-react.surge.sh/?selectedKind=Backoffice&selectedStory=Button&full=0&down=0&left=1&panelRight=0) | "Cancel" button                          |
+| okButtonDriver         | -         | [ButtonDriver](https://wix-wix-style-react.surge.sh/?selectedKind=Backoffice&selectedStory=Button&full=0&down=0&left=1&panelRight=0) | "OK" button                              |
+| searchDriver           | -         | [SearchDriver](https://wix-wix-style-react.surge.sh/?selectedKind=3.%20Inputs&selectedStory=3.9%20Search&full=0&down=0&left=1&panelRight=0) | Search input                             |
+| subtitleTextDriver     | -         | [TextDriver](https://wix-wix-style-react.surge.sh/?selectedKind=Core&selectedStory=Text&full=0&down=0&left=1&panelRight=0) | Subtitle of the modal                    |
 | getTitle               | -         | string                                   | Title of the modal                       |
 | clickOnClose           | -         | -                                        | Click on "X" button of modal             |
 | getEmptyState          | -         | Element                                  | Get the "emptyState" element             |

--- a/src/MultiSelect/README.TESTKIT.md
+++ b/src/MultiSelect/README.TESTKIT.md
@@ -7,9 +7,9 @@
 ### Exposed Drivers
 The `<MultiSelect/>` TestKit is exposing the following drivers:
 * Its own driver (see examples below).
-* [inputDriver](https://wix.github.io/wix-style-react/?selectedKind=Core&selectedStory=Input&full=0&down=0&left=1&panelRight=0)
-* [dropdownLayoutDriver](https://wix.github.io/wix-style-react/?selectedKind=Core&selectedStory=DropdownLayout&full=0&down=0&left=1&panelRight=0)
-* [tagDriver](https://wix.github.io/wix-style-react/?selectedKind=Core&selectedStory=Tag&full=0&down=0&left=1&panelRight=0) using the `getTagDriverByTagId(id)` function
+* [inputDriver](https://wix-wix-style-react.surge.sh/?selectedKind=Core&selectedStory=Input&full=0&down=0&left=1&panelRight=0)
+* [dropdownLayoutDriver](https://wix-wix-style-react.surge.sh/?selectedKind=Core&selectedStory=DropdownLayout&full=0&down=0&left=1&panelRight=0)
+* [tagDriver](https://wix-wix-style-react.surge.sh/?selectedKind=Core&selectedStory=Tag&full=0&down=0&left=1&panelRight=0) using the `getTagDriverByTagId(id)` function
 
 
 ### Enzyme / ReactTestUtils

--- a/src/Page/README.md
+++ b/src/Page/README.md
@@ -34,7 +34,7 @@ flex-flow: column;
 min-height: 0;
 ```
 
-A live example is available [here](https://wix.github.io/wix-style-react/?selectedKind=2.%20Layout&selectedStory=2.6%20%2B%20Page%20Example).
+A live example is available [here](https://wix-wix-style-react.surge.sh/?selectedKind=2.%20Layout&selectedStory=2.6%20%2B%20Page%20Example).
 
 ## Gradient
 

--- a/src/Search/README.TESTKIT.md
+++ b/src/Search/README.TESTKIT.md
@@ -2,7 +2,7 @@
 
 ## Enzyme/ReactTestUtils TestKit API
 
-Search testkit is identical to [InputWithOptions](https://wix.github.io/wix-style-react/?selectedKind=Core&selectedStory=InputWithOptions&full=0&down=0&left=1&panelRight=0) testkit
+Search testkit is identical to [InputWithOptions](https://wix-wix-style-react.surge.sh/?selectedKind=Core&selectedStory=InputWithOptions&full=0&down=0&left=1&panelRight=0) testkit
 
 ## Protractor TestKit API
 

--- a/src/TPA/TextLink/TextLink.e2e.js
+++ b/src/TPA/TextLink/TextLink.e2e.js
@@ -4,7 +4,7 @@
 // describe('TPA TextLink', () => {
 //   const storyUrl = getStoryUrl('TPA', 'TextLink');
 //   const linkText = 'Click me';
-//   const expectedUrlAfterClick = 'https://wix.github.io/wix-style-react/?selectedKind=Introduction&selectedStory=Getting%20started&full=0&down=0&left=1&panelRight=0';
+//   const expectedUrlAfterClick = 'https://wix-wix-style-react.surge.sh/?selectedKind=Introduction&selectedStory=Getting%20started&full=0&down=0&left=1&panelRight=0';
 
 //   eyes.it('should nav to new address after click', () => {
 //     const dataHook = 'story-text-link';

--- a/stories/TPA/TextLink/CustomExample.js
+++ b/stories/TPA/TextLink/CustomExample.js
@@ -13,7 +13,7 @@ function Example() {
   return (
     <div>
       <div className="ltr" style={style}>
-        <TextLink link="https://wix.github.io/wix-style-react/?selectedKind=Introduction&selectedStory=Getting%20started&full=0&down=0&left=1&panelRight=0" target="_blank" className={styles.someCustomClass}>Click me</TextLink>
+        <TextLink link="https://wix-wix-style-react.surge.sh/?selectedKind=Introduction&selectedStory=Getting%20started&full=0&down=0&left=1&panelRight=0" target="_blank" className={styles.someCustomClass}>Click me</TextLink>
       </div>
     </div>
   );

--- a/stories/TPA/TextLink/Example.js
+++ b/stories/TPA/TextLink/Example.js
@@ -12,7 +12,7 @@ function Example() {
   return (
     <div>
       <div className="ltr" style={style}>
-        <TextLink link="https://wix.github.io/wix-style-react/?selectedKind=Introduction&selectedStory=Getting%20started&full=0&down=0&left=1&panelRight=0" data-hook="story-text-link">Click me</TextLink>
+        <TextLink link="https://wix-wix-style-react.surge.sh/?selectedKind=Introduction&selectedStory=Getting%20started&full=0&down=0&left=1&panelRight=0" data-hook="story-text-link">Click me</TextLink>
       </div>
     </div>
   );


### PR DESCRIPTION
### What changed

Deprecation of `gh-pages-auto-release`

### Why it changed

Because it's deprecated.

---

- [ ] Change is tested
- [ ] Change is documented
- [ ] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
