### PR TITLE
<Icons /> - migration ColorPicker, CollapsedHeader

### DIFF
--- a/src/Backoffice/Button/Button.js
+++ b/src/Backoffice/Button/Button.js
@@ -84,4 +84,3 @@ class Button extends WixComponent {
 }
 
 export default withFocusable(Button);
-

--- a/src/Card/CollapsedHeader/CollapsedHeader.js
+++ b/src/Card/CollapsedHeader/CollapsedHeader.js
@@ -6,8 +6,8 @@ import Switch from '../../../src/ToggleSwitch';
 import WixComponent from '../../../src/BaseComponents/WixComponent';
 import Collapse from 'react-collapse';
 import Button from '../../../src/Button';
-import ArrowDownThin from '../../../src/Icons/dist/components/ArrowDownThin';
-import ArrowUpThin from '../../../src/Icons/dist/components/ArrowUpThin';
+import ChevronDown from '../../../new-icons/ChevronDown';
+import ChevronUp from '../../../new-icons/ChevronUp';
 
 class CollapsedHeader extends WixComponent {
   static propTypes = {
@@ -93,7 +93,7 @@ class CollapsedHeader extends WixComponent {
         <Button
           dataHook="button"
           height="medium"
-          prefixIcon={this.state.isCollapsed ? <ArrowDownThin/> : <ArrowUpThin/>}
+          prefixIcon={this.state.isCollapsed ? <ChevronDown/> : <ChevronUp/>}
           onClick={this.onToggleChange}
           theme="whiteblueprimary"
           type="button"

--- a/src/ColorPicker/color-picker-actions.js
+++ b/src/ColorPicker/color-picker-actions.js
@@ -2,18 +2,18 @@ import React from 'react';
 import {func} from 'prop-types';
 
 import Button from '../Button';
-import Close from '../Icons/dist/components/Close';
-import V from '../Icons/dist/components/V';
+import X from '../../new-icons/X';
+import Check from '../../new-icons/Check';
 
 import css from './color-picker-actions.scss';
 
 const ColorPickerActions = ({onCancel, onConfirm}) =>
   <div className={css.root}>
     <Button height="small" theme="icon-standardsecondary" onClick={onCancel}>
-      <Close size="12px"/>
+      <X/>
     </Button>
     <Button height="small" theme="icon-standard" onClick={onConfirm}>
-      <V size="12px"/>
+      <Check/>
     </Button>
   </div>;
 


### PR DESCRIPTION
### What changed

- migrated ColorPicker
- migrated Card/CollapsedHeader

### Why it changed

new icons migration

---

- [x] Change is tested
- [x] Change is documented
- [ ] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
