### PR TITLE
RTE link without protocol leads to relative path

### DIFF
--- a/src/RichTextArea/README.md
+++ b/src/RichTextArea/README.md
@@ -5,7 +5,7 @@
 
 | propName | propType | defaultValue | isRequired | description |
 |----------|----------|--------------|------------|-------------|
-| absoluteLinks | bool | false | - | Is the rich text area automatically transform relative links to absolute after user insert |
+| absoluteLinks | bool | false | - | Is the rich text area automatically transforming relative links to absolute after user insert |
 | disabled | bool | false | - | Is the rich text area disabled |
 | error  | bool | false | - | Is input value erroneous |
 | errorMessage | string | - | - | The error message to display when hovering the error icon, if not given or empty there will be no tooltip |

--- a/src/RichTextArea/README.md
+++ b/src/RichTextArea/README.md
@@ -5,6 +5,7 @@
 
 | propName | propType | defaultValue | isRequired | description |
 |----------|----------|--------------|------------|-------------|
+| absoluteLinks | bool | false | - | Is the rich text area automatically transform relative links to absolute after user insert |
 | disabled | bool | false | - | Is the rich text area disabled |
 | error  | bool | false | - | Is input value erroneous |
 | errorMessage | string | - | - | The error message to display when hovering the error icon, if not given or empty there will be no tooltip |

--- a/src/RichTextArea/RichTextArea.e2e.js
+++ b/src/RichTextArea/RichTextArea.e2e.js
@@ -107,6 +107,31 @@ describe('RichTextArea', () => {
       expect(await richTextAreaTestkit.getText()).toBe('sometext and wix');
       expect(await richTextAreaTestkit.isLinkAdded('http://www.wix.com')).toBeTruthy();
     });
+
+    it('should insert link and it should become absolute if absoluteLinks props true', async () => {
+      await autoExampleDriver.setProps({absoluteLinks: true});
+      await focusEditor();
+      await richTextAreaTestkit.clickButtonByType('link');
+      await richTextAreaTestkit.isLinkDialogVisible();
+      await richTextAreaTestkit.enterLinkUrl('www.wix.com');
+      await richTextAreaTestkit.enterLinkText('WixSite');
+      await richTextAreaTestkit.insertLink();
+      expect(await richTextAreaTestkit.getText()).toBe('WixSite');
+      expect(await richTextAreaTestkit.isLinkAdded('//www.wix.com')).toBeTruthy();
+    });
+
+    it('should insert link and it should not become absolute if absoluteLinks props false', async () => {
+      await autoExampleDriver.setProps({absoluteLinks: false});
+      await focusEditor();
+      await richTextAreaTestkit.clickButtonByType('link');
+      await richTextAreaTestkit.isLinkDialogVisible();
+      await richTextAreaTestkit.enterLinkUrl('www.wix.com');
+      await richTextAreaTestkit.enterLinkText('WixSite');
+      await richTextAreaTestkit.insertLink();
+      expect(await richTextAreaTestkit.getText()).toBe('WixSite');
+      expect(await richTextAreaTestkit.isLinkAdded('//www.wix.com')).toBeFalsy();
+      expect(await richTextAreaTestkit.isLinkAdded('www.wix.com')).toBeTruthy();
+    });
   });
 
 

--- a/src/RichTextArea/RichTextArea.js
+++ b/src/RichTextArea/RichTextArea.js
@@ -20,7 +20,7 @@ const defaultBlock = {
   key: 'defaultBlock'
 };
 
