### PR TITLE
`<Page/>` - Remove content jumping when minimization occurs

### DIFF
--- a/src/Page/Page.js
+++ b/src/Page/Page.js
@@ -178,9 +178,7 @@ class Page extends WixComponent {
     // fixedContainerHeight (and other heights) are calculated only when the Page is NOT minimized
     const {fixedContainerHeight, tailHeight, fixedContentHeight} = this.state;
 
-
     const minimizedFixedContainerHeight = PageTail ? fixedContainerHeight - 78 : fixedContainerHeight - (78 - TAIL_TOP_PADDING_PX);
-
     const headerContainerHeight = fixedContainerHeight - fixedContentHeight;
     const imageHeight = `${headerContainerHeight + (PageTail ? -tailHeight : 39)}px`;
     const gradientHeight = gradientCoverTail ? `${headerContainerHeight + (PageTail ? -SCROLL_TOP_THRESHOLD : 39)}px` : imageHeight;
@@ -270,7 +268,7 @@ class Page extends WixComponent {
           onScroll={this._handleScroll}
           data-hook="page-scrollable-content"
           data-class="page-scrollable-content"
-          style={{paddingTop: `${minimized ? minimizedFixedContainerHeight : fixedContainerHeight}px`}}
+          style={{paddingTop: `${fixedContainerHeight}px`}}
           ref={r => this.scrollableContentRef = r}
           >
           {


### PR DESCRIPTION
It was a feature to avoid a large "gap" between the content and the minimized header.

I suggested that the "gap" is reasonable, and the jumping of the content is NOT reasonable and is bad experience for the user.
Image a user reading a sentence on the bottom part of the screen, and then scrolling a bit to see the rest of the sentence, and suddenly the paragraph jumps and he needs to re-orient himself.

Anyways, when the use scrolls down, his eyes are focused on the bottom part of the screen, I don't think they notice a that gap, which anyways disappears usually fast when user scrolls a bit further.

@milkyfruit agreed with me.