### PR TITLE
release storybook on pr even if eyes fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:e2e": "concurrently 'npm run test:e2e-only' 'node scripts/e2e-server.js' --names 'protractor,e2e-server' --success first --kill-others",
     "test:e2e-only": "NODE_ENV=production yoshi test --protractor",
     "build": "npm run lint && svg2react-icon && yoshi build && build-storybook && npm run export-components",
+    "pr-postbuild": "teamcity-surge-autorelease --dist=storybook-static",
     "storybook": "start-storybook -p 6006",
     "postpublish": "teamcity-surge-autorelease --dist=storybook-static",
     "export-components": "import-path --path src",


### PR DESCRIPTION
at the moment `pr-release` is redundant (identical to pr-postbuild)
we should consider removing it