### PR TITLE
<DropdownLayout/> - allow a divider option without an id

### DIFF
--- a/src/DropdownLayout/DropdownLayout.js
+++ b/src/DropdownLayout/DropdownLayout.js
@@ -219,7 +219,7 @@ class DropdownLayout extends WixComponent {
   renderOption({option, idx}) {
     const {value, id, disabled, title, overrideStyle, linkTo} = option;
     if (value === DIVIDER_OPTION_VALUE) {
-      return this.renderDivider(idx, `dropdown-divider-${id || idx}`);
+      return this.renderDivider(idx, `dropdown-item-${id || idx}`);
     }
 
     const content = this.renderItem({

--- a/src/DropdownLayout/DropdownLayout.js
+++ b/src/DropdownLayout/DropdownLayout.js
@@ -53,8 +53,18 @@ class DropdownLayout extends WixComponent {
   }
 
   isLegalOption(option) {
-    return typeof option === 'object' && typeof option.id !== 'undefined' && trim(option.id).length > 0 &&
-        (typeof option.value !== 'undefined') && (React.isValidElement(option.value) || (typeof option.value === 'string' && trim(option.value).length > 0));
+    if (typeof option !== 'object' || typeof option.value === 'undefined') {
+      return false;
+    }
+
+    if (option.value === DIVIDER_OPTION_VALUE) {
+      return true;
+    }
+
+    return typeof option.id !== 'undefined' && trim(option.id).length > 0 && (
+      React.isValidElement(option.value) ||
+      (typeof option.value === 'string' && trim(option.value).length > 0)
+    );
   }
 
   onClickOutside(event) {
@@ -209,7 +219,7 @@ class DropdownLayout extends WixComponent {
   renderOption({option, idx}) {
     const {value, id, disabled, title, overrideStyle, linkTo} = option;
     if (value === DIVIDER_OPTION_VALUE) {
-      return this.renderDivider(idx, `dropdown-item-${id}`);
+      return this.renderDivider(idx, `dropdown-divider-${id || idx}`);
     }
 
     const content = this.renderItem({
@@ -308,19 +318,26 @@ DropdownLayout.propTypes = {
   /** Callback function called whenever the user selects a different option in the list */
   onSelect: PropTypes.func,
   visible: PropTypes.bool,
-  /** Array of objects. Objects must have an Id and can can include value and node. If value is '-', a divider will be rendered instead. */
-  options: PropTypes.arrayOf(PropTypes.shape({
-    id: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number
-    ]).isRequired,
-    value: PropTypes.oneOfType([
-      PropTypes.node,
-      PropTypes.string
-    ]).isRequired,
-    disabled: PropTypes.bool,
-    overrideStyle: PropTypes.bool
-  })),
+  /** Array of objects. Objects must have an Id and can can include value and node. If value is '-', a divider will be rendered instead  (dividers do not require and id). */
+  options: PropTypes.arrayOf(PropTypes.oneOfType([
+    PropTypes.shape({
+      id: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number
+      ]).isRequired,
+      value: PropTypes.oneOfType([
+        PropTypes.node,
+        PropTypes.string
+      ]).isRequired,
+      disabled: PropTypes.bool,
+      overrideStyle: PropTypes.bool
+    }),
+
+    // A divider option without an id
+    PropTypes.shape({
+      value: PropTypes.oneOf([DIVIDER_OPTION_VALUE])
+    })
+  ])),
   /** The id of the selected option in the list  */
   selectedId: PropTypes.oneOfType([
     PropTypes.string,

--- a/src/DropdownLayout/DropdownLayout.spec.js
+++ b/src/DropdownLayout/DropdownLayout.spec.js
@@ -16,7 +16,8 @@ describe('DropdownLayout', () => {
     {id: 2, value: 'Option 3', disabled: true},
     {id: 3, value: 'Option 4'},
     {id: 'divider1', value: '-'},
-    {id: 'element1', value: <span style={{color: 'brown'}}>Option 4</span>}
+    {id: 'element1', value: <span style={{color: 'brown'}}>Option 4</span>},
+    {value: '-'}
   ];
 
   it('should have be invisible and drop down by default', () => {
@@ -82,11 +83,14 @@ describe('DropdownLayout', () => {
 
   it('should have options', () => {
     const driver = createDriver(<DropdownLayout visible options={options}/>);
-    expect(driver.optionsLength()).toBe(6);
+    expect(driver.optionsLength()).toBe(7);
     expect(driver.optionContentAt(0)).toBe('Option 1');
     expect(driver.isOptionADivider(4)).toBeTruthy();
-    expect(driver.optionByHook('dropdown-item-divider1').isDivider()).toBeTruthy();
+    expect(driver.optionByHook('dropdown-divider-divider1').isDivider()).toBeTruthy();
     expect(driver.optionContentAt(5)).toBe('Option 4');
+
+    expect(driver.isOptionADivider(6)).toBeTruthy();
+    expect(driver.optionByHook('dropdown-divider-6').isDivider()).toBeTruthy();
   });
 
   it('should not hover any option by default', () => {
@@ -376,7 +380,7 @@ describe('DropdownLayout', () => {
       const wrapper = div.appendChild(ReactTestUtils.renderIntoDocument(<div><DropdownLayout dataHook={dataHook} options={options}/></div>));
       const dropdownLayoutTestkit = dropdownLayoutTestkitFactory({wrapper, dataHook});
       expect(dropdownLayoutTestkit.exists()).toBeTruthy();
-      expect(dropdownLayoutTestkit.optionsLength()).toBe(6);
+      expect(dropdownLayoutTestkit.optionsLength()).toBe(7);
     });
   });
 
@@ -386,7 +390,7 @@ describe('DropdownLayout', () => {
       const wrapper = mount(<DropdownLayout dataHook={dataHook} options={options}/>);
       const dropdownLayoutTestkit = enzymeDropdownLayoutTestkitFactory({wrapper, dataHook});
       expect(dropdownLayoutTestkit.exists()).toBeTruthy();
-      expect(dropdownLayoutTestkit.optionsLength()).toBe(6);
+      expect(dropdownLayoutTestkit.optionsLength()).toBe(7);
     });
   });
 });

--- a/src/DropdownLayout/DropdownLayout.spec.js
+++ b/src/DropdownLayout/DropdownLayout.spec.js
@@ -86,11 +86,11 @@ describe('DropdownLayout', () => {
     expect(driver.optionsLength()).toBe(7);
     expect(driver.optionContentAt(0)).toBe('Option 1');
     expect(driver.isOptionADivider(4)).toBeTruthy();
-    expect(driver.optionByHook('dropdown-divider-divider1').isDivider()).toBeTruthy();
+    expect(driver.optionByHook('dropdown-item-divider1').isDivider()).toBeTruthy();
     expect(driver.optionContentAt(5)).toBe('Option 4');
 
     expect(driver.isOptionADivider(6)).toBeTruthy();
-    expect(driver.optionByHook('dropdown-divider-6').isDivider()).toBeTruthy();
+    expect(driver.optionByHook('dropdown-item-6').isDivider()).toBeTruthy();
   });
 
   it('should not hover any option by default', () => {


### PR DESCRIPTION
### What changed

* Allowing a divider option without an `id`
* Allow it also in the component propTypes
* ~~Dividers are rendered with a data hook that matches a different template: https://github.com/wix/wix-style-react/blob/6fa8072def153134c4c2610d64d0f86ace569d1f/src/DropdownLayout/DropdownLayout.js#L222~~
* Updated tests accordingly

### Why it changed

Fixes #1983.

---

- [ ] Change is tested
- [ ] Change is documented
- [ ] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
