### PR TITLE
WIP - <Table/> -[1] switch from selection boolean array to  selectedIds

### DIFF
--- a/src/Table/BulkSelection/BulkSelection.js
+++ b/src/Table/BulkSelection/BulkSelection.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import {string, number, arrayOf, oneOfType, func, any} from 'prop-types';
 import isEqual from 'lodash/isEqual';
-import without from 'lodash/without';
 import createReactContext from 'create-react-context';
 export const BulkSelectionContext = createReactContext();
 
@@ -55,9 +54,9 @@ export class BulkSelection extends React.Component {
 
   toggleAll = enable => {
     if (enable) {
-      this.setSelectedIds({selectedIds: this.props.allIds});
+      this.setSelectedIds(this.props.allIds);
     } else {
-      this.setSelectedIds({selectedIds: []});
+      this.setSelectedIds([]);
     }
   }
 
@@ -77,16 +76,17 @@ export class BulkSelection extends React.Component {
   }
 
   toggleSelectionById = id => {
-    let newSelectedIds;
-    if (this.isSelected(id)) {
-      newSelectedIds = without(this.state.selectedIds, id);
-    } else {
-      newSelectedIds = [...this.state.selectedIds, id];
-    }
-    this.setSelectedIds({selectedIds: newSelectedIds});
+    this.setSelectedIds(
+      this.isSelected(id) ?
+      this.state.selectedIds.filter(_id => _id !== id) :
+      this.state.selectedIds.concat(id)
+    );
   }
 
-  setSelectedIds = ({selectedIds}) => {
+  setSelectedIds = selectedIds => {
+    if (!Array.isArray(selectedIds)) {
+      throw new Error('selectedIds must be an array');
+    }
     this.setState({selectedIds}, () => {
       this.props.onSelectionChanged && this.props.onSelectionChanged(selectedIds.slice());
     });

--- a/src/Table/BulkSelection/BulkSelection.js
+++ b/src/Table/BulkSelection/BulkSelection.js
@@ -2,7 +2,6 @@ import React from 'react';
 import {string, number, arrayOf, oneOfType, func, any} from 'prop-types';
 import isEqual from 'lodash/isEqual';
 import without from 'lodash/without';
-import defaultTo from 'lodash/defaultTo';
 import createReactContext from 'create-react-context';
 export const BulkSelectionContext = createReactContext();
 
@@ -25,7 +24,7 @@ export class BulkSelection extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      selectedIds: defaultTo(props.selectedIds, [])
+      selectedIds: (props.selectedIds || []).slice()
     };
   }
 

--- a/src/Table/BulkSelection/BulkSelection.js
+++ b/src/Table/BulkSelection/BulkSelection.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import {string, number, arrayOf, oneOfType, func, any} from 'prop-types';
 import isEqual from 'lodash/isEqual';
 import without from 'lodash/without';
 import defaultTo from 'lodash/defaultTo';
@@ -120,13 +120,13 @@ export class BulkSelection extends React.Component {
 
 BulkSelection.propTypes = {
   /** Array of item selection boolean states. Should correspond in length to the data prop */
-  selectedIds: PropTypes.arrayOf(PropTypes.string),
+  selectedIds: oneOfType([arrayOf(string), arrayOf(number)]),
   /** An array of all item ids (string ids) */
-  allIds: PropTypes.arrayOf(PropTypes.string).isRequired,
+  allIds: oneOfType([arrayOf(string), arrayOf(number)]).isRequired,
   /** Called when item selection changes. Receives the updated selectedIds array as argument. */
-  onSelectionChanged: PropTypes.func,
+  onSelectionChanged: func,
   /** Any - can consume the BulkSelectionProvider context */
-  children: PropTypes.any
+  children: any
 };
 
 

--- a/src/Table/BulkSelection/BulkSelection.spec.js
+++ b/src/Table/BulkSelection/BulkSelection.spec.js
@@ -1,22 +1,47 @@
 import React from 'react';
 import {mount} from 'enzyme';
 import {BulkSelectionConsumer} from './BulkSelectionConsumer';
+import {BulkSelection} from './BulkSelection';
 
 describe('BulkSelection', () => {
-  it('should throw error when consumer is not within a BulkSelection', () => {
-    const create = () => mount(<BulkSelectionConsumer>{() => null}</BulkSelectionConsumer>);
-    expect(create).toThrow();
+  describe('BulkSelectionConsumer error', () => {
+    it('should throw error when consumer is not within a BulkSelection', () => {
+      const create = () => mount(<BulkSelectionConsumer>{() => null}</BulkSelectionConsumer>);
+      expect(create).toThrow();
+    });
 
+    it('should throw custom error when consumer is not within a BulkSelection', () => {
+      const create = () => mount(
+        <BulkSelectionConsumer consumerCompName="Consumer" providerCompName="Provider">
+          {() => null}
+        </BulkSelectionConsumer>
+      );
+      expect(create).toThrow('Consumer cannot be rendered outside the Provider component');
+    });
   });
 
-  it('should throw custom error when consumer is not within a BulkSelection', () => {
-
-    const create = () => mount(
-      <BulkSelectionConsumer noContextMsg="the message">
-        {() => null}
-      </BulkSelectionConsumer>
-      );
-    expect(create).toThrow('the message');
-
+  it('setSelectionIds & isSelected', () => {
+    let _setSelectedIds, _isSelected;
+    mount(
+      <BulkSelection allIds={[1, 2, 3]}>
+        <BulkSelectionConsumer>
+          {({setSelectedIds, isSelected}) => {
+            _setSelectedIds = setSelectedIds;
+            _isSelected = isSelected;
+            return (
+              <div/>
+            );
+          }}
+        </BulkSelectionConsumer>
+      </BulkSelection>
+    );
+    expect(_isSelected(1)).toBeFalsy();
+    expect(_isSelected(2)).toBeFalsy();
+    expect(_isSelected(3)).toBeFalsy();
+    _setSelectedIds([1, 2]);
+    expect(_isSelected(1)).toBeTruthy();
+    expect(_isSelected(2)).toBeTruthy();
+    expect(_isSelected(3)).toBeFalsy();
   });
 });
+

--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import {string, number, arrayOf, oneOfType, func, bool, any} from 'prop-types';
 import omit from 'lodash/omit';
 import defaultTo from 'lodash/defaultTo';
 import createReactContext from 'create-react-context';
@@ -34,7 +34,7 @@ function createColumns({tableProps, bulkSelectionContext}) {
         onChange={() => toggleBulkSelection()}
         />,
       render: (row, rowNum) => {
-        const id = defaultTo(row.id, String(rowNum));
+        const id = defaultTo(row.id, rowNum);
         return (
           <Checkbox
             dataHook="row-select"
@@ -61,7 +61,7 @@ const TableHeader = props => {
 };
 TableHeader.displayName = 'Table.Header';
 TableHeader.propTypes = {
-  children: PropTypes.any
+  children: any
 };
 
 const TableFooter = props => {
@@ -75,7 +75,7 @@ const TableFooter = props => {
 };
 TableHeader.displayName = 'Table.Footer';
 TableFooter.propTypes = {
-  children: PropTypes.any
+  children: any
 };
 
 /**
@@ -142,7 +142,7 @@ const TableContent = ({titleBarVisible}) => {
 };
 TableContent.displayName = 'Table.Content';
 TableContent.propTypes = {
-  titleBarVisible: PropTypes.bool
+  titleBarVisible: bool
 };
 TableContent.defaultProps = {
   titleBarVisible: true
@@ -179,7 +179,7 @@ export default class Table extends WixComponent {
       <TableContext.Provider value={this.state}>
         <BulkSelection
           selectedIds={this.props.selectedIds}
-          allIds={this.state.data.map((rowData, rowIndex) => defaultTo(rowData.id, String(rowIndex)))}
+          allIds={this.state.data.map((rowData, rowIndex) => defaultTo(rowData.id, rowIndex))}
           onSelectionChanged={this.props.onSelectionChanged}
           >
           <div> {/* Wrapping with a div in case multiple children are passed*/}
@@ -204,11 +204,13 @@ Table.defaultProps = {
 Table.propTypes = {
   ...omit(DataTable.propTypes, ['thPadding', 'thHeight', 'thFontSize', 'thBorder', 'thColor', 'thOpacity', 'thLetterSpacing', 'hideHeader']),
   /** Indicates wether to show a selection column (with checkboxes) */
-  showSelection: PropTypes.bool,
-  /** Array of row selection boolean states. Should correspond in length to the data prop */
-  selections: PropTypes.arrayOf(PropTypes.bool),
+  showSelection: bool,
+    /** Array of selected row ids.
+     *  Idealy, id should be a property on the data row object.
+     *  If data objects do not have id property, then the data row's index would be used as an id. */
+  selectedIds: oneOfType([arrayOf(string), arrayOf(number)]),
   /** Called when row selection changes. Receives the updated selection array as argument. */
-  onSelectionChanged: PropTypes.func
+  onSelectionChanged: func
 };
 
 

--- a/src/Table/Table.spec.js
+++ b/src/Table/Table.spec.js
@@ -17,10 +17,10 @@ describe('Table', () => {
     return {driver, wrapper};
   };
 
-
+  const ID_1 = 'aaa', ID_2 = 'bbb';
   const defaultProps = {
     id: 'id',
-    data: [{a: 'value 1', b: 'value 2'}, {a: 'value 3', b: 'value 4'}],
+    data: [{id: ID_1, a: 'value 1', b: 'value 2'}, {id: ID_2, a: 'value 3', b: 'value 4'}],
     columns: [
       {title: 'Row Num', render: (row, rowNum) => rowNum},
       {title: 'A', render: row => row.a},
@@ -31,14 +31,9 @@ describe('Table', () => {
     children: <Table.Content/>
   };
   const noneSelected = () => [];
-  const firstSelected = () => ['0'];
-  const secondSelected = () => ['1'];
-  const allSelected = () => ['0', '1'];
-
-  const withSelection = {
-    selectedIds: ['0'],
-    showSelection: true
-  };
+  const firstSelected = () => [ID_1];
+  const secondSelected = () => [ID_2];
+  const allSelected = () => [ID_1, ID_2];
 
   it('should pass id prop to child', () => {
     const driver = createDriver(<Table {...defaultProps}/>);
@@ -47,7 +42,7 @@ describe('Table', () => {
 
   describe('showSelection prop', () => {
     it('should display selection column', () => {
-      const driver = createDriver(<Table {...defaultProps} {...withSelection}/>);
+      const driver = createDriver(<Table {...defaultProps} selectedIds={firstSelected()}/>);
       expect(driver.isRowCheckboxVisible(1)).toBeTruthy();
       expect(driver.isBulkSelectionCheckboxVisible()).toBeTruthy();
     });
@@ -60,8 +55,31 @@ describe('Table', () => {
   });
 
   describe('selectedIds prop', () => {
-    it('should select rows according to selectedIds prop', () => {
-      const driver = createDriver(<Table {...defaultProps} {...withSelection}/>);
+    it('should select rows according to selectedIds prop given string ids', () => {
+      const driver = createDriver(<Table {...defaultProps} selectedIds={firstSelected()}/>);
+      expect(driver.isRowSelected(0)).toBeTruthy();
+      expect(driver.isRowSelected(1)).toBeFalsy();
+    });
+
+    it('should select rows according to selectedIds prop given numeric ids', () => {
+      const ID_1 = 1234, ID_2 = 1235;
+      const driver = createDriver(
+        <Table
+          {...defaultProps}
+          data={[{id: ID_1, a: 'value 1', b: 'value 2'}, {id: ID_2, a: 'value 3', b: 'value 4'}]}
+          selectedIds={[ID_1]}
+          />);
+      expect(driver.isRowSelected(0)).toBeTruthy();
+      expect(driver.isRowSelected(1)).toBeFalsy();
+    });
+
+    it('should select rows according to selectedIds prop given row index as ids', () => {
+      const driver = createDriver(
+        <Table
+          {...defaultProps}
+          data={[{a: 'value 1', b: 'value 2'}, {a: 'value 3', b: 'value 4'}]}
+          selectedIds={[0]}
+          />);
       expect(driver.isRowSelected(0)).toBeTruthy();
       expect(driver.isRowSelected(1)).toBeFalsy();
     });
@@ -70,23 +88,23 @@ describe('Table', () => {
       const selectedIds = [];
       const {driver, wrapper} = createEnzymeDriver(<Table {...defaultProps} selectedIds={selectedIds}/>);
       expect(driver.isRowSelected(0)).toBeFalsy();
-      wrapper.setProps({selectedIds: ['0']});
+      wrapper.setProps({selectedIds: firstSelected()});
       expect(driver.isRowSelected(0)).toBeTruthy();
     });
 
     //TODO: It seems that DataTable.render is not called (verified with console.log). But this test shows it does.
     xit('should NOT re-render DataTable when new props are set but selection has NOT changed', async () => {
-      const {wrapper} = createEnzymeDriver(<Table {...defaultProps} selectedIds={['0']}/>);
+      const {wrapper} = createEnzymeDriver(<Table {...defaultProps} selectedIds={firstSelected()}/>);
       const renderMock = jest.fn();
       wrapper.find(DataTable).instance().render = renderMock;
-      wrapper.setProps({selectedIds: ['0']});
+      wrapper.setProps({selectedIds: firstSelected()});
       expect(renderMock.mock.calls.length).toBe(0);
     });
   });
 
   describe('row selection', () => {
     it('should select row when checkbox clicked given row not selected', () => {
-      const driver = createDriver(<Table {...defaultProps} {...withSelection}/>);
+      const driver = createDriver(<Table {...defaultProps} selectedIds={firstSelected()}/>);
       driver.clickRowChecbox(1);
       expect(driver.isRowSelected(1)).toBeTruthy();
     });

--- a/src/Table/Table.spec.js
+++ b/src/Table/Table.spec.js
@@ -1,6 +1,7 @@
 import TableDriverFactory from './Table.driver';
 import React from 'react';
 import Table from './Table';
+import DataTable from '../DataTable';
 import ReactTestUtils from 'react-dom/test-utils';
 import {createDriverFactory} from '../test-common';
 import {tableTestkitFactory} from '../../testkit';
@@ -16,6 +17,7 @@ describe('Table', () => {
     return {driver, wrapper};
   };
 
+
   const defaultProps = {
     id: 'id',
     data: [{a: 'value 1', b: 'value 2'}, {a: 'value 3', b: 'value 4'}],
@@ -28,9 +30,13 @@ describe('Table', () => {
     showSelection: true,
     children: <Table.Content/>
   };
+  const noneSelected = () => [];
+  const firstSelected = () => ['0'];
+  const secondSelected = () => ['1'];
+  const allSelected = () => ['0', '1'];
 
   const withSelection = {
-    selections: [true, false],
+    selectedIds: ['0'],
     showSelection: true
   };
 
@@ -53,45 +59,46 @@ describe('Table', () => {
     });
   });
 
-  describe('selection prop', () => {
-    it('should select rows according to selection prop', () => {
+  describe('selectedIds prop', () => {
+    it('should select rows according to selectedIds prop', () => {
       const driver = createDriver(<Table {...defaultProps} {...withSelection}/>);
       expect(driver.isRowSelected(0)).toBeTruthy();
       expect(driver.isRowSelected(1)).toBeFalsy();
     });
 
     it('should update selection if selection prop has change', async () => {
-      const selections = [false, false];
-      const {driver, wrapper} = createEnzymeDriver(<Table {...defaultProps} selections={selections}/>);
-      selections[0] = true;
-      wrapper.setProps({selections});
+      const selectedIds = [];
+      const {driver, wrapper} = createEnzymeDriver(<Table {...defaultProps} selectedIds={selectedIds}/>);
+      expect(driver.isRowSelected(0)).toBeFalsy();
+      wrapper.setProps({selectedIds: ['0']});
       expect(driver.isRowSelected(0)).toBeTruthy();
     });
 
-    it('should NOT reupdate selection if selection prop has change', async () => {
-      const selections = [false, false];
-      const {driver, wrapper} = createEnzymeDriver(<Table {...defaultProps} selections={selections}/>);
-      selections[0] = true;
-      wrapper.setProps({selections});
-      expect(driver.isRowSelected(0)).toBeTruthy();
+    //TODO: It seems that DataTable.render is not called (verified with console.log). But this test shows it does.
+    xit('should NOT re-render DataTable when new props are set but selection has NOT changed', async () => {
+      const {wrapper} = createEnzymeDriver(<Table {...defaultProps} selectedIds={['0']}/>);
+      const renderMock = jest.fn();
+      wrapper.find(DataTable).instance().render = renderMock;
+      wrapper.setProps({selectedIds: ['0']});
+      expect(renderMock.mock.calls.length).toBe(0);
     });
   });
 
   describe('row selection', () => {
-    it('should select row when checkbox clicked give row not selected', () => {
+    it('should select row when checkbox clicked given row not selected', () => {
       const driver = createDriver(<Table {...defaultProps} {...withSelection}/>);
       driver.clickRowChecbox(1);
       expect(driver.isRowSelected(1)).toBeTruthy();
     });
 
-    it('should unselect row when checkbox clicked give row selected', () => {
-      const driver = createDriver(<Table {...defaultProps} selections={[true, true]}/>);
+    it('should unselect row when checkbox clicked given row selected', () => {
+      const driver = createDriver(<Table {...defaultProps} selectedIds={allSelected()}/>);
       driver.clickRowChecbox(1);
       expect(driver.isRowSelected(1)).toBeFalsy();
     });
   });
 
-  describe('data prop', () => {
+  describe('re-render', () => {
     it('should re-render on data update', () => {
       const props = {
         id: 'id',
@@ -111,52 +118,60 @@ describe('Table', () => {
       wrapper.setProps({data});
       expect(driver.getCell(ROW_INDEX, COLUMN_A_INDEX).textContent).toBe(newValue);
     });
+
+    it('should keep selection when re-rendered given selectedIds not provided (Uncontrolled)', () => {
+      const {driver, wrapper} = createEnzymeDriver(<Table {...defaultProps}/>);
+      driver.clickRowChecbox(1);
+      expect(driver.isRowSelected(1)).toBeTruthy();
+      wrapper.setProps({...defaultProps});
+      expect(driver.isRowSelected(1)).toBeTruthy();
+    });
   });
 
   describe('BulkSelection', () => {
     describe('initial render', () => {
       it('should display bulk-selection as checked when all rows are selected', () => {
-        const selections = [true, true];
-        const driver = createDriver(<Table {...defaultProps} selections={selections}/>);
+        const selectedIds = allSelected();
+        const driver = createDriver(<Table {...defaultProps} selectedIds={selectedIds}/>);
         expect(driver.isBulkSelectionChecked()).toBeTruthy();
         expect(driver.isBulkSelectionUnchecked()).toBeFalsy();
         expect(driver.isBulkSelectionIndeterminate()).toBeFalsy();
       });
 
       it('should display bulk-selection as unchecked when no rows are selected', () => {
-        const selections = [false, false];
-        const driver = createDriver(<Table {...defaultProps} selections={selections}/>);
+        const selectedIds = noneSelected();
+        const driver = createDriver(<Table {...defaultProps} selectedIds={selectedIds}/>);
         expect(driver.isBulkSelectionUnchecked()).toBeTruthy();
         expect(driver.isBulkSelectionChecked()).toBeFalsy();
       });
 
       it('should display bulk-selection as partial when some rows are selected', () => {
-        const selections = [false, true];
-        const driver = createDriver(<Table {...defaultProps} selections={selections}/>);
+        const selectedIds = secondSelected();
+        const driver = createDriver(<Table {...defaultProps} selectedIds={selectedIds}/>);
         expect(driver.isBulkSelectionIndeterminate()).toBeTruthy();
       });
     });
 
     describe('Update row selection', () => {
       it('should select all rows when bulk-selection checkbox clicked given no checkboxes are checked', () => {
-        const selections = [false, false];
-        const driver = createDriver(<Table {...defaultProps} selections={selections}/>);
+        const selectedIds = noneSelected();
+        const driver = createDriver(<Table {...defaultProps} selectedIds={selectedIds}/>);
         driver.clickBulkSelectionCheckbox();
         expect(driver.isRowSelected(0)).toBeTruthy();
         expect(driver.isRowSelected(1)).toBeTruthy();
       });
 
       it('should select all rows when bulk-selection checkbox clicked given some checkboxes are checked', () => {
-        const selections = [false, true];
-        const driver = createDriver(<Table {...defaultProps} selections={selections}/>);
+        const selectedIds = secondSelected();
+        const driver = createDriver(<Table {...defaultProps} selectedIds={selectedIds}/>);
         driver.clickBulkSelectionCheckbox();
         expect(driver.isRowSelected(0)).toBeTruthy();
         expect(driver.isRowSelected(1)).toBeTruthy();
       });
 
       it('should unselect all rows when bulk-selection checkbox clicked given all checkboxes are checked', () => {
-        const selections = [true, true];
-        const driver = createDriver(<Table {...defaultProps} selections={selections}/>);
+        const selectedIds = allSelected();
+        const driver = createDriver(<Table {...defaultProps} selectedIds={selectedIds}/>);
         driver.clickBulkSelectionCheckbox();
         expect(driver.isRowSelected(0)).toBeFalsy();
         expect(driver.isRowSelected(1)).toBeFalsy();
@@ -166,47 +181,47 @@ describe('Table', () => {
     describe('onSelectionChanged', () => {
       it('should call onSelectionChanged when bulk-selection checkbox clicked given no checkboxes are checked', () => {
         const onSelectionChanged = jest.fn();
-        const selections = [false, false];
-        const driver = createDriver(<Table {...defaultProps} selections={selections} onSelectionChanged={onSelectionChanged}/>);
+        const selectedIds = noneSelected();
+        const driver = createDriver(<Table {...defaultProps} selectedIds={selectedIds} onSelectionChanged={onSelectionChanged}/>);
         driver.clickBulkSelectionCheckbox();
-        expect(onSelectionChanged).toHaveBeenCalledWith([true, true]);
+        expect(onSelectionChanged).toHaveBeenCalledWith(allSelected());
       });
 
       it('should call onSelectionChanged when row selected given no checkboxes are checked', () => {
         const onSelectionChanged = jest.fn();
-        const selections = [false, false];
-        const driver = createDriver(<Table {...defaultProps} selections={selections} onSelectionChanged={onSelectionChanged}/>);
+        const selectedIds = noneSelected();
+        const driver = createDriver(<Table {...defaultProps} selectedIds={selectedIds} onSelectionChanged={onSelectionChanged}/>);
         driver.clickRowChecbox(0);
         expect(onSelectionChanged.mock.calls.length).toBe(1);
-        expect(onSelectionChanged).toHaveBeenCalledWith([true, false]);
+        expect(onSelectionChanged).toHaveBeenCalledWith(firstSelected());
       });
     });
 
     describe('Update BulkSelection', () => {
       it('should check bulk-selection checkbox when all rows change to check', () => {
-        const selections = [false, true];
-        const driver = createDriver(<Table {...defaultProps} selections={selections}/>);
+        const selectedIds = secondSelected();
+        const driver = createDriver(<Table {...defaultProps} selectedIds={selectedIds}/>);
         driver.clickRowChecbox(0);
         expect(driver.isBulkSelectionChecked()).toBeTruthy();
       });
 
       it('should uncheck bulk-selection checkbox when all rows change to not-selected', () => {
-        const selections = [false, true];
-        const driver = createDriver(<Table {...defaultProps} selections={selections}/>);
+        const selectedIds = secondSelected();
+        const driver = createDriver(<Table {...defaultProps} selectedIds={selectedIds}/>);
         driver.clickRowChecbox(1);
         expect(driver.isBulkSelectionUnchecked()).toBeTruthy();
       });
 
       it('should show partial in bulk-selection checkbox when row unselected given all rows selected', () => {
-        const selections = [true, true];
-        const driver = createDriver(<Table {...defaultProps} selections={selections}/>);
+        const selectedIds = allSelected();
+        const driver = createDriver(<Table {...defaultProps} selectedIds={selectedIds}/>);
         driver.clickRowChecbox(1);
         expect(driver.isBulkSelectionIndeterminate()).toBeTruthy();
       });
 
       it('should show partial in bulk-selection checkbox when row selected given all rows not selected', () => {
-        const selections = [false, false];
-        const driver = createDriver(<Table {...defaultProps} selections={selections}/>);
+        const selectedIds = noneSelected();
+        const driver = createDriver(<Table {...defaultProps} selectedIds={selectedIds}/>);
         driver.clickRowChecbox(1);
         expect(driver.isBulkSelectionIndeterminate()).toBeTruthy();
       });
@@ -219,7 +234,7 @@ describe('Table', () => {
         <Table
           {...defaultProps}
           showSelection
-          selections={[false, false]}
+          selectedIds={noneSelected()}
           />
         );
       expect(!!driver.getHeader()).toBeFalsy();
@@ -232,7 +247,7 @@ describe('Table', () => {
         <Table
           {...defaultProps}
           showSelection
-          selections={[true, true]}
+          selectedIds={allSelected()}
           >
           <Table.Header>
             {({getNumSelected}) => <div>{`${getNumSelected()} Selected`}</div>}
@@ -249,7 +264,7 @@ describe('Table', () => {
         <Table
           {...defaultProps}
           showSelection
-          selections={[true, true]}
+          selectedIds={allSelected()}
           >
           <Table.Content/>
           <Table.Footer>
@@ -266,7 +281,7 @@ describe('Table', () => {
         <Table
           {...defaultProps}
           showSelection
-          selections={[true, true]}
+          selectedIds={allSelected()}
           >
           <div>
             <Table.TitleBar/>


### PR DESCRIPTION
expect the `data` to include an `id` property in each row's data.
If it doesn't exist then use the rowIndex as id.

The selection state, holds selectedIds instead of an array or booleans:
So instead of `[true,false]`, now this selection is represented with `[0]`.