### PR TITLE
Fix TextLink color prop isn't working (#1887)

### DIFF
--- a/src/BaseComponents/TextLinkLayout/TextLinkLayout.driver.js
+++ b/src/BaseComponents/TextLinkLayout/TextLinkLayout.driver.js
@@ -18,7 +18,8 @@ const textLinkLayoutDriverFactory = ({element, wrapper, component}) => {
     setProps: props => {
       const ClonedWithProps = React.cloneElement(component, Object.assign({}, component.props, props), ...(component.props.children || []));
       ReactDOM.render(<div ref={r => element = r}>{ClonedWithProps}</div>, wrapper);
-    }
+    },
+    getColor: () => element.style._values.color
   };
 };
 

--- a/src/BaseComponents/TextLinkLayout/TextLinkLayout.js
+++ b/src/BaseComponents/TextLinkLayout/TextLinkLayout.js
@@ -75,7 +75,7 @@ export default class TextLinkLayout extends WixComponent {
   render() {
     const {isHover} = this.state;
     const {underlineStyle, size, children, display, disabled} = this.props;
-    const color = this.getColor();
+    const color = this.props.color || this.getColor();
 
     const style = {
       color,

--- a/src/BaseComponents/TextLinkLayout/TextLinkLayout.spec.js
+++ b/src/BaseComponents/TextLinkLayout/TextLinkLayout.spec.js
@@ -80,6 +80,21 @@ describe('TextLinkLayout', () => {
     const driver = createDriver(<TextLinkLayout display="inline-block"/>);
     expect(driver.getDisplay()).toBe('inline-block');
   });
+
+  describe('custom color', () => {
+    const colorToPass = '#FF0000';
+    const colorToCheck = 'rgb(255, 0, 0)';
+
+    it('should be with default theme', () => {
+      const driver = createDriver(<TextLinkLayout color={colorToPass}/>);
+      expect(driver.getColor()).toBe(colorToCheck);
+    });
+
+    it('should be with custom theme', () => {
+      const driver = createDriver(<TextLinkLayout color={colorToPass} theme="greyScale"/>);
+      expect(driver.getColor()).toBe(colorToCheck);
+    });
+  });
 });
 
 describe('testkit', () => {


### PR DESCRIPTION
### What changed
Fixed ability to pass custom color to TextLink component

### Why it changed
It seems that it was working before changes provided in 3c6460ab1e62da51458e4c06ea3b3f6015be10a0
---

- [*] Change is tested
- [*] Change is documented
- [*] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
