### PR TITLE
<ColorPicker/> - Previous color (history) behavior doesn’t work

### DIFF
--- a/src/ColorPicker/color-picker-history.js
+++ b/src/ColorPicker/color-picker-history.js
@@ -1,14 +1,21 @@
 import React from 'react';
-import {bool, object} from 'prop-types';
+import {bool, func, object} from 'prop-types';
 
 import css from './color-picker-history.scss';
 
-const ColorPickerHistory = ({show, current, previous}) => {
+const ColorPickerHistory = ({show, current, previous, onClick}) => {
   if (show) {
     return (
-      <div className={css.root}>
-        <div style={{background: previous.hex()}}/>
-        <div style={{background: current.hex()}}/>
+      <div className={css.root} data-hook="color-picker-history">
+        <div
+          data-hook="color-picker-history-previous"
+          style={{background: previous.hex()}}
+          onClick={() => onClick(previous)}
+          />
+        <div
+          data-hook="color-picker-history-current"
+          style={{background: current.hex()}}
+          />
       </div>
     );
   }
@@ -18,7 +25,8 @@ const ColorPickerHistory = ({show, current, previous}) => {
 ColorPickerHistory.propTypes = {
   show: bool.isRequired,
   previous: object.isRequired,
-  current: object.isRequired
+  current: object.isRequired,
+  onClick: func.isRequired
 };
 
 export default ColorPickerHistory;

--- a/src/ColorPicker/color-picker-hsb.js
+++ b/src/ColorPicker/color-picker-hsb.js
@@ -60,7 +60,12 @@ export default class ColorPickerHsb extends WixComponent {
       top: `${100 - current.value()}%`
     };
     return (
-      <div className={css.root} ref={e => this.gradient = e} onMouseDown={this.onMarkerDragStart}>
+      <div
+        className={css.root}
+        data-hook="color-picker-hsb"
+        ref={e => this.gradient = e}
+        onMouseDown={this.onMarkerDragStart}
+        >
         <div className={css.hue} style={{background: hue.hex()}}/>
         <div className={css.saturation}/>
         <div className={css.brightness}/>

--- a/src/ColorPicker/color-picker.driver.js
+++ b/src/ColorPicker/color-picker.driver.js
@@ -1,0 +1,20 @@
+import ReactTestUtils from 'react-dom/test-utils';
+
+const colorPickerDriverFactory = ({element}) => {
+  return {
+    exists: () => !!element,
+    selectBlackColor: () => {
+      // as with jsdom size of pallette 0 px, then click to 1,1 will make color black
+      ReactTestUtils.Simulate.mouseDown(element.querySelector('[data-hook="color-picker-hsb"]'), {
+        clientX: 1,
+        clientY: 1
+      });
+    },
+    clickOnPreviousColor: () => ReactTestUtils.Simulate.click(element.querySelector('[data-hook="color-picker-history-previous"]')),
+    historyPanelExists: () => !!element.querySelector('[data-hook="color-picker-history"]'),
+    historyCurrentColor: () => element.querySelector('[data-hook="color-picker-history-current"]').style.background,
+    historyPreviousColor: () => element.querySelector('[data-hook="color-picker-history-previous"]').style.background
+  };
+};
+
+export default colorPickerDriverFactory;

--- a/src/ColorPicker/color-picker.js
+++ b/src/ColorPicker/color-picker.js
@@ -91,7 +91,7 @@ export default class ColorPicker extends WixComponent {
   }
 
   change(color) {
-    this.setState({current: color}, () => {
+    this.setState({current: color, previous: this.state.current}, () => {
       this.props.onChange(color);
     });
   }

--- a/src/ColorPicker/color-picker.js
+++ b/src/ColorPicker/color-picker.js
@@ -73,7 +73,12 @@ export default class ColorPicker extends WixComponent {
       <div className={css.root}>
         <ColorPickerHsb current={current} onChange={this.change}/>
         <ColorPickerHue current={current} onChange={this.change}/>
-        <ColorPickerHistory show={showHistory} current={current} previous={previous}/>
+        <ColorPickerHistory
+          show={showHistory}
+          current={current}
+          previous={previous}
+          onClick={this.change}
+          />
         <ColorPickerConverter showConverter={showConverter} showInput={showInput} current={current} onChange={this.change}/>
         {children && (
           <div className={css.children}>{children}</div>
@@ -103,7 +108,6 @@ export default class ColorPicker extends WixComponent {
   cancel() {
     this.props.onCancel(this.state.previous);
   }
-
 }
 
 function equal(color1, color2) {

--- a/src/ColorPicker/color-picker.spec.js
+++ b/src/ColorPicker/color-picker.spec.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import color from 'color';
+import {createDriverFactory} from '../test-common';
+import colorPickerDriverFactory from './color-picker.driver';
+
+import ColorPicker from './color-picker';
+
+describe('ColorPicker', () => {
+  const createDriver = createDriverFactory(colorPickerDriverFactory);
+  let driver;
+
+  function createComponent(props) {
+    driver = createDriver(<ColorPicker {...props}/>);
+  }
+
+  it('should successfully render a component', () => {
+    const onChange = jest.fn();
+    const onCancel = jest.fn();
+    const onConfirm = jest.fn();
+    createComponent({value: '#000000', onChange, onCancel, onConfirm});
+    expect(driver.exists()).toBeTruthy();
+    expect(driver.historyPanelExists()).toBeFalsy();
+  });
+
+  describe('History', () => {
+    it('should show history panel with current color selected as previous', () => {
+      const onChange = jest.fn();
+      const onCancel = jest.fn();
+      const onConfirm = jest.fn();
+      const value = '#000000';
+      createComponent({value, onChange, onCancel, onConfirm, showHistory: true});
+      expect(driver.historyPanelExists()).toBeTruthy();
+      expect(color(driver.historyCurrentColor()).hex()).toBe(value);
+      expect(color(driver.historyPreviousColor()).hex()).toBe(value);
+    });
+
+    it('should update previous color', () => {
+      const onChange = jest.fn();
+      const onCancel = jest.fn();
+      const onConfirm = jest.fn();
+      const value = '#00FF00';
+      createComponent({value, onChange, onCancel, onConfirm, showHistory: true});
+      driver.selectBlackColor();
+      expect(color(driver.historyCurrentColor()).hex()).toBe('#000000');
+      expect(color(driver.historyPreviousColor()).hex()).toBe(value);
+    });
+
+    it('should set previous color to be active color', () => {
+      const onChange = jest.fn();
+      const onCancel = jest.fn();
+      const onConfirm = jest.fn();
+      const value = '#00FF00';
+      createComponent({value, onChange, onCancel, onConfirm, showHistory: true});
+      driver.selectBlackColor();
+      driver.clickOnPreviousColor();
+      expect(color(driver.historyCurrentColor()).hex()).toBe(value);
+      expect(color(driver.historyPreviousColor()).hex()).toBe('#000000');
+    });
+  });
+});


### PR DESCRIPTION
### What changed

<ColorPicker/> - Previous color (history) behavior fixed

### Why it changed

Previous color (history) behavior doesn’t work

---

- [x] Change is tested
- [x] Change is documented
- [x] Build is green
- [x] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
