### PR TITLE
<InputWithOptions />- fix bug where delimiters did not behave like En…

### DIFF
--- a/src/InputWithOptions/InputWithOptions.js
+++ b/src/InputWithOptions/InputWithOptions.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import WixComponent from '../BaseComponents/WixComponent';
 import Input from '../Input';
 import omit from 'omit';
+import defaultTo from 'lodash/defaultTo';
 import DropdownLayout from '../DropdownLayout/DropdownLayout';
 import Highlighter from '../Highlighter/Highlighter';
 
@@ -224,14 +225,12 @@ class InputWithOptions extends WixComponent {
       this.setState({isEditing: true});
     }
     if (!this.dropdownLayout._onKeyDown(event)) {
-      switch (event.key) {
-        case 'Enter':
-        case 'Tab': {
-          this._onManuallyInput(this.state.inputValue);
-          break;
-        }
-        default:
-          this.showOptions();
+      const defaultDelimiters = ['Enter', 'Tab'];
+      const delimiters = (defaultTo(this.inputAdditionalProps(), {}).delimiters || []).concat(defaultDelimiters);
+      if (delimiters.includes(event.key)) {
+        this._onManuallyInput(this.state.inputValue);
+      } else {
+        this.showOptions();
       }
     }
   }

--- a/src/MultiSelect/MultiSelect.spec.js
+++ b/src/MultiSelect/MultiSelect.spec.js
@@ -81,20 +81,6 @@ describe('multiSelect', () => {
     expect(inputDriver.isFocus()).toBeTruthy();
   });
 
-  it('should not lose Focus or close the list on selection with comma press', () => {
-    const onSelect = jest.fn();
-    const onChange = jest.fn();
-    const {driver, inputDriver, dropdownLayoutDriver} = createDriver(
-      <MultiSelect value={options[0].value} options={options} delimiters={[',']} onSelect={onSelect} onChange={onChange}/>
-    );
-    driver.focus();
-    inputDriver.trigger('keyDown', {key: ','});
-    expect(onSelect).toBeCalledWith([{id: options[0].id, label: options[0].value}]);
-    expect(onChange).toBeCalledWith({target: {value: ''}});
-    expect(dropdownLayoutDriver.isShown()).toBeTruthy();
-    expect(inputDriver.isFocus()).toBeTruthy();
-  });
-
   it('should call onSelect on click-outside if options empty', () => {
     const onSelect = jest.fn();
     const {driver} = createDriver(<MultiSelect value={'bob'} onSelect={onSelect}/>);
@@ -119,15 +105,13 @@ describe('multiSelect', () => {
   it('should support custom delimiters', () => {
     const onSelect = jest.fn();
     const onChange = jest.fn();
-    const {driver, inputDriver, dropdownLayoutDriver} = createDriver(
+    const {driver, inputDriver} = createDriver(
       <MultiSelect value={options[0].value} options={options} delimiters={[';']} onSelect={onSelect} onChange={onChange}/>
     );
     driver.focus();
     inputDriver.trigger('keyDown', {key: ';'});
     expect(onSelect).toBeCalledWith([{id: options[0].id, label: options[0].value}]);
     expect(onChange).toBeCalledWith({target: {value: ''}});
-    expect(dropdownLayoutDriver.isShown()).toBeTruthy();
-    expect(inputDriver.isFocus()).toBeTruthy();
   });
 
   it('should display a placeholder if there are no tags', () => {


### PR DESCRIPTION
<InputWithOptions />- fix bug where delimiters did not behave like Enter/Tab

### What changed
Delimiters passed to InputWithOptions now trigger onManuallyInput similarly to Enter/Tab

### Why it changed
pressing a delimiter when manually entering an option would not behave the same as pressing Enter/Tab

approved by [milkyfruit]
---

- [X] Change is tested
- [ ] Change is documented
- [x] Build is green
- [X] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
