### PR TITLE
<InputArea/> - pass event for on focus handler

### DIFF
--- a/src/InputArea/InputArea.js
+++ b/src/InputArea/InputArea.js
@@ -125,9 +125,9 @@ class InputArea extends WixComponent {
     this.textArea && this.textArea.select();
   }
 
-  _onFocus() {
+  _onFocus(e) {
     this.setState({focus: true});
-    this.props.onFocus && this.props.onFocus();
+    this.props.onFocus && this.props.onFocus(e);
 
     if (this.props.autoSelect) {
       // Set timeout is needed here since onFocus is called before react


### PR DESCRIPTION
### What changed

<InputArea/> - pass event for on focus handler

### Why it changed

Using for <FormField/> component, I am using focus target value to calculate characters left.
<Input/> field passes the event, <InputArea/> does not, but it should.

---

- [x] Change is tested
- [x] Change is documented
- [x] Build is green
- [x] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)
