### PR TITLE
<Search /> - added `loading` prop

### DIFF
--- a/src/InputWithOptions/InputWithOptions.js
+++ b/src/InputWithOptions/InputWithOptions.js
@@ -123,7 +123,7 @@ class InputWithOptions extends WixComponent {
     return (
       <div>
         {dropDirectionUp ? this._renderDropdownLayout() : null}
-        <div onKeyDown={this._onKeyDown} className={this.inputClasses()}>
+        <div onKeyDown={this._onKeyDown} data-input-parent className={this.inputClasses()}>
           {this.renderInput()}
         </div>
         {!dropDirectionUp ? this._renderDropdownLayout() : null}

--- a/src/Search/Search.driver.js
+++ b/src/Search/Search.driver.js
@@ -1,1 +1,22 @@
-export {default} from '../InputWithOptions/InputWithOptions.driver';
+import inputWithOptionsDriverFactory from '../InputWithOptions/InputWithOptions.driver';
+
+const EXPANDABLE_CLASS = 'expandableStyles';
+const EXPANDABLE_COLLAPSED = 'collapsed';
+const EXPANDABLE_EXPANDED = 'expanded';
+
+const searchDriverFactory = args => {
+  const inputWithOptionsDriver = inputWithOptionsDriverFactory({
+    ...args,
+    element: args.element && args.element.childNodes[0]
+  });
+
+  const {element} = args;
+
+  return {
+    ...inputWithOptionsDriver,
+    isExpandable: () => element.className.includes(EXPANDABLE_CLASS),
+    isCollapsed: () => element.className.includes(EXPANDABLE_COLLAPSED) && !element.className.includes(EXPANDABLE_EXPANDED)
+  };
+};
+
+export default searchDriverFactory;

--- a/src/Search/Search.driver.js
+++ b/src/Search/Search.driver.js
@@ -15,7 +15,8 @@ const searchDriverFactory = args => {
   return {
     ...inputWithOptionsDriver,
     isExpandable: () => element.className.includes(EXPANDABLE_CLASS),
-    isCollapsed: () => element.className.includes(EXPANDABLE_COLLAPSED) && !element.className.includes(EXPANDABLE_EXPANDED)
+    isCollapsed: () => element.className.includes(EXPANDABLE_COLLAPSED) && !element.className.includes(EXPANDABLE_EXPANDED),
+    hasLoadingSuffix: () => !!element.querySelector('.loaderContainer')
   };
 };
 

--- a/src/Search/Search.js
+++ b/src/Search/Search.js
@@ -34,11 +34,11 @@ export default class Search extends WixComponent {
   constructor(props) {
     super(props);
 
-    const initalValue = (!this._isControlled && props.defaultValue) || '';
+    const initialValue = (!this._isControlled && props.defaultValue) || '';
 
     this.state = {
-      inputValue: initalValue,
-      collapsed: props.expandable && initalValue === ''
+      inputValue: initialValue,
+      collapsed: props.expandable && initialValue === ''
     };
   }
 
@@ -133,7 +133,7 @@ export default class Search extends WixComponent {
     }
   };
 
-  _renderDefaultLoading = () => (<div className={styles.loaderContainer}><Loader size={'small'}/></div>);
+  _renderDefaultLoading = () => (<Loader size={'small'}/>);
 
   render() {
     const wrapperClasses = classNames({
@@ -142,13 +142,15 @@ export default class Search extends WixComponent {
       [styles.expanded]: !this.state.collapsed && this.props.expandable
     });
 
+    const loadingRenderFn = this.props.renderLoading || this._renderDefaultLoading;
+
     return (
       <div className={wrapperClasses} onClick={this._onWrapperClick} onMouseDown={this._onWrapperMouseDown}>
         <InputWithOptions
           {...this.props}
           ref="searchInput"
           roundInput
-          suffix={this.props.loading ? (this.props.renderLoading || this._renderDefaultLoading)() : null}
+          suffix={this.props.loading ? (<div className={styles.loaderContainer}>{loadingRenderFn()}</div>) : null}
           prefix={<div className={styles.leftIcon}><SearchIcon/></div>}
           menuArrow={false}
           clearButton

--- a/src/Search/Search.js
+++ b/src/Search/Search.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 import InputWithOptions from '../InputWithOptions';
 import SearchIcon from 'wix-ui-icons-common/Search';
@@ -17,6 +18,7 @@ export default class Search extends WixComponent {
   static propTypes = {
     ...InputWithOptions.propTypes,
     placeholder: PropTypes.string,
+    expandable: PropTypes.bool,
     loading: PropTypes.bool,
     renderLoading: PropTypes.func
   };
@@ -24,6 +26,7 @@ export default class Search extends WixComponent {
   static defaultProps = {
     ...InputWithOptions.defaultProps,
     placeholder: 'Search',
+    expandable: false,
     loading: false,
     renderLoading: null
   };
@@ -31,8 +34,11 @@ export default class Search extends WixComponent {
   constructor(props) {
     super(props);
 
+    const initalValue = (!this._isControlled && props.defaultValue) || '';
+
     this.state = {
-      inputValue: (!this._isControlled && props.defaultValue) || ''
+      inputValue: initalValue,
+      collapsed: props.expandable && initalValue === ''
     };
   }
 
@@ -64,23 +70,97 @@ export default class Search extends WixComponent {
     }
   };
 
+  _onClear = () => {
+    const {
+      onClear
+    } = this.props;
+
+    if (!this.state.collapsed && this.props.expandable) {
+      this.setState({
+        collapsed: true
+      });
+    }
+
+    onClear && onClear();
+  };
+
+  _currentValue = () => {
+    let value;
+
+    if (this._isControlled) {
+      value = this.props.value;
+    } else {
+      value = this.state.inputValue;
+    }
+
+    return value;
+  };
+
+  _onBlur = () => {
+    const {
+      onBlur
+    } = this.props;
+
+    if (!this.state.collapsed && this.props.expandable) {
+      const value = this._currentValue();
+
+      if (value === '') {
+        this.setState({
+          collapsed: true
+        });
+      }
+    }
+
+    onBlur && onBlur();
+  };
+
+  _onWrapperClick = () => {
+    if (this.props.expandable && this.state.collapsed) {
+      this.refs.searchInput.input.focus();
+      this.setState({collapsed: false});
+    }
+  };
+
+  _onWrapperMouseDown = e => {
+    // We need to capture mouse down and prevent it's event if the input
+    // is already open
+    if (this.props.expandable && !this.state.collapsed) {
+      const value = this._currentValue();
+
+      if (value === '') {
+        e.preventDefault();
+      }
+    }
+  };
+
   _renderDefaultLoading = () => (<div className={styles.loaderContainer}><Loader size={'small'}/></div>);
 
   render() {
+    const wrapperClasses = classNames({
+      [styles.expandableStyles]: this.props.expandable,
+      [styles.collapsed]: this.state.collapsed && this.props.expandable,
+      [styles.expanded]: !this.state.collapsed && this.props.expandable
+    });
+
     return (
-      <InputWithOptions
-        {...this.props}
-        roundInput
-        suffix={this.props.loading ? (this.props.renderLoading || this._renderDefaultLoading)() : null}
-        prefix={<div className={styles.leftIcon}><SearchIcon/></div>}
-        menuArrow={false}
-        clearButton
-        closeOnSelect
-        showOptionsIfEmptyInput={false}
-        options={this._filteredOptions}
-        onChange={this._onChange}
-        highlight
-        />
+      <div className={wrapperClasses} onClick={this._onWrapperClick} onMouseDown={this._onWrapperMouseDown}>
+        <InputWithOptions
+          {...this.props}
+          ref="searchInput"
+          roundInput
+          suffix={this.props.loading ? (this.props.renderLoading || this._renderDefaultLoading)() : null}
+          prefix={<div className={styles.leftIcon}><SearchIcon/></div>}
+          menuArrow={false}
+          clearButton
+          closeOnSelect
+          showOptionsIfEmptyInput={false}
+          options={this._filteredOptions}
+          onClear={this._onClear}
+          onChange={this._onChange}
+          onBlur={this._onBlur}
+          highlight
+          />
+      </div>
     );
   }
 }

--- a/src/Search/Search.js
+++ b/src/Search/Search.js
@@ -6,7 +6,7 @@ import SearchIcon from 'wix-ui-icons-common/Search';
 import WixComponent from '../BaseComponents/WixComponent';
 
 import styles from './Search.scss';
-import Loader from "../Loader/Loader";
+import Loader from '../Loader/Loader';
 
 /**
  * Search component with suggestions based on input value listed in dropdown

--- a/src/Search/Search.js
+++ b/src/Search/Search.js
@@ -6,6 +6,7 @@ import SearchIcon from 'wix-ui-icons-common/Search';
 import WixComponent from '../BaseComponents/WixComponent';
 
 import styles from './Search.scss';
+import Loader from "../Loader/Loader";
 
 /**
  * Search component with suggestions based on input value listed in dropdown
@@ -15,12 +16,16 @@ export default class Search extends WixComponent {
 
   static propTypes = {
     ...InputWithOptions.propTypes,
-    placeholder: PropTypes.string
+    placeholder: PropTypes.string,
+    loading: PropTypes.bool,
+    renderLoading: PropTypes.func
   };
 
   static defaultProps = {
     ...InputWithOptions.defaultProps,
-    placeholder: 'Search'
+    placeholder: 'Search',
+    loading: false,
+    renderLoading: null
   };
 
   constructor(props) {
@@ -59,11 +64,14 @@ export default class Search extends WixComponent {
     }
   };
 
+  _renderDefaultLoading = () => (<div className={styles.loaderContainer}><Loader size={'small'}/></div>);
+
   render() {
     return (
       <InputWithOptions
         {...this.props}
         roundInput
+        suffix={this.props.loading ? (this.props.renderLoading || this._renderDefaultLoading)() : null}
         prefix={<div className={styles.leftIcon}><SearchIcon/></div>}
         menuArrow={false}
         clearButton

--- a/src/Search/Search.scss
+++ b/src/Search/Search.scss
@@ -10,3 +10,9 @@
         height: 22px;
     }
 }
+
+.loaderContainer {
+  margin-right: 6px;
+  margin-left: 6px;
+  display: flex;
+}

--- a/src/Search/Search.scss
+++ b/src/Search/Search.scss
@@ -1,14 +1,49 @@
 @import '../common';
 
-.leftIcon {
-    margin: 0 4px 0 3px;
-    color: $B10;
+$iconSize: 22px;
 
-    & > svg {
-        display: block;
-        width: 22px;
-        height: 22px;
+.leftIcon {
+  margin: 0 5px 0 5px;
+  color: $B10;
+
+  & > svg {
+    display: block;
+    width: $iconSize;
+    height: $iconSize;
+  }
+}
+
+.expandableStyles {
+  > div {
+    > div {
+      > div {
+        transition: width .3s;
+      }
     }
+  }
+}
+
+.collapsed {
+  cursor: pointer;
+
+  [data-input-parent] {
+    > div:nth-of-type(1) {
+      border-color: transparent;
+      width: 14 + $iconSize;
+
+      input {
+        min-width: 0 !important;
+      }
+    }
+  }
+}
+
+.expanded {
+  [data-input-parent] {
+    > div:nth-of-type(1) {
+      width: 100%;
+    }
+  }
 }
 
 .loaderContainer {

--- a/src/Search/Search.spec.js
+++ b/src/Search/Search.spec.js
@@ -13,7 +13,8 @@ import {runInputWithOptionsTest} from '../InputWithOptions/InputWithOptions.spec
 import {makeControlled} from '../../test/utils';
 import {mount} from 'enzyme';
 
-runInputWithOptionsTest(searchDriverFactory);
+// We use the parent component because the Search component has a wrapper around <InputWithOption />
+runInputWithOptionsTest(args => searchDriverFactory({...args, element: args.element ? args.element.parentElement : args.element}));
 
 const options = [
   'The quick',
@@ -192,6 +193,78 @@ describe('Search', () => {
 
       driver.inputDriver.focus();
       expect(driver.dropdownLayoutDriver.optionsLength()).toBe(1);
+    });
+  });
+
+  describe('Expandable', () => {
+    it('should start as collapsed element by default when expndable=true', () => {
+      const driver = createDriver(
+        <Search options={options} expandable/>
+      );
+
+      expect(driver.isExpandable()).toBeTruthy();
+      expect(driver.isCollapsed()).toBeTruthy();
+    });
+
+    it('should extend the search input when clicked', () => {
+      const driver = createDriver(
+        <Search options={options} expandable/>
+      );
+
+      expect(driver.isCollapsed()).toBeTruthy();
+      driver.inputDriver.click();
+      expect(driver.isCollapsed()).toBeFalsy();
+    });
+
+    it('should be focused on the input after expanding the search component', () => {
+      const driver = createDriver(
+        <Search options={options} expandable/>
+      );
+
+      expect(driver.inputDriver.isFocus()).toBeFalsy();
+      driver.inputDriver.click();
+      expect(driver.inputDriver.isFocus()).toBeTruthy();
+    });
+
+    it('should not collapse the input if the input has no value and blurred', () => {
+      const driver = createDriver(
+        <Search options={options} expandable/>
+      );
+
+      driver.inputDriver.click();
+      driver.inputDriver.enterText('wix');
+      driver.inputDriver.blur();
+      expect(driver.isCollapsed()).toBeFalsy();
+    });
+
+    it('should collapse the input if the input has no value and blurred', () => {
+      const driver = createDriver(
+        <Search options={options} expandable/>
+      );
+
+      driver.inputDriver.click();
+      driver.inputDriver.blur();
+      expect(driver.isCollapsed()).toBeTruthy();
+    });
+
+    it('should have non-collapsed input when expandaple=true and the input has initial value', () => {
+      const driver = createDriver(
+        <Search options={options} expandable defaultValue={'Test'}/>
+      );
+
+      expect(driver.isExpandable()).toBeTruthy();
+      expect(driver.isCollapsed()).toBeFalsy();
+    });
+
+    it('should not be collapsed by default', () => {
+      const driver = createDriver(
+        <Search options={options}/>
+      );
+
+      expect(driver.isExpandable()).toBeFalsy();
+      expect(driver.isCollapsed()).toBeFalsy();
+      driver.inputDriver.click();
+      expect(driver.isCollapsed()).toBeFalsy();
     });
   });
 

--- a/src/Search/Search.spec.js
+++ b/src/Search/Search.spec.js
@@ -269,11 +269,26 @@ describe('Search', () => {
   });
 
   describe('With Loader', () => {
-    it('should render without loader as deafult', () => {});
+    it('should render without loader as deafult', () => {
+      const driver = createDriver(<Search options={options}/>);
 
-    it('should render with default loader when loading=true', () => {});
+      expect(driver.hasLoadingSuffix()).toBeFalsy();
+    });
 
-    it('should allow to use custom loader when loading=true', () => {});
+    it('should render with default loader when loading=true', () => {
+      const driver = createDriver(<Search loading options={options}/>);
+
+      expect(driver.hasLoadingSuffix()).toBeTruthy();
+    });
+
+    it('should allow to use custom loader when loading=true', () => {
+      const renderSpy = jest.fn();
+      renderSpy.mockReturnValue(<div className={'custom-loader'}/>);
+      const driver = createDriver(<Search loading renderLoading={renderSpy} options={options}/>);
+
+      expect(driver.hasLoadingSuffix()).toBeTruthy();
+      expect(renderSpy.mock.calls.length).toBe(1);
+    });
   });
 });
 

--- a/src/Search/Search.spec.js
+++ b/src/Search/Search.spec.js
@@ -194,6 +194,14 @@ describe('Search', () => {
       expect(driver.dropdownLayoutDriver.optionsLength()).toBe(1);
     });
   });
+
+  describe('With Loader', () => {
+    it('should render without loader as deafult', () => {});
+
+    it('should render with default loader when loading=true', () => {});
+
+    it('should allow to use custom loader when loading=true', () => {});
+  });
 });
 
 describe('Testkits', () => {


### PR DESCRIPTION
### What changed

Added `loading` prop with a default of `<Loader size={'small'} />`. It also possible to override the loader using render-prop (`renderLoading={...}`).

This PR is based on this PR: https://github.com/wix-private/wsr-issues/issues/106 (because I needed the search driver implementation).

### Why it changed

https://github.com/wix-private/wsr-issues/issues/106

---

- [x] Change is tested
- [x] Change is documented
- [ ] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