-const makeHrefAbsolute = href => href.indexOf('://') === -1 ? `//${href}` : href;
+const makeHrefAbsolute = href => /^(https?:)?\/\//.test(href) ? href : `//${href}`;
 
 class RichTextArea extends WixComponent {
   static propTypes = {
@@ -39,6 +39,7 @@ class RichTextArea extends WixComponent {
   }
 
   static defaultProps = {
+    absoluteLinks: false,
     errorMessage: '',
     value: '<p></p>'
   }

--- a/src/RichTextArea/RichTextArea.js
+++ b/src/RichTextArea/RichTextArea.js
@@ -20,8 +20,11 @@ const defaultBlock = {
   key: 'defaultBlock'
 };
 
+const makeHrefAbsolute = href => href.indexOf('://') === -1 ? `//${href}` : href;
+
 class RichTextArea extends WixComponent {
   static propTypes = {
+    absoluteLinks: PropTypes.bool,
     buttons: PropTypes.arrayOf(PropTypes.string), // TODO: use PropTypes.oneOf(),
     dataHook: PropTypes.string,
     disabled: PropTypes.bool,
@@ -267,6 +270,10 @@ class RichTextArea extends WixComponent {
   handleLinkButtonClick = ({href, text} = {}) => {
     const {editorState} = this.state;
     const transform = editorState.transform();
+    const decoratedHref = this.props.absoluteLinks
+      ? makeHrefAbsolute(href)
+      : href;
+
     if (this.hasLink()) {
       transform
         .unwrapInline('link');
@@ -274,12 +281,12 @@ class RichTextArea extends WixComponent {
       transform
         .wrapInline({
           type: 'link',
-          data: {href}
+          data: {href: decoratedHref}
         })
         .focus()
         .collapseToEnd()
     } else {
-      const linkContent = text || href;
+      const linkContent = text || decoratedHref;
       const startPos = editorState.anchorOffset;
       transform
         .insertText(linkContent)
@@ -291,7 +298,7 @@ class RichTextArea extends WixComponent {
         })
         .wrapInline({
           type: 'link',
-          data: {href}
+          data: {href: decoratedHref}
         })
         .focus()
         .collapseToEnd();

--- a/src/RichTextArea/RichTextArea.js
+++ b/src/RichTextArea/RichTextArea.js
@@ -21,11 +21,11 @@ const defaultBlock = {
 };
 
 /*
-  here we are checking is link relative(if it contain 'https' or http or '//')
-  and if it not relative, then we add '//' at the beginning of it,
-  to make link absolute(instead of relative)
+  here we are checking is link absolute(if it contain 'https' or http or '//')
+  and if it not absolute, then we add '//' at the beginning of it,
+  to make link absolute
 */
-const makeHrefAbsolute = href => /^(https?:)?\/\//.test(href) ? href : `//${href}`;
+export const makeHrefAbsolute = href => /^(https?:)?\/\//.test(href) ? href : `//${href}`;
 
 class RichTextArea extends WixComponent {
   static propTypes = {

--- a/src/RichTextArea/RichTextArea.js
+++ b/src/RichTextArea/RichTextArea.js
@@ -20,6 +20,11 @@ const defaultBlock = {
   key: 'defaultBlock'
 };
 
+/*
+  here we are checking is link relative(if it contain 'https' or http or '//')
+  and if it not relative, then we add '//' at the beginning of it,
+  to make link absolute(instead of relative)
+*/
 const makeHrefAbsolute = href => /^(https?:)?\/\//.test(href) ? href : `//${href}`;
 
 class RichTextArea extends WixComponent {

--- a/src/RichTextArea/RichTextArea.spec.js
+++ b/src/RichTextArea/RichTextArea.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import {createDriverFactory} from '../test-common';
 import richTextAreaDriverFactory from './RichTextArea.driver';
-import RichTextArea from './RichTextArea';
+import RichTextArea, {makeHrefAbsolute} from './RichTextArea';
 
 const mockGetSelection = () => {
   const original = window.getSelection;
@@ -19,6 +19,23 @@ describe('RichTextArea', () => {
 
   afterEach(() => {
     window.getSelection.restore();
+  });
+
+  describe('makeHrefAbsolute method', () => {
+    it('should do nothing', () => {
+      expect(makeHrefAbsolute('http://www.wix.com')).toBe('http://www.wix.com');
+      expect(makeHrefAbsolute('https://www.wix.com')).toBe('https://www.wix.com');
+      expect(makeHrefAbsolute('https://www.wix.com')).toBe('https://www.wix.com');
+      expect(makeHrefAbsolute('//www.wix.com')).toBe('//www.wix.com');
+      expect(makeHrefAbsolute('//wix.com')).toBe('//wix.com');
+    });
+
+    it('should make href absolute', () => {
+      expect(makeHrefAbsolute('www.wix.com')).toBe('//www.wix.com');
+      expect(makeHrefAbsolute('wix.com')).toBe('//wix.com');
+      expect(makeHrefAbsolute('x')).toBe('//x');
+      expect(makeHrefAbsolute('')).toBe('//');
+    });
   });
 
   it('should render value as text', () => {

--- a/stories/RichTextArea/RichTextArea.story.js
+++ b/stories/RichTextArea/RichTextArea.story.js
@@ -12,6 +12,7 @@ export default {
   component: RichTextArea,
   componentPath: '../../src/RichTextArea',
   componentProps: setProps => ({
+    absoluteLinks: false,
     dataHook: settings.dataHook,
     onChange: value => {
       setProps({value});

--- a/stories/RichTextArea/RichTextArea.story.js
+++ b/stories/RichTextArea/RichTextArea.story.js
@@ -12,7 +12,6 @@ export default {
   component: RichTextArea,
   componentPath: '../../src/RichTextArea',
   componentProps: setProps => ({
-    absoluteLinks: false,
     dataHook: settings.dataHook,
     onChange: value => {
       setProps({value});


### PR DESCRIPTION
### What changed

- added new prop that give ability to RTE to automatically transform relative links to absolute after user insert

### Why it changed

- our customers asked for this, because most of them enter links like "wix.com" and expect to go to wix.com, but with current behivier they will go to http://somesite.com/wix.com - which is wrong for them

---

- [x] Change is tested
- [x] Change is documented
- [x] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
