### PR TITLE
<TimeInput/> - disableAmPm isn’t working for <TimePicker/>

### DIFF
--- a/src/TimeInput/TimeInput.js
+++ b/src/TimeInput/TimeInput.js
@@ -52,7 +52,7 @@ export default class extends Component {
       focus: false,
       lastCaretIdx: 0,
       hover: false,
-      ...this.getInitTime(this.props.defaultValue)
+      ...this.getInitTime(this.props.defaultValue, this.props.disableAmPm)
     };
   }
 

--- a/src/TimeInput/TimeInput.js
+++ b/src/TimeInput/TimeInput.js
@@ -57,20 +57,20 @@ export default class extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.defaultValue !== this.props.defaultValue) {
-      this.setState(this.getInitTime(nextProps.defaultValue));
+    const isDefaultValueChanged = nextProps.defaultValue !== this.props.defaultValue;
+    const isAmPmModeChanged = nextProps.disableAmPm !== this.props.disableAmPm;
+    if (isAmPmModeChanged || isDefaultValueChanged) {
+      this.setState(this.getInitTime(nextProps.defaultValue, nextProps.disableAmPm));
     }
   }
 
-  isAmPmMode() {
-    return !this.props.disableAmPm && moment('2016-04-03 13:14:00').format('LT').indexOf('PM') !== -1;
-  }
+  isAmPmMode = disableAmPm => !disableAmPm && moment('2016-04-03 13:14:00').format('LT').indexOf('PM') !== -1
 
-  getInitTime(value) {
+  getInitTime(value, disableAmPm) {
     let time = value || moment(),
       am = time.hours() < 12;
 
-    const ampmMode = this.isAmPmMode();
+    const ampmMode = this.isAmPmMode(disableAmPm);
 
     ({time, am} = this.normalizeTime(am, time, ampmMode));
     const text = this.formatTime(time, ampmMode);

--- a/src/TimeInput/TimeInput.spec.js
+++ b/src/TimeInput/TimeInput.spec.js
@@ -48,6 +48,18 @@ describe('TimeInput', () => {
       expect(driver.getValue()).toBe(format24Hours(props.defaultValue));
     });
 
+    it(`should allow rendering time in 24 hours mode(dynamic update)`, () => {
+      const props = {
+        defaultValue: defaultMoment,
+        disableAmPm: false
+      };
+      const driver = createDriver(<TimePicker {...props}/>);
+      expect(driver.getValue()).toBe(format12Hours(props.defaultValue));
+
+      driver.setProps({disableAmPm: true});
+      expect(driver.getValue()).toBe(format24Hours(props.defaultValue));
+    });
+
     it(`should display am/pm indicator when in 12 hours mode`, () => {
       const props = {
         defaultValue: defaultMoment,


### PR DESCRIPTION
### What changed

- added re-initialize on ampm mode change

### Why it changed

- <TimeInput/> - disableAmPm isn’t working for <TimePicker/>

---

- [x] Change is tested
- [x] Change is documented
- [x] Build is green
- [x] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
