### PR TITLE
set notification to a fixed size

### DIFF
--- a/src/Notification/Notification.scss
+++ b/src/Notification/Notification.scss
@@ -11,6 +11,7 @@
   justify-content: center;
   overflow: hidden;
   padding: 12px;
+  height: 48px;
 }
 
 .label {


### PR DESCRIPTION

### What changed
Set Notification size to a fixed 48px


### Why it changed
This makes the button CTA Notification the same size as the other notifications. this also protects against the bug that too-long CTA text might stretch the notification indefinitely

...

---

- [V ] Change is tested
- [ ] Change is documented
- [V ] Build is green

### Thanks for contributing :)
