### PR TITLE
fix <Heading /> font weight

### DIFF
--- a/src/Typography/Typography.scss
+++ b/src/Typography/Typography.scss
@@ -5,6 +5,7 @@
   font-size: $font-size;
   color: $color;
   line-height: $line-height;
+  font-weight: normal;
 }
 
 @mixin generateVariations($list) {


### PR DESCRIPTION
Looks like font-weight was forgotten behind

### What changed
<Heading /> font-weight
...

### Why it changed
Upgrading to v4 broke the header style
...

---

- [ ] Change is tested
- [ ] Change is documented
- [ ] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
