### PR TITLE
New TooltipContainerStrategy: appendByPredicate

### DIFF
--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -65,9 +65,9 @@ class Tooltip extends WixComponent {
     appendToParent: PropTypes.bool,
 
     /**
-     * In cases when you need to append the tooltip to some ancestor which is not the direct parent, you can pass a
-     * predicate function of the form: (element: DOMElement) => Boolean, and the tooltip will be attached to the
-     * closest ancestor for which the predicate returns "true"
+     * In cases where you need to append the tooltip to some ancestor which is not the direct parent, you can pass a
+     * predicate function of the form `(element: DOMElement) => Boolean`, and the tooltip will be attached to the
+     * closest ancestor for which the predicate returns `true`
      */
     appendByPredicate: PropTypes.func,
 

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -64,6 +64,13 @@ class Tooltip extends WixComponent {
      */
     appendToParent: PropTypes.bool,
 
+    /**
+     * In cases when you need to append the tooltip to some ancestor which is not the direct parent, you can pass a
+     * predicate function of the form: (element: DOMElement) => Boolean, and the tooltip will be attached to the
+     * closest ancestor for which the predicate returns "true"
+     */
+    appendByPredicate: PropTypes.func,
+
     /** Element to attach the tooltip to  */
     appendTo: PropTypes.any,
 
@@ -135,7 +142,7 @@ class Tooltip extends WixComponent {
       hidden: true
     };
 
-    this._tooltipContainerStrategy = new TooltipContainerStrategy(props.appendTo, props.appendToParent);
+    this._tooltipContainerStrategy = new TooltipContainerStrategy(props.appendTo, props.appendToParent, props.appendByPredicate);
   }
 
   componentElements() {

--- a/src/Tooltip/TooltipContainerStrategy.js
+++ b/src/Tooltip/TooltipContainerStrategy.js
@@ -4,16 +4,19 @@ const predicates = [
   element => element === document.body
 ];
 
+const neverMatchAnyElement = () => false;
+
 export class TooltipContainerStrategy {
-  constructor(appendTo, appendToParent) {
+  constructor(appendTo, appendToParent, appendByPredicate) {
     this._ancestor = null;
     this._appendTo = appendTo;
     this._appendToParent = appendToParent;
+    this._appendByPredicate = appendByPredicate || neverMatchAnyElement;
   }
 
   _findAncestor(element) {
     while (element) {
-      if (predicates.some(pred => pred(element))) { // eslint-disable-line
+      if ([...predicates, this._appendByPredicate].some(pred => pred(element))) { // eslint-disable-line
         break;
       }
 

--- a/src/Tooltip/TooltipContainerStrategy.js
+++ b/src/Tooltip/TooltipContainerStrategy.js
@@ -1,22 +1,21 @@
-
-const predicates = [
-  element => element.getAttribute('data-class') === 'page-scrollable-content',
-  element => element === document.body
-];
-
-const neverMatchAnyElement = () => false;
-
 export class TooltipContainerStrategy {
   constructor(appendTo, appendToParent, appendByPredicate) {
+    this._predicates = [
+      element => element.getAttribute('data-class') === 'page-scrollable-content',
+      element => element === document.body
+    ];
+
     this._ancestor = null;
     this._appendTo = appendTo;
     this._appendToParent = appendToParent;
-    this._appendByPredicate = appendByPredicate || neverMatchAnyElement;
+    if (appendByPredicate) {
+      this._predicates.push(appendByPredicate);
+    }
   }
 
   _findAncestor(element) {
     while (element) {
-      if ([...predicates, this._appendByPredicate].some(pred => pred(element))) { // eslint-disable-line
+      if (this._predicates.some(pred => pred(element))) { // eslint-disable-line
         break;
       }
 

--- a/src/Tooltip/TooltipContainerStrategy.spec.js
+++ b/src/Tooltip/TooltipContainerStrategy.spec.js
@@ -26,6 +26,18 @@ describe('TooltipContainerStrategy', () => {
     expect(container).toBe(parent);
   });
 
+  it('should return matching ancestor by predicate when appendByPredicate has a value', () => {
+    const tooltipContainerStrategy = new TooltipContainerStrategy(null, null, el => el.getAttribute('some-attr') === 'some-value');
+    const ancestor = document.createElement('div');
+    ancestor.setAttribute('some-attr', 'some-value');
+    const parent = document.createElement('div');
+    ancestor.appendChild(parent);
+    const element = document.createElement('div');
+    parent.appendChild(element);
+    const container = tooltipContainerStrategy.getContainer(element);
+    expect(container).toBe(ancestor);
+  });
+
   it('should return appendTo element when provided and appendToParent is true', () => {
     const appendToElement = document.createElement('div');
     const tooltipContainerStrategy = new TooltipContainerStrategy(appendToElement, true);


### PR DESCRIPTION
### What changed

Added a new tooltip strategy: now you can pass a predicate to a prop named `appendByPredicate`, which receives an element and returns a boolean value.
The tooltip will be attached to the closest ancestor which matches the predicate.

Example:

```javascript
<div className="container">
  <div className="panel">
    <Tooltip content={...} appendByPredicate={el => el.className === 'container'}>
      <Icons.QuestionMark />
    </Tooltip>
  </div>
</div>
```

### Why it changed

The whole matter was discussed with Shlomi. If you want the long version, here it is 😅:

Real life story: I have the following element within a scrollable list. The element has a hover state and at the bottom: an icon which opens a tooltip with a clickable link:

![example](https://user-images.githubusercontent.com/6681893/40385006-eb685bbe-5e0d-11e8-8d19-69653f35c63c.png)

Default behaviour is no good, as two things happen:
1. The tooltip scrolls along with the page
2. The element loses focus

Appending to parent is no good, as the direct parent is only a part of the element and is covered by other parts of that element, which cover the tooltip as well if we append it to parent.

Just using `append` introduces new complexity: it forces me to add state, render the component "temporarily" until the ref to the correct ancestor is available, and change my tests to await the component to truly be ready (as now mounting it is not enough, I have to wait for ref).

With `appendByPredicate`, I can easily let the tooltip attach itself to the nearest matching ancestor by just passing a simple predicate.

---

- [x] Change is tested
- [x] Change is documented
- [x] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
