### PR TITLE
<Checkbox>. Increasing e2e speed. 

### DIFF
--- a/src/Checkbox/Checkbox.e2e.js
+++ b/src/Checkbox/Checkbox.e2e.js
@@ -7,7 +7,7 @@ import {runFocusTests} from '../common/Focusable/FocusableTestsE2E';
 
 const NO_DESCRIPTION = '';
 
-fdescribe('Checkbox', () => {
+describe('Checkbox', () => {
   const storyUrl = getStoryUrl('4. Selection', '4.2 Checkbox');
   const checkboxDriver = checkboxTestkitFactory({dataHook: 'storybook-checkbox'});
 

--- a/src/Checkbox/Checkbox.e2e.js
+++ b/src/Checkbox/Checkbox.e2e.js
@@ -70,7 +70,6 @@ describe('Checkbox', () => {
 
       eyes.it('should be disabled', async () => {
         expect(checkboxDriver.isDisabled()).toBe(true);
-        expect(checkboxDriver.isFocused()).toBe(false);
       });
 
       eyes.it('should not be focusable', async () => {

--- a/src/Checkbox/Checkbox.e2e.js
+++ b/src/Checkbox/Checkbox.e2e.js
@@ -16,16 +16,13 @@ describe('Checkbox', () => {
     const waitForCheckbox = () => waitForVisibilityOf(checkboxDriver.element(), 'Cannot find Checkbox');
     const clickTab = () => browser.actions().sendKeys(protractor.Key.TAB).perform();
 
-    beforeEach(async () => {
-      // TODO: We do browser.get() before EACH test in order to reset the focus.
-      // implmement a generic solution in AutoExampleDriver that will do
-      // propper reset of the focus, so we don't have to get the page,
-      // and thus the test will run faster.
+    beforeAll(async () => {
       await browser.get(storyUrl);
-
-      // No need for reset as long as we do browser.get() before each test.
-      // await autoExampleDriver.reset();
       await waitForCheckbox();
+    });
+
+    beforeEach(async () => {
+      await autoExampleDriver.remount();
     });
 
     eyes.it('should have default props', async () => {
@@ -42,6 +39,7 @@ describe('Checkbox', () => {
     });
 
     eyes.it('should show focused styles', async () => {
+
       expect(checkboxDriver.isFocused()).toBe(false);
       await clickTab();
       expect(checkboxDriver.isFocused()).toBe(true);
@@ -73,6 +71,7 @@ describe('Checkbox', () => {
 
       eyes.it('should be disabled', async () => {
         expect(checkboxDriver.isDisabled()).toBe(true);
+        expect(checkboxDriver.isFocused()).toBe(false);
       });
 
       eyes.it('should not be focusable', async () => {

--- a/src/Checkbox/Checkbox.e2e.js
+++ b/src/Checkbox/Checkbox.e2e.js
@@ -7,7 +7,7 @@ import {runFocusTests} from '../common/Focusable/FocusableTestsE2E';
 
 const NO_DESCRIPTION = '';
 
-describe('Checkbox', () => {
+fdescribe('Checkbox', () => {
   const storyUrl = getStoryUrl('4. Selection', '4.2 Checkbox');
   const checkboxDriver = checkboxTestkitFactory({dataHook: 'storybook-checkbox'});
 
@@ -21,7 +21,7 @@ describe('Checkbox', () => {
       await waitForCheckbox();
     });
 
-    beforeEach(async () => {
+    afterEach(async () => {
       await autoExampleDriver.remount();
     });
 
@@ -39,7 +39,6 @@ describe('Checkbox', () => {
     });
 
     eyes.it('should show focused styles', async () => {
-
       expect(checkboxDriver.isFocused()).toBe(false);
       await clickTab();
       expect(checkboxDriver.isFocused()).toBe(true);

--- a/src/common/Focusable/FocusableTestsE2E.js
+++ b/src/common/Focusable/FocusableTestsE2E.js
@@ -1,5 +1,4 @@
-import {waitForVisibilityOf} from 'wix-ui-test-utils/protractor';
-import {flattenInternalDriver} from '../../../test/utils/private-drivers';
+import {waitForVisibilityOf, flattenInternalDriver} from '../../test-common';
 import autoExampleDriver from 'wix-storybook-utils/AutoExampleDriver';
 
 /**
@@ -68,6 +67,9 @@ function runFocusTestsImpl(driver, storyUrl) {
     beforeAll(async () => {
       await browser.get(storyUrl);
       await waitForVisibilityOf(driver.element(), 'Cannot find element');
+    });
+    beforeEach(async () => {
+      autoExampleDriver.remount();
     });
 
     beforeEach(() => autoExampleDriver.remount());

--- a/src/common/Focusable/FocusableTestsE2E.js
+++ b/src/common/Focusable/FocusableTestsE2E.js
@@ -1,4 +1,5 @@
-import {waitForVisibilityOf, flattenInternalDriver} from '../../test-common';
+import {waitForVisibilityOf} from 'wix-ui-test-utils/protractor';
+import {flattenInternalDriver} from '../../../test/utils/private-drivers';
 import autoExampleDriver from 'wix-storybook-utils/AutoExampleDriver';
 
 /**
@@ -68,8 +69,7 @@ function runFocusTestsImpl(driver, storyUrl) {
       await browser.get(storyUrl);
       await waitForVisibilityOf(driver.element(), 'Cannot find element');
     });
-
-    afterEach(async () => {
+    beforeEach(async () => {
       autoExampleDriver.remount();
     });
 

--- a/src/common/Focusable/FocusableTestsE2E.js
+++ b/src/common/Focusable/FocusableTestsE2E.js
@@ -69,9 +69,6 @@ function runFocusTestsImpl(driver, storyUrl) {
       await browser.get(storyUrl);
       await waitForVisibilityOf(driver.element(), 'Cannot find element');
     });
-    beforeEach(async () => {
-      autoExampleDriver.remount();
-    });
 
     beforeEach(() => autoExampleDriver.remount());
 

--- a/src/common/Focusable/FocusableTestsE2E.js
+++ b/src/common/Focusable/FocusableTestsE2E.js
@@ -68,7 +68,8 @@ function runFocusTestsImpl(driver, storyUrl) {
       await browser.get(storyUrl);
       await waitForVisibilityOf(driver.element(), 'Cannot find element');
     });
-    beforeEach(async () => {
+
+    afterEach(async () => {
       autoExampleDriver.remount();
     });
 


### PR DESCRIPTION
Adding new autoexample method remount() which unmounts the whole component from DOM. Increased speed locally from 18s to 5s ( > 3x). 

P.S. Tests in tc are failing because of eyes.it. Previously eyes.it was used with beforeEach() where it takes screenshot on rendered component. 