### PR TITLE
<Loader/> - error message margin should be 18px and not 24px like now

### DIFF
--- a/src/Loader/Loader.scss
+++ b/src/Loader/Loader.scss
@@ -45,7 +45,7 @@
   }
 
   .text {
-    margin-top: 24px;
+    margin-top: 18px;
   }
 
   &.small {


### PR DESCRIPTION
### What changed

- updated loader text margin

### Why it changed

- because of issue with info about new design

---

- [x] Change is tested
- [x] Change is documented
- [x] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
