### PR TITLE
<MessageBoxFunctionalLayout/> - add footer border for scrollable content

### DIFF
--- a/src/MessageBox/FooterLayout.js
+++ b/src/MessageBox/FooterLayout.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Button from '../Backoffice/Button';
 import * as styles from './FooterLayout.scss';
-import classNames from 'classnames';
 
 const FooterLayout = ({
   bottomChildren,
@@ -14,14 +13,10 @@ const FooterLayout = ({
   confirmText,
   buttonsHeight,
   enableOk,
-  enableCancel,
-  withTopPadding
+  enableCancel
 }) =>
   <div>
-    <div
-      className={classNames(styles.footer, {[styles.withTopPadding]: withTopPadding})}
-      data-hook="message-box-footer"
-      >
+    <div className={styles.footer} data-hook="message-box-footer">
       {children}
 
       <div className={styles.footerbuttons}>
@@ -66,16 +61,14 @@ FooterLayout.propTypes = {
   theme: PropTypes.string,
   buttonsHeight: PropTypes.string,
   children: PropTypes.any,
-  bottomChildren: PropTypes.node,
-  withTopPadding: PropTypes.bool
+  bottomChildren: PropTypes.node
 };
 
 FooterLayout.defaultProps = {
   theme: 'blue',
   buttonsHeight: 'small',
   enableOk: true,
-  enableCancel: true,
-  withTopPadding: false
+  enableCancel: true
 };
 
 export default FooterLayout;

--- a/src/MessageBox/FooterLayout.scss
+++ b/src/MessageBox/FooterLayout.scss
@@ -1,13 +1,9 @@
 @import '../common.scss';
 
 .footer {
-  padding: 0 30px 30px;
+  padding: 30px;
   display: flex;
   align-items: center;
-
-  &.withTopPadding {
-    padding-top: 30px;
-  }
 }
 
 .bottomChildren{

--- a/src/MessageBox/FooterLayout.scss
+++ b/src/MessageBox/FooterLayout.scss
@@ -13,7 +13,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 10px 30px 14px 30px;
+  padding: 12px 30px;
   margin-top: -12px;
   box-sizing: border-box;
 }

--- a/src/MessageBox/HeaderLayout.scss
+++ b/src/MessageBox/HeaderLayout.scss
@@ -4,8 +4,8 @@
 {
     @include FontLight();
     box-sizing:border-box;
-    min-height      : 57px;
-    padding         : 16px 18px;
+    min-height      : 60px;
+    padding         : 18px;
     padding-left    : 30px;
     font-weight     : normal;
     font-size       : 20px;

--- a/src/MessageBox/MessageBox.e2e.js
+++ b/src/MessageBox/MessageBox.e2e.js
@@ -1,6 +1,6 @@
 import eyes from 'eyes.it';
 import {createStoryUrl, waitForVisibilityOf, scrollToElement} from '../../test/utils/protractor';
-import {buttonTestkitFactory} from '../../testkit/protractor';
+import {buttonTestkitFactory, messageBoxFunctionalLayoutTestkitFactory} from '../../testkit/protractor';
 
 const byDataHook = dataHook => $(`[data-hook="${dataHook}"]`);
 
@@ -25,6 +25,24 @@ describe('MessageBox', () => {
       await verifyItem(secondary);
       await verifyItem(footnote);
       await verifyItem(scrollable);
+    });
+
+    eyes.it('should show footer border for scrollable modal and hide the border when scroll is on the bottom', async () => {
+      const storyUrl = createStoryUrl({kind: '9. Modals', story: '9.1 Alert'});
+      await browser.get(storyUrl);
+      await verifyItem(scrollable);
+
+      const driver = messageBoxFunctionalLayoutTestkitFactory({dataHook: scrollable});
+      const SMALL_SCROLL_OFFSET = 50;
+      const MAX_SCROLL_OFFSET = 500;
+
+      expect(await driver.toHaveFooterBorder()).toBe(true);
+
+      await (driver.scrollBodyDown(SMALL_SCROLL_OFFSET));
+      expect(await driver.toHaveFooterBorder()).toBe(true);
+
+      await (driver.scrollBodyDown(MAX_SCROLL_OFFSET));
+      expect(await driver.toHaveFooterBorder()).toBe(false);
     });
   });
 

--- a/src/MessageBox/MessageBoxFunctionalLayout.js
+++ b/src/MessageBox/MessageBoxFunctionalLayout.js
@@ -4,10 +4,44 @@ import HeaderLayout from './HeaderLayout';
 import FooterLayout from './FooterLayout';
 import WixComponent from '../BaseComponents/WixComponent';
 import classNames from 'classnames';
+import throttle from 'lodash/throttle';
 
 import styles from './MessageBoxFunctionalLayout.scss';
 
 class MessageBoxFunctionalLayout extends WixComponent {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      hasScroll: false,
+      scrolledToBottom: false
+    };
+    this.messageBoxRef = null;
+  }
+
+  componentWillUnmount() {
+    if (this.state.hasScroll) {
+      this.messageBoxRef.removeEventListener('scroll', this._handleMessageBoxScroll);
+    }
+  }
+
+  _initializeMessageBoxRef = el => {
+    if (el && el.scrollHeight > el.clientHeight) {
+      this.setState({hasScroll: true});
+
+      this.messageBoxRef = el;
+      this.messageBoxRef.addEventListener('scroll', this._handleMessageBoxScroll);
+    }
+  };
+
+  _handleMessageBoxScroll = throttle(() => {
+    const scrolledToBottom =
+      this.messageBoxRef.scrollTop + this.messageBoxRef.clientHeight === this.messageBoxRef.scrollHeight;
+
+      if (scrolledToBottom !== this.state.scrolledToBottom) {
+        this.setState({scrolledToBottom});
+      }
+    }, 16);
 
   render() {
     const {
@@ -30,6 +64,7 @@ class MessageBoxFunctionalLayout extends WixComponent {
       maxHeight,
       fullscreen
     } = this.props;
+    const {hasScroll, scrolledToBottom} = this.state;
 
 
     const messageBoxBodyClassNames = classNames(
@@ -37,7 +72,9 @@ class MessageBoxFunctionalLayout extends WixComponent {
       {
         [styles.scrollable]: typeof maxHeight !== 'undefined',
         [styles.noPadding]: noBodyPadding,
-        [styles.fullscreenBody]: fullscreen
+        [styles.fullscreenBody]: fullscreen,
+        [styles.noFooter]: hideFooter,
+        [styles.footerBorder]: hasScroll && !scrolledToBottom
       }
     );
     const messageBoxBodyStyle = {
@@ -58,6 +95,7 @@ class MessageBoxFunctionalLayout extends WixComponent {
           data-hook="message-box-body"
           className={messageBoxBodyClassNames}
           style={messageBoxBodyStyle}
+          ref={this._initializeMessageBoxRef}
           >
           {children}
         </div>

--- a/src/MessageBox/MessageBoxFunctionalLayout.js
+++ b/src/MessageBox/MessageBoxFunctionalLayout.js
@@ -38,10 +38,10 @@ class MessageBoxFunctionalLayout extends WixComponent {
     const scrolledToBottom =
       this.messageBoxRef.scrollTop + this.messageBoxRef.clientHeight === this.messageBoxRef.scrollHeight;
 
-      if (scrolledToBottom !== this.state.scrolledToBottom) {
-        this.setState({scrolledToBottom});
-      }
-    }, 16);
+    if (scrolledToBottom !== this.state.scrolledToBottom) {
+      this.setState({scrolledToBottom});
+    }
+  }, 16);
 
   render() {
     const {

--- a/src/MessageBox/MessageBoxFunctionalLayout.protractor.driver.js
+++ b/src/MessageBox/MessageBoxFunctionalLayout.protractor.driver.js
@@ -1,0 +1,17 @@
+import styles from './MessageBoxFunctionalLayout.scss';
+
+const messageBoxFunctionalLayoutDriverFactory = component => {
+  const body = () => component.$('[data-hook="message-box-body"]');
+
+  return {
+    element: () => component,
+    toHaveFooterBorder: async () => {
+      const bodyClassNames = await body().getAttribute('class');
+      return bodyClassNames.includes(styles.footerBorder);
+    },
+    scrollBodyDown: async offset =>
+      browser.executeScript(`arguments[0].scrollTop = ${offset};`, await body().getWebElement())
+  };
+};
+
+export default messageBoxFunctionalLayoutDriverFactory;

--- a/src/MessageBox/MessageBoxFunctionalLayout.scss
+++ b/src/MessageBox/MessageBoxFunctionalLayout.scss
@@ -23,8 +23,12 @@ $minimum-modal-margin: 48px;
   color: $paletteD2;
   font-size: 16px;
   line-height: 24px;
-  padding: 36px 30px 42px 30px;
+  padding: 36px 30px 12px 30px;
   box-sizing: border-box;
+
+  &.no-padding {
+    padding: 0;
+  }
 }
 
 .fullscreen-body {
@@ -35,8 +39,12 @@ $minimum-modal-margin: 48px;
 .scrollable {
   @include default-scroll-bar;
   overflow-y: auto;
+
+  &.footer-border:not(.no-footer) {
+    border-bottom: 1px solid $D60;
+  }
 }
 
-.no-padding {
-  padding: 0;
+.no-footer {
+  padding-bottom: 42px;
 }

--- a/src/ModalSelectorLayout/ModalSelectorLayout.js
+++ b/src/ModalSelectorLayout/ModalSelectorLayout.js
@@ -352,7 +352,6 @@ export default class ModalSelectorLayout extends WixComponent {
 
     return (
       <FooterLayout
-        withTopPadding={isLoaded}
         onCancel={onCancel}
         onOk={() => onOk(multiple ? enabledItems : enabledItems[0])}
         cancelText={cancelButtonText}

--- a/src/ModalSelectorLayout/ModalSelectorLayout.js
+++ b/src/ModalSelectorLayout/ModalSelectorLayout.js
@@ -335,10 +335,7 @@ export default class ModalSelectorLayout extends WixComponent {
     items.filter(({disabled}) => !disabled);
 
   _renderFooter = () => {
-    const {
-      isLoaded,
-      selectedItems
-    } = this.state;
+    const {selectedItems} = this.state;
 
     const {
       onCancel,

--- a/testkit/protractor.js
+++ b/testkit/protractor.js
@@ -135,6 +135,9 @@ export const tooltipTestkitFactory = protractorTestkitFactoryCreator(tooltipDriv
 import formFieldDriverFactory from '../src/FormField/FormField.protractor.driver';
 export const formFieldTestkitFactory = protractorTestkitFactoryCreator(formFieldDriverFactory);
 
+import messageBoxFunctionalLayoutDriverFactory from '../src/MessageBox/MessageBoxFunctionalLayout.protractor.driver';
+export const messageBoxFunctionalLayoutTestkitFactory = protractorTestkitFactoryCreator(messageBoxFunctionalLayoutDriverFactory);
+
 // wix-ui-backoffice proxy
 
 export {


### PR DESCRIPTION
### What changed

Added correct footer behavior for scrollable content in `<MessageBoxFunctionalLayout/>`

### Why it changed

By design. https://app.zeplin.io/project/5864e02695b5754a69f56150/screen/58d3b8c1d8b7910f2f5d65bf

---

- [ ] Change is tested
- [ ] Change is documented
- [ ] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

