### PR TITLE
<RichTextArea/> - fix Placeholder doesn’t update when props change

### DIFF
--- a/src/RichTextArea/RichTextArea.js
+++ b/src/RichTextArea/RichTextArea.js
@@ -122,7 +122,9 @@ class RichTextArea extends WixComponent {
   }
 
   componentWillReceiveProps(props) {
-    if (props.value && props.value !== this.props.value && props.value !== this.lastValue) {
+    const isPlaceholderChanged = props.placeholder !== this.props.placeholder;
+    const isValueChanged = props.value && props.value !== this.props.value && props.value !== this.lastValue;
+    if (isPlaceholderChanged || isValueChanged) {
       if (props.isAppend) {
         const newEditorState = this.state.editorState
               .transform()


### PR DESCRIPTION
### What changed

Placeholder doesn’t work

### Why it changed

https://github.com/wix-private/wsr-issues/issues/34

---

- [ ] Change is tested
- [ ] Change is documented
- [ ] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
