### PR TITLE
`<Card/>` - Add overflow: hidden

### DIFF
--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -1,12 +1,13 @@
 @import '../common.scss';
 
 .card {
-
   $border-radius: 8px;
-
+  
   background: $D80;
   border-radius: $border-radius;
+  overflow: hidden;
 }
+
 .stretch-vertically {
   height: 100%;
   flex-grow: 1;


### PR DESCRIPTION
When putting Table in a Card (without Card.Content),
 then row's white background overflows and we don't see the Card's rounded corners.