### PR TITLE
Remove unsupported color prop from TextLink component (#1887)

### DIFF
--- a/src/BaseComponents/TextLink/TextLink.js
+++ b/src/BaseComponents/TextLink/TextLink.js
@@ -13,7 +13,6 @@ export default class BaseTextLink extends WixComponent {
     rel: PropTypes.string,
     target: PropTypes.string,
     ariaLabel: PropTypes.string,
-    color: PropTypes.string,
     onMouseEnter: PropTypes.func,
     onMouseLeave: PropTypes.func,
     onClick: PropTypes.func
@@ -50,7 +49,6 @@ export default class BaseTextLink extends WixComponent {
       role: 'link',
       style: {
         textDecoration: 'inherit',
-        color: this.props.color ? this.props.color : 'inherit',
         tabIndex: 0,
         display: 'inline-block'
       },


### PR DESCRIPTION
### What changed

Removed `color` prop of `TextLink` component

### Why it changed

Due to issue #1887 and corresponding discussion in https://github.com/wix/wix-style-react/pull/1905

---

- [*] Change is tested
- [*] Change is documented
- [*] Build is green
- [*] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
