### PR TITLE
fix bug where <MultiSelect> always shows scrollbar (#1842)

### DIFF
--- a/src/Input/Input.scss
+++ b/src/Input/Input.scss
@@ -114,9 +114,11 @@ $material-gap: 8px;
 
 .size {
   &-small  { @include Size($height: 30px, $fontSize: 14px); }
+  &-small-with-selection { @include Size($height: 28px, $fontSize: 14px); }
   &-normal { @include Size($height: 36px, $fontSize: 16px); }
   &-normal-with-selection { @include Size($height: 34px, $fontSize: 16px); }
   &-large  { @include Size($height: 60px, $fontSize: 22px); }
+  &-large-with-selection { @include Size($height: 58px, $fontSize: 22px); }
 }
 
 .theme {

--- a/src/MultiSelect/InputWithTags.js
+++ b/src/MultiSelect/InputWithTags.js
@@ -71,15 +71,16 @@ class InputWithTags extends React.Component {
       'fixedFooter',
       'dataHook',
       'onFocus',
+      'withSelection',
       'onBlur',
       'onInputClicked'], inputProps);
     const fontSize = (desiredProps.size && desiredProps.size === 'small') ? '14px' : '16px';
 
     let rowMultiplier;
     if (tags.length && tags[0].size === 'large') {
-      rowMultiplier = 48;
+      rowMultiplier = 47;
     } else {
-      rowMultiplier = 36;
+      rowMultiplier = 35;
     }
     const maxHeight = this.props.maxHeight || this.props.maxNumRows * rowMultiplier || 'initial';
 
@@ -113,6 +114,7 @@ class InputWithTags extends React.Component {
                 desiredProps.onChange && desiredProps.onChange(e);
               }
             }}
+            withSelection
             />
         </span>
       </div>

--- a/src/MultiSelect/InputWithTags.scss
+++ b/src/MultiSelect/InputWithTags.scss
@@ -2,7 +2,6 @@
 
 .input {
   min-width: 30px;
-  margin: -1px;
 }
 
 .emptyInput {
@@ -31,7 +30,7 @@
 }
 
 .hasMaxHeight {
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 // Override <Input>'s default focus style

--- a/src/MultiSelect/MultiSelect.spec.js
+++ b/src/MultiSelect/MultiSelect.spec.js
@@ -244,7 +244,7 @@ describe('multiSelect', () => {
   it('should set maxHeight when maxNumRows defined', () => {
     const {driver} = createDriver(<MultiSelect maxNumRows={2} options={options}/>);
 
-    expect(driver.getMaxHeight()).toBe('72px');
+    expect(driver.getMaxHeight()).toBe('70px');
   });
 
   it('should set maxHeight when maxNumRows defined (large tags)', () => {
@@ -254,7 +254,7 @@ describe('multiSelect', () => {
 
     const {driver} = createDriver(<MultiSelect maxNumRows={2} tags={options} options={options}/>);
 
-    expect(driver.getMaxHeight()).toBe('96px');
+    expect(driver.getMaxHeight()).toBe('94px');
   });
 
   it('should allow to write any text as tag when options are empty', () => {


### PR DESCRIPTION
### What changed

changed overflow-y to auto and removed a negative margin in .input, so that <InputWithTags> container is lte than its content and would show a scrollbar only when needed

### Why it changed

scrollbar would be visible regardless of component height, rendering it useless.

---

- [ ] Change is tested
- [ ] Change is documented
- [ ] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
