### PR TITLE
<ColorPicker/> - last tab in the color picker doesn't stretch to the end

### DIFF
--- a/src/ColorPicker/color-picker-converter.js
+++ b/src/ColorPicker/color-picker-converter.js
@@ -50,7 +50,12 @@ export default class ColorPickerConverter extends WixComponent {
 
     return (
       <div>
-        <Tabs items={tabs} activeId={activeTab} onClick={this.changeTab}/>
+        <Tabs
+          minWidth={0}
+          items={tabs}
+          activeId={activeTab}
+          onClick={this.changeTab}
+          />
         {activeTab === HEX && <ColorPickerConverterHex current={current} onChange={this.props.onChange}/>}
         {activeTab === RGB && <ColorPickerConverterRgb current={current} onChange={this.props.onChange}/>}
         {activeTab === HSB && <ColorPickerConverterHsb current={current} onChange={this.props.onChange}/>}

--- a/src/ColorPicker/color-picker-converter.js
+++ b/src/ColorPicker/color-picker-converter.js
@@ -54,6 +54,7 @@ export default class ColorPickerConverter extends WixComponent {
           minWidth={0}
           items={tabs}
           activeId={activeTab}
+          type="uniformFull"
           onClick={this.changeTab}
           />
         {activeTab === HEX && <ColorPickerConverterHex current={current} onChange={this.props.onChange}/>}

--- a/src/ColorPicker/color-picker.js
+++ b/src/ColorPicker/color-picker.js
@@ -103,7 +103,6 @@ export default class ColorPicker extends WixComponent {
   cancel() {
     this.props.onCancel(this.state.previous);
   }
-
 }
 
 function equal(color1, color2) {

--- a/src/Tabs/README.md
+++ b/src/Tabs/README.md
@@ -10,6 +10,7 @@
 | activeId | string or number | - | - | Id of active tab |
 | type | string ('compact', 'uniformSide', 'uniformFull') | - | - | Tabs type |
 | width | string or number | - | - | Set tab width (only for uniformSide type) |
+| minWidth | string or number | - | - | Override tabs minWidth |
 | hasDivider | bool | true | - | Controls whether grey divider is visible |
 
 ## Item

--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -34,14 +34,15 @@ class Tabs extends WixComponent {
 }
 
 Tabs.propTypes = {
-  items: TabPropTypes.items.isRequired,
-  onClick: TabPropTypes.onClick,
   activeId: TabPropTypes.activeId,
-  type: TabPropTypes.type,
-  width: TabPropTypes.width,
-  sideContent: TabPropTypes.sideContent,
   dataHook: PropTypes.string,
-  hasDivider: PropTypes.bool
+  hasDivider: PropTypes.bool,
+  items: TabPropTypes.items.isRequired,
+  minWidth: TabPropTypes.width,
+  type: TabPropTypes.type,
+  sideContent: TabPropTypes.sideContent,
+  width: TabPropTypes.width,
+  onClick: TabPropTypes.onClick
 };
 
 export default Tabs;

--- a/src/Tabs/core/TabItems/index.js
+++ b/src/Tabs/core/TabItems/index.js
@@ -31,7 +31,11 @@ class TabItems extends React.Component {
     const className = classNames(styles.itemsContainer, styles[type]);
 
     return (
-      <ul className={className} data-hook={dataHook}>
+      <ul
+        className={className}
+        data-hook={dataHook}
+        style={{minWidth: this.props.minWidth}}
+        >
         {items.map(item => this.renderItem(item))}
       </ul>
     );
@@ -40,13 +44,14 @@ class TabItems extends React.Component {
 }
 
 TabItems.propTypes = {
-  type: TabPropTypes.type,
-  items: TabPropTypes.items.isRequired,
   activeId: TabPropTypes.activeId,
-  onClick: TabPropTypes.onClick,
-  width: TabPropTypes.width,
   dataHook: PropTypes.string,
-  itemMaxWidth: PropTypes.number
+  itemMaxWidth: PropTypes.number,
+  items: TabPropTypes.items.isRequired,
+  minWidth: TabPropTypes.width,
+  type: TabPropTypes.type,
+  width: TabPropTypes.width,
+  onClick: TabPropTypes.onClick
 };
 
 export default withItemMaxWidth(TabItems);

--- a/src/Tabs/core/withItemMaxWidth/index.js
+++ b/src/Tabs/core/withItemMaxWidth/index.js
@@ -33,7 +33,7 @@ const withMaxWidth = WrappedComponent => {
 
     render() {
       return (
-        <div ref={el => this.initMaxWidth(el)}>
+        <div ref={el => this.initMaxWidth(el)} style={{width: '100%'}}>
           <WrappedComponent {...this.props} itemMaxWidth={this.state.itemMaxWidth}/>
         </div>
       );


### PR DESCRIPTION
### What changed

<ColorPicker/> - last tab in the color picker doesn't stretch to the end
Added new minWidth property for Tabs to be able to override hardcoded css minWidth property

### Why it changed

to fix layout problems

---

- [x] Change is tested
- [x] Change is documented
- [x] Build is green
- [x] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
