### PR TITLE
<Input/> - remove the size prop

### DIFF
--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -238,7 +238,6 @@ class Input extends Component {
 Input.displayName = 'Input';
 
 Input.defaultProps = {
-  size: 'normal',
   theme: 'normal',
   errorMessage: '',
   helpMessage: '',
@@ -354,9 +353,6 @@ Input.propTypes = {
 
   /** Flip the magnify glass image so it be more suitable to rtl */
   rtl: PropTypes.bool,
-
-  /** Specifies the size of the input */
-  size: PropTypes.oneOf(['small', 'normal', 'large']),
 
   /** Component you want to show as the suffix of the input */
   suffix: PropTypes.node,

--- a/src/Input/Input.spec.js
+++ b/src/Input/Input.spec.js
@@ -515,28 +515,6 @@ describe('Input', () => {
     });
   });
 
-  describe('size attribute', () => {
-    it('should use "normal" size by default', () => {
-      const driver = createDriver(<Input/>);
-      expect(driver.isOfSize('normal')).toBeTruthy();
-    });
-
-    it('should use "normal-with-selection" size if withSelection', () => {
-      const driver = createDriver(<Input size="normal" withSelection/>);
-      expect(driver.isOfSize('normal-with-selection')).toBeTruthy();
-    });
-
-    it('should use "small" size', () => {
-      const driver = createDriver(<Input size="small"/>);
-      expect(driver.isOfSize('small')).toBeTruthy();
-    });
-
-    it('should use "large" size', () => {
-      const driver = createDriver(<Input size="large"/>);
-      expect(driver.isOfSize('large')).toBeTruthy();
-    });
-  });
-
   describe('prefix attribute', () => {
     it('should allow adding a custom prefix component', () => {
       const driver = createDriver(<Input prefix={<div className="my-button"/>}/>);


### PR DESCRIPTION
### What changed

- removed unused props

### Why it changed

- because it is unused props

---

- [x] Change is tested
- [x] Change is documented
- [ ] Build is green
- [x] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
