### PR TITLE
fix(<MultiSelectCheckbox/>) pass on inputElement prop

### DIFF
--- a/src/MultiSelectCheckbox/MultiSelectCheckbox.js
+++ b/src/MultiSelectCheckbox/MultiSelectCheckbox.js
@@ -42,7 +42,6 @@ class MultiSelectCheckbox extends InputWithOptions {
 
   inputAdditionalProps() {
     return {
-      inputElement: <Input textOverflow="ellipsis" readOnly/>,
       value: this.selectedOptionsToText()
     };
   }
@@ -103,11 +102,15 @@ MultiSelectCheckbox.propTypes = {
   onDeselect: PropTypes.func,
 
   /** delimiter between the selected options that will be displayed in the input. */
-  delimiter: PropTypes.string
+  delimiter: PropTypes.string,
+
+  /** An input element to use instead of the default one */
+  inputElement: PropTypes.element
 };
 
 MultiSelectCheckbox.defaultProps = {
   ...InputWithOptions.defaultProps,
+  inputElement: <Input textOverflow="ellipsis" readOnly/>,
   delimiter: ', ',
   selectedOptions: [],
   closeOnSelect: false

--- a/src/MultiSelectCheckbox/MultiSelectCheckbox.spec.js
+++ b/src/MultiSelectCheckbox/MultiSelectCheckbox.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
 import multiSelectCheckboxDriverFactory from './MultiSelectCheckbox.driver';
 import MultiSelectCheckbox from './MultiSelectCheckbox';
+import Input from '../Input';
 import {createDriverFactory} from '../test-common';
 import {multiSelectCheckboxTestkitFactory} from '../../testkit';
 import {multiSelectCheckboxTestkitFactory as enzymeMultiSelectCheckboxTestkitFactory} from '../../testkit/enzyme';
@@ -11,7 +12,6 @@ import {runInputWithOptionsTest} from '../InputWithOptions/InputWithOptions.spec
 runInputWithOptionsTest(multiSelectCheckboxDriverFactory);
 
 describe('multiSelectCheckbox', () => {
-
   const createDriver = createDriverFactory(multiSelectCheckboxDriverFactory);
   const options = [
     {value: 'Alabama', id: 'Alabama'},
@@ -33,27 +33,42 @@ describe('multiSelectCheckbox', () => {
     expect(inputDriver.getReadOnly()).toBeTruthy();
   });
 
+  it('should render custom input element', () => {
+    const {inputWrapper} = createDriver(
+      <MultiSelectCheckbox options={options} inputElement={<Input dataHook="custom-input"/>}/>
+    );
+    expect(inputWrapper.find('[data-hook="custom-input"]').exists()).toBeTruthy();
+  });
+
   it('should show dropdown on input click', () => {
-    const {inputDriver, dropdownLayoutDriver} = createDriver(<MultiSelectCheckbox options={options}/>);
+    const {inputDriver, dropdownLayoutDriver} = createDriver(
+      <MultiSelectCheckbox options={options}/>
+    );
     inputDriver.click();
     expect(dropdownLayoutDriver.isShown()).toBeTruthy();
   });
 
   it('should not show dropdown on input click when disabled', () => {
-    const {inputDriver, dropdownLayoutDriver} = createDriver(<MultiSelectCheckbox disabled options={options}/>);
+    const {inputDriver, dropdownLayoutDriver} = createDriver(
+      <MultiSelectCheckbox disabled options={options}/>
+    );
     inputDriver.click();
     expect(dropdownLayoutDriver.isShown()).toBeFalsy();
   });
 
   it('should close dropdown on second input click', () => {
-    const {inputDriver, dropdownLayoutDriver} = createDriver(<MultiSelectCheckbox options={options}/>);
+    const {inputDriver, dropdownLayoutDriver} = createDriver(
+      <MultiSelectCheckbox options={options}/>
+    );
     inputDriver.click();
     inputDriver.click();
     expect(dropdownLayoutDriver.isShown()).toBeFalsy();
   });
 
   it('should close dropdown on Escape', () => {
-    const {inputDriver, dropdownLayoutDriver} = createDriver(<MultiSelectCheckbox options={options}/>);
+    const {inputDriver, dropdownLayoutDriver} = createDriver(
+      <MultiSelectCheckbox options={options}/>
+    );
     inputDriver.click();
     inputDriver.focus();
     inputDriver.keyDown('Escape');
@@ -67,7 +82,9 @@ describe('multiSelectCheckbox', () => {
   ];
   OPEN_DROPDOWN_CHARS.forEach(charData => {
     it(`should show dropdown on input focus and press on ${charData.key}`, () => {
-      const {inputDriver, dropdownLayoutDriver} = createDriver(<MultiSelectCheckbox options={options}/>);
+      const {inputDriver, dropdownLayoutDriver} = createDriver(
+        <MultiSelectCheckbox options={options}/>
+      );
       inputDriver.focus();
       inputDriver.trigger('keyDown', charData);
       expect(dropdownLayoutDriver.isShown()).toBeTruthy();
@@ -75,7 +92,9 @@ describe('multiSelectCheckbox', () => {
   });
 
   it('should not lose Focus or close the list on selection with a mouse click', () => {
-    const {inputDriver, dropdownLayoutDriver} = createDriver(<MultiSelectCheckbox options={options}/>);
+    const {inputDriver, dropdownLayoutDriver} = createDriver(
+      <MultiSelectCheckbox options={options}/>
+    );
 
     inputDriver.focus();
     dropdownLayoutDriver.clickAtOption(0);
@@ -84,43 +103,63 @@ describe('multiSelectCheckbox', () => {
 
   it('should display a selectedOptions separetaed by default delimiter', () => {
     const selectedOptions = [options[0].id, options[1].id];
-    const {inputDriver} = createDriver(<MultiSelectCheckbox options={options} selectedOptions={selectedOptions}/>);
+    const {inputDriver} = createDriver(
+      <MultiSelectCheckbox options={options} selectedOptions={selectedOptions}/>
+    );
     expect(inputDriver.getValue()).toBe(`${options[0].id}, ${options[1].id}`);
   });
 
   it('should display a selectedOptions separetaed by custom delimiter', () => {
     const selectedOptions = [options[0].id, options[1].id];
     const delimiter = ';';
-    const {inputDriver} = createDriver(<MultiSelectCheckbox options={options} selectedOptions={selectedOptions} delimiter={delimiter}/>);
+    const {inputDriver} = createDriver(
+      <MultiSelectCheckbox
+        options={options}
+        selectedOptions={selectedOptions}
+        delimiter={delimiter}
+        />
+    );
     expect(inputDriver.getValue()).toBe(`${options[0].id};${options[1].id}`);
   });
 
   it('should not display the selectedOptions that not included in options', () => {
     const selectedOptions = [options[0].id, 'NOT_LEGAL_ID', options[1].id];
-    const {inputDriver} = createDriver(<MultiSelectCheckbox options={options} selectedOptions={selectedOptions}/>);
+    const {inputDriver} = createDriver(
+      <MultiSelectCheckbox options={options} selectedOptions={selectedOptions}/>
+    );
     expect(inputDriver.getValue()).toBe(`${options[0].id}, ${options[1].id}`);
   });
 
   it('should use provided valueParser that will enable handling option with a component in value', () => {
     const specialOption = options.find(x => typeof x.value !== 'string');
     const selectedOptions = [specialOption.id];
-    const valueParser = option => typeof option.value === 'string' ? option.value : option.label;
+    const valueParser = option => (typeof option.value === 'string' ? option.value : option.label);
 
-    const {driver} = createDriver(<MultiSelectCheckbox valueParser={valueParser} options={options} selectedOptions={selectedOptions}/>);
+    const {driver} = createDriver(
+      <MultiSelectCheckbox
+        valueParser={valueParser}
+        options={options}
+        selectedOptions={selectedOptions}
+        />
+    );
     expect(driver.getLabelAt(0)).toBe(specialOption.label);
   });
 
   it('should contain specific selected values', () => {
     const selectedOptions = [options[0].id, options[1].id];
 
-    const {driver} = createDriver(<MultiSelectCheckbox options={options} selectedOptions={selectedOptions}/>);
+    const {driver} = createDriver(
+      <MultiSelectCheckbox options={options} selectedOptions={selectedOptions}/>
+    );
     expect(driver.getNumOfLabels()).toBe(selectedOptions.length);
     expect(driver.getLabelAt(0)).toBe(options[0].id);
     expect(driver.getLabelAt(1)).toBe(options[1].id);
   });
 
   it('should not close dropdown after clicking on an option', () => {
-    const {inputDriver, dropdownLayoutDriver} = createDriver(<MultiSelectCheckbox options={options}/>);
+    const {inputDriver, dropdownLayoutDriver} = createDriver(
+      <MultiSelectCheckbox options={options}/>
+    );
     inputDriver.click();
     dropdownLayoutDriver.clickAtOption(0);
     expect(dropdownLayoutDriver.isShown()).toBeTruthy();
@@ -128,7 +167,9 @@ describe('multiSelectCheckbox', () => {
 
   it('should call onSelect when selecting unselected option', () => {
     const onSelect = jest.fn();
-    const {dropdownLayoutDriver} = createDriver(<MultiSelectCheckbox options={options} onSelect={onSelect}/>);
+    const {dropdownLayoutDriver} = createDriver(
+      <MultiSelectCheckbox options={options} onSelect={onSelect}/>
+    );
     dropdownLayoutDriver.clickAtOption(0);
     expect(onSelect).toHaveBeenCalledWith(options[0].value);
   });
@@ -136,7 +177,9 @@ describe('multiSelectCheckbox', () => {
   it('should not call onSelect when selecting a disabled option', () => {
     const onSelect = jest.fn();
     const indexOfDisabled = options.findIndex(opt => opt.disabled);
-    const {dropdownLayoutDriver} = createDriver(<MultiSelectCheckbox options={options} onSelect={onSelect}/>);
+    const {dropdownLayoutDriver} = createDriver(
+      <MultiSelectCheckbox options={options} onSelect={onSelect}/>
+    );
     dropdownLayoutDriver.clickAtOption(indexOfDisabled);
     expect(onSelect).not.toHaveBeenCalled();
   });
@@ -144,7 +187,13 @@ describe('multiSelectCheckbox', () => {
   it('should call onDeselect when selecting selected option', () => {
     const selectedOptions = [options[0].id, options[1].id];
     const onDeselect = jest.fn();
-    const {dropdownLayoutDriver} = createDriver(<MultiSelectCheckbox options={options} selectedOptions={selectedOptions} onDeselect={onDeselect}/>);
+    const {dropdownLayoutDriver} = createDriver(
+      <MultiSelectCheckbox
+        options={options}
+        selectedOptions={selectedOptions}
+        onDeselect={onDeselect}
+        />
+    );
     dropdownLayoutDriver.clickAtOption(0);
     expect(onDeselect).toHaveBeenCalledWith(options[0].id);
   });
@@ -154,7 +203,17 @@ describe('multiSelectCheckbox', () => {
       const div = document.createElement('div');
       const dataHook = 'myDataHook';
       const selectedOptions = [options[0].id];
-      const wrapper = div.appendChild(ReactTestUtils.renderIntoDocument(<div><MultiSelectCheckbox dataHook={dataHook} selectedOptions={selectedOptions} options={options}/></div>));
+      const wrapper = div.appendChild(
+        ReactTestUtils.renderIntoDocument(
+          <div>
+            <MultiSelectCheckbox
+              dataHook={dataHook}
+              selectedOptions={selectedOptions}
+              options={options}
+              />
+          </div>
+        )
+      );
       const multiSelectCheckboxTestkit = multiSelectCheckboxTestkitFactory({wrapper, dataHook});
       expect(multiSelectCheckboxTestkit.driver.exists()).toBeTruthy();
       expect(multiSelectCheckboxTestkit.inputDriver.exists()).toBeTruthy();
@@ -166,8 +225,17 @@ describe('multiSelectCheckbox', () => {
     it('should exist', () => {
       const dataHook = 'myDataHook';
       const selectedOptions = [options[0].id];
-      const wrapper = mount(<MultiSelectCheckbox dataHook={dataHook} selectedOptions={selectedOptions} options={options}/>);
-      const multiSelectCheckboxTestkit = enzymeMultiSelectCheckboxTestkitFactory({wrapper, dataHook});
+      const wrapper = mount(
+        <MultiSelectCheckbox
+          dataHook={dataHook}
+          selectedOptions={selectedOptions}
+          options={options}
+          />
+      );
+      const multiSelectCheckboxTestkit = enzymeMultiSelectCheckboxTestkitFactory({
+        wrapper,
+        dataHook
+      });
       expect(multiSelectCheckboxTestkit.driver.exists()).toBeTruthy();
       expect(multiSelectCheckboxTestkit.inputDriver.exists()).toBeTruthy();
       expect(multiSelectCheckboxTestkit.dropdownLayoutDriver.exists()).toBeTruthy();


### PR DESCRIPTION
### What changed

When inputElement prop is pass, pass it on to inputWithOptions
...

### Why it changed

Because that prop is exposed on the api and not working otherwise.
...

---

- [ ] Change is tested
- [ ] Change is documented
- [ ] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
