### PR TITLE
<TextArea/> - InputArea should not add hover styles when focused and hovered

### DIFF
--- a/src/InputArea/InputArea.e2e.js
+++ b/src/InputArea/InputArea.e2e.js
@@ -17,9 +17,23 @@ describe('input area page', () => {
   });
 
   eyes.it('should show focus styles', async () => {
-    expect(inputAreaTestkit.isFocused()).toBe(false);
+    expect(inputAreaTestkit.isFocused()).toBeFalsy();
     await browser.actions().sendKeys(protractor.Key.TAB).perform();
-    expect(inputAreaTestkit.isFocused()).toBe(true);
+    expect(inputAreaTestkit.isFocused()).toBeTruthy();
   });
 
+  eyes.it('should show hover styles', async () => {
+    expect(await inputAreaTestkit.isHovered()).toBeFalsy();
+    await browser.actions().mouseMove(inputAreaTestkit.textArea()).perform();
+    expect(await inputAreaTestkit.isHovered()).toBeTruthy();
+  });
+
+  eyes.it('should show hover and focus styles', async () => {
+    expect(await inputAreaTestkit.isHovered()).toBeFalsy();
+    expect(inputAreaTestkit.isFocused()).toBeFalsy();
+    await browser.actions().sendKeys(protractor.Key.TAB).perform();
+    await browser.actions().mouseMove(inputAreaTestkit.textArea()).perform();
+    expect(inputAreaTestkit.isFocused()).toBeTruthy();
+    expect(await inputAreaTestkit.isHovered()).toBeTruthy();
+  });
 });

--- a/src/InputArea/InputArea.e2e.js
+++ b/src/InputArea/InputArea.e2e.js
@@ -24,15 +24,14 @@ describe('input area page', () => {
 
   eyes.it('should show hover styles', async () => {
     expect(await inputAreaTestkit.isHovered()).toBeFalsy();
-    await browser.actions().mouseMove(inputAreaTestkit.textArea()).perform();
+    await inputAreaTestkit.hover();
     expect(await inputAreaTestkit.isHovered()).toBeTruthy();
   });
 
   eyes.it('should show hover and focus styles', async () => {
     expect(await inputAreaTestkit.isHovered()).toBeFalsy();
     expect(inputAreaTestkit.isFocused()).toBeFalsy();
-    await browser.actions().sendKeys(protractor.Key.TAB).perform();
-    await browser.actions().mouseMove(inputAreaTestkit.textArea()).perform();
+    await inputAreaTestkit.click();
     expect(inputAreaTestkit.isFocused()).toBeTruthy();
     expect(await inputAreaTestkit.isHovered()).toBeTruthy();
   });

--- a/src/InputArea/InputArea.protractor.driver.js
+++ b/src/InputArea/InputArea.protractor.driver.js
@@ -1,9 +1,11 @@
 
+import {mouseEnter} from 'wix-ui-test-utils/protractor';
 import {isFocused} from '../test-common';
 
 const toggleSwitchDriverFactory = component => ({
   element: () => component,
-  textArea: () => component.$('textarea'),
+  hover: () => mouseEnter(component.$('textarea')),
+  click: () => component.$('textarea').click(),
   isFocused: () => isFocused(component.$('textarea')),
   isHovered: () => component.$(':hover').isPresent()
 });

--- a/src/InputArea/InputArea.protractor.driver.js
+++ b/src/InputArea/InputArea.protractor.driver.js
@@ -3,7 +3,9 @@ import {isFocused} from '../test-common';
 
 const toggleSwitchDriverFactory = component => ({
   element: () => component,
-  isFocused: async () => isFocused(component.$('textarea'))
+  textArea: () => component.$('textarea'),
+  isFocused: () => isFocused(component.$('textarea')),
+  isHovered: () => component.$(':hover').isPresent()
 });
 
 export default toggleSwitchDriverFactory;

--- a/src/InputArea/InputAreaMixins.scss
+++ b/src/InputArea/InputAreaMixins.scss
@@ -18,6 +18,7 @@
 @mixin ThemeFocus {
     &.hasFocus {
         @include FocusBox;
+        background-color: transparent;
 
         &.hasError {
             @include FocusBoxError


### PR DESCRIPTION


### What changed

- InputArea should not add hover styles when focused and hovered

### Why it changed

- issue was created

---

- [x] Change is tested
- [x] Change is documented
- [x] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
