### PR TITLE
<RichTextEditor>. Increasing e2e speed.

### DIFF
--- a/src/RichTextArea/RichTextArea.e2e.js
+++ b/src/RichTextArea/RichTextArea.e2e.js
@@ -13,6 +13,7 @@ describe('RichTextArea', () => {
 
   const pressTab = times => browser.actions().sendKeys([...Array(times)].map(() => protractor.Key.TAB)).perform();
   const focusEditor = () => pressTab(EDITOR_TAB_ORDINAL);
+  const mouseDown = () => browser.actions().mouseMove({x: 0, y: 0});
 
   beforeAll(() => {
     browser.get(storyUrl);
@@ -144,6 +145,7 @@ describe('RichTextArea', () => {
       expect(await richTextAreaTestkit.isEditorFocused()).toBe(false);
       await focusEditor();
       expect(await richTextAreaTestkit.isEditorFocused()).toBe(true);
+      mouseDown();
     });
 
     eyes.it('should show focus styles for each button', async () => {
@@ -153,6 +155,7 @@ describe('RichTextArea', () => {
         expect(await richTextAreaTestkit.isButtonFocused(index)).toBe(false);
         await pressTab(1);
         expect(await richTextAreaTestkit.isButtonFocused(index)).toBe(true);
+        mouseDown();
         await eyes.checkWindow(`Button ${type}`);
       }
     });

--- a/src/RichTextArea/RichTextArea.e2e.js
+++ b/src/RichTextArea/RichTextArea.e2e.js
@@ -143,6 +143,8 @@ describe('RichTextArea', () => {
       await autoExampleDriver.setProps({error: true});
     });
 
+    afterEach(async () => await autoExampleDriver.remount());
+
     eyes.it('should show focus styles for editor', async () => {
       expect(await richTextAreaTestkit.isEditorFocused()).toBe(false);
       await focusEditor();

--- a/src/RichTextArea/RichTextArea.e2e.js
+++ b/src/RichTextArea/RichTextArea.e2e.js
@@ -20,8 +20,6 @@ describe('RichTextArea', () => {
 
   beforeEach(async () => {
     await waitForVisibilityOf(richTextAreaTestkit.element());
-    await autoExampleDriver.reset();
-    await autoExampleDriver.remount();
   });
 
   afterEach(async () => {

--- a/src/RichTextArea/RichTextArea.e2e.js
+++ b/src/RichTextArea/RichTextArea.e2e.js
@@ -14,15 +14,15 @@ describe('RichTextArea', () => {
   const pressTab = times => browser.actions().sendKeys([...Array(times)].map(() => protractor.Key.TAB)).perform();
   const focusEditor = () => pressTab(EDITOR_TAB_ORDINAL);
 
-  // TODO: We can change this to beforeAll (to make the test go faster),
-  // after we have a way to reset the focus before Each test.
-  beforeEach(() => {
+  beforeAll(() => {
     browser.get(storyUrl);
   });
 
   beforeEach(async () => {
     await waitForVisibilityOf(richTextAreaTestkit.element());
   });
+
+  afterEach(async () => await autoExampleDriver.remount());
 
   eyes.it('should render default props', async () => {
     expect(richTextAreaTestkit.isEditorFocused()).toBe(false, 'isEditorFocused');

--- a/src/RichTextArea/RichTextArea.e2e.js
+++ b/src/RichTextArea/RichTextArea.e2e.js
@@ -13,7 +13,6 @@ describe('RichTextArea', () => {
 
   const pressTab = times => browser.actions().sendKeys([...Array(times)].map(() => protractor.Key.TAB)).perform();
   const focusEditor = () => pressTab(EDITOR_TAB_ORDINAL);
-  const mouseDown = () => browser.actions().mouseMove({x: 0, y: 0});
 
   beforeAll(() => {
     browser.get(storyUrl);
@@ -148,7 +147,6 @@ describe('RichTextArea', () => {
       expect(await richTextAreaTestkit.isEditorFocused()).toBe(false);
       await focusEditor();
       expect(await richTextAreaTestkit.isEditorFocused()).toBe(true);
-      mouseDown();
     });
 
     eyes.it('should show focus styles for each button', async () => {
@@ -158,7 +156,6 @@ describe('RichTextArea', () => {
         expect(await richTextAreaTestkit.isButtonFocused(index)).toBe(false);
         await pressTab(1);
         expect(await richTextAreaTestkit.isButtonFocused(index)).toBe(true);
-        mouseDown();
         await eyes.checkWindow(`Button ${type}`);
       }
     });

--- a/src/RichTextArea/RichTextArea.e2e.js
+++ b/src/RichTextArea/RichTextArea.e2e.js
@@ -20,6 +20,8 @@ describe('RichTextArea', () => {
 
   beforeEach(async () => {
     await waitForVisibilityOf(richTextAreaTestkit.element());
+    await autoExampleDriver.reset();
+    await autoExampleDriver.remount();
   });
 
   afterEach(async () => {
@@ -142,8 +144,6 @@ describe('RichTextArea', () => {
     beforeEach(async () => {
       await autoExampleDriver.setProps({error: true});
     });
-
-    afterEach(async () => await autoExampleDriver.remount());
 
     eyes.it('should show focus styles for editor', async () => {
       expect(await richTextAreaTestkit.isEditorFocused()).toBe(false);

--- a/src/RichTextArea/RichTextArea.e2e.js
+++ b/src/RichTextArea/RichTextArea.e2e.js
@@ -23,7 +23,10 @@ describe('RichTextArea', () => {
     await waitForVisibilityOf(richTextAreaTestkit.element());
   });
 
-  afterEach(async () => await autoExampleDriver.remount());
+  afterEach(async () => {
+    await autoExampleDriver.reset();
+    await autoExampleDriver.remount();
+  });
 
   eyes.it('should render default props', async () => {
     expect(richTextAreaTestkit.isEditorFocused()).toBe(false, 'isEditorFocused');


### PR DESCRIPTION
Some eyes.it tests are failing because coponent.click() on adding a link leaves hover effect on the editor. Previously the whole page refresh eliminated this effect. I think there shouldn't be any implementations done for disabling this hove as it does not effect the test itself. 

Another way of course is to figure out how to improve remount() method in autoexample.