### PR TITLE
<MultiSelect/> - Fix thumb background color on hover bug

### DIFF
--- a/src/MultiSelect/InputWithTags.scss
+++ b/src/MultiSelect/InputWithTags.scss
@@ -4,6 +4,15 @@
   min-width: 30px;
 }
 
+// Override <Input>'s default focus style
+.input div {
+  border-color: transparent !important;
+}
+
+.input div:hover {
+  background-color: transparent !important;
+}
+
 .emptyInput {
   width: 100%;
 }
@@ -31,15 +40,6 @@
 
 .hasMaxHeight {
   overflow-y: auto;
-}
-
-// Override <Input>'s default focus style
-.tagsContainer div {
-  border-color: transparent !important;
-}
-
-.tagsContainer div:hover {
-  background-color: transparent !important;
 }
 
 .error {


### PR DESCRIPTION
### What changed

A piece of CSS in `MultiSelect/InputWithTags.scss` tried to override `<Input>`'s default focus style by applying the styles to every `<div>` within the component.

This PR fixes #1858 by applying the required styles to the the element containing the `<Input>` component.

### Why it changed

Fixed #1858.

---

- [ ] Change is tested
- [ ] Change is documented
- [ ] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
