### PR TITLE
Locked wix-ui-icons-common@1.0.39

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "slate": "^0.20.3",
     "wix-animations": "^1.0.141",
     "wix-ui-backoffice": "1.0.252",
-    "wix-ui-icons-common": "^1.0.19",
+    "wix-ui-icons-common": "1.0.39",
     "wix-ui-test-utils": "^1.0.0"
   },
   "optionalDependencies": {


### PR DESCRIPTION
### What changed

Locked wix-ui-icons-common@1.0.39

### Why it changed

Because of broken icons after wix-ui-icons-common release

---

- [x] Change is tested
- [x] Change is documented
- [ ] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
