### PR TITLE
Fix issue with tooltip #2113

### DIFF
--- a/.storybook/stories.js
+++ b/.storybook/stories.js
@@ -136,3 +136,4 @@ import '../stories/SideBar';
 
 // Tests
 import '../stories/Page/PageTestStories.js'; // Tests/2.5 + Page/
+import '../stories/Tooltip/Composite/PopoverMenuRegressionTest.js'; // Tests/7.3. Popover Menu/

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "highlight.js": "^9.8.0",
     "identity-obj-proxy": "^3.0.0",
     "import-path": "^1.0.0",
+    "protractor-browser-logs": "^1.0.351",
     "react": "^15.5.4",
     "react-docgen": "^2.15.0",
     "react-dom": "^15.5.4",

--- a/src/PopoverMenu/PopoverMenu.e2e.js
+++ b/src/PopoverMenu/PopoverMenu.e2e.js
@@ -1,3 +1,4 @@
+import browserLogs from 'protractor-browser-logs';
 import {
   POPOVER_MENU_DATA_HOOK,
   POPOVER_MENU_ITEM_DATA_HOOK
@@ -12,12 +13,18 @@ import {getStoryUrl} from '../../test/utils/storybook-helpers';
 describe('PopoverMenu', () => {
   const storyUrl = getStoryUrl('7. Tooltips', '7.3. Popover Menu');
   let driver;
+  const logs = browserLogs(browser);
 
   beforeEach(() => {
+    logs.reset();
+    logs.ignore(message => message.message.indexOf('Uncaught') === -1);
+
     driver = popoverMenuTestkitFactory({dataHook: POPOVER_MENU_DATA_HOOK})
       .init.menuItemDataHook(POPOVER_MENU_ITEM_DATA_HOOK);
     browser.get(storyUrl);
   });
+
+  afterEach(() => logs.verify());
 
   it('should show popover menu', () => {
     waitForVisibilityOf(driver.element(), 'Can not find PopoverMenu trigger element').then(() => {
@@ -40,6 +47,38 @@ describe('PopoverMenu', () => {
           'PopoverMenu has not been hidden after menu item click',
         );
       });
+    });
+  });
+
+  describe('regression tests', () => {
+    it('Uncaught TypeError: https://github.com/wix/wix-style-react/issues/2113', async () => {
+      const storyUrl = getStoryUrl('Tests/7. Tooltip', '7.3. Popover Menu');
+      await browser.get(storyUrl);
+
+      driver = popoverMenuTestkitFactory({dataHook: 'popover-0'})
+        .init.menuItemDataHook('popover-item-0');
+
+      await waitForVisibilityOf(driver.element());
+
+      driver.click();
+
+      await waitForVisibilityOf(driver.menu.element());
+
+      driver.menu.clickItemAt(0);
+
+      await browser.wait(
+        EC.stalenessOf(driver.menu.element()),
+        5000,
+        'PopoverMenu has not been hidden after menu item click',
+      );
+
+      await browser.wait(
+        EC.stalenessOf(driver.element()),
+        5000,
+        'PopoverMenu has not been removed after menu item click',
+      );
+
+      return logs.expect(/Uncaught TypeError: Cannot read property 'parentElement' of null/);
     });
   });
 });

--- a/src/PopoverMenu/PopoverMenu.e2e.js
+++ b/src/PopoverMenu/PopoverMenu.e2e.js
@@ -58,11 +58,11 @@ describe('PopoverMenu', () => {
 
       await waitForVisibilityOf(driver.element());
 
-      driver.click();
+      await driver.click();
 
       await waitForVisibilityOf(driver.menu.element());
 
-      driver.menu.clickItemAt(0);
+      await driver.menu.clickItemAt(0);
 
       await browser.wait(
         EC.stalenessOf(driver.menu.element()),

--- a/src/PopoverMenu/PopoverMenu.e2e.js
+++ b/src/PopoverMenu/PopoverMenu.e2e.js
@@ -81,7 +81,7 @@ describe('PopoverMenu', () => {
         .then(() => {
           fail('Expected error occurred');
         })
-        .catch((e) => {
+        .catch(e => {
           expect(e.message).toContain('NO MESSAGE TO EXPECT');
         });
     });

--- a/src/PopoverMenu/PopoverMenu.e2e.js
+++ b/src/PopoverMenu/PopoverMenu.e2e.js
@@ -24,8 +24,6 @@ describe('PopoverMenu', () => {
     browser.get(storyUrl);
   });
 
-  afterEach(() => logs.verify());
-
   it('should show popover menu', () => {
     waitForVisibilityOf(driver.element(), 'Can not find PopoverMenu trigger element').then(() => {
       driver.click();
@@ -78,7 +76,14 @@ describe('PopoverMenu', () => {
         'PopoverMenu has not been removed after menu item click',
       );
 
-      return logs.expect(/Uncaught TypeError: Cannot read property 'parentElement' of null/);
+      logs.expect(/Uncaught TypeError: Cannot read property 'parentElement' of null/);
+      await logs.verify()
+        .then(() => {
+          fail('Expected error occurred');
+        })
+        .catch((e) => {
+          expect(e.message).toContain('NO MESSAGE TO EXPECT');
+        });
     });
   });
 });

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -224,7 +224,7 @@ class Tooltip extends WixComponent {
           textAlign={this.props.textAlign}
           lineHeight={this.props.lineHeight}
           color={this.props.color}
-        >
+          >
           {this.props.content}
         </TooltipContent>);
 

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -165,6 +165,7 @@ class Tooltip extends WixComponent {
   componentWillUnmount() {
     super.componentWillUnmount && super.componentWillUnmount();
     this._unmounted = true;
+    this._removeNode();
     this._getContainer() && this.hide();
 
     if (this._showInterval) {
@@ -223,7 +224,7 @@ class Tooltip extends WixComponent {
           textAlign={this.props.textAlign}
           lineHeight={this.props.lineHeight}
           color={this.props.color}
-          >
+        >
           {this.props.content}
         </TooltipContent>);
 
@@ -337,18 +338,11 @@ class Tooltip extends WixComponent {
 
     if (this.state.visible) {
       const hideLazy = () => {
-        if (this._mountNode) {
-          ReactDOM.unmountComponentAtNode(this._mountNode);
-          props.onHide && props.onHide();
-          const container = this._getContainer();
-          if (container) {
-            container.removeChild(this._mountNode);
-            container.removeEventListener('scroll', this._containerScrollHandler);
-          }
-          this._mountNode = null;
-        }
+        props.onHide && props.onHide();
+
         this._hideTimeout = null;
         if (!this._unmounted) {
+          this._removeNode();
           this.setState({visible: false});
         }
       };
@@ -360,6 +354,19 @@ class Tooltip extends WixComponent {
       this._hideTimeout = setTimeout(hideLazy, props.hideDelay);
     }
   };
+
+  _removeNode() {
+    if (this._mountNode) {
+      ReactDOM.unmountComponentAtNode(this._mountNode);
+
+      const container = this._getContainer();
+      if (container) {
+        container.removeChild(this._mountNode);
+        container.removeEventListener('scroll', this._containerScrollHandler);
+      }
+      this._mountNode = null;
+    }
+  }
 
   _hideOrShow(event) {
     if (this.props.hideTrigger === event && !this.state.hidden) {

--- a/src/Tooltip/Tooltip.spec.js
+++ b/src/Tooltip/Tooltip.spec.js
@@ -443,12 +443,11 @@ describe('Tooltip', () => {
     });
   });
 
-  describe('regression tests', function () {
-
+  describe('regression tests', () => {
 
     it('should not throw an error when call "hide" method and then unmount', () => {
-      // Link to the issue https://github.com/wix/wix-style-react/issues/2113
-      const wrapper = mount(<div><Tooltip {..._props} appendToParent hideDelay={0}>{children}</Tooltip></div>, {
+      const dataHook = 'myDataHook';
+      const wrapper = mount(<div><Tooltip dataHook={dataHook} {..._props} appendToParent hideDelay={0}>{children}</Tooltip></div>, {
         attachTo: document.body.appendChild(document.createElement('div'))
       });
       const driver = enzymeTooltipTestkitFactory({wrapper, dataHook});

--- a/src/Tooltip/Tooltip.spec.js
+++ b/src/Tooltip/Tooltip.spec.js
@@ -442,43 +442,6 @@ describe('Tooltip', () => {
       });
     });
   });
-
-  describe('regression tests', () => {
-
-    it('should not throw an error when call "hide" method and then unmount', () => {
-      const dataHook = 'myDataHook';
-      const wrapper = mount(<div><Tooltip dataHook={dataHook} {..._props} appendToParent hideDelay={0}>{children}</Tooltip></div>, {
-        attachTo: document.body.appendChild(document.createElement('div'))
-      });
-      const driver = enzymeTooltipTestkitFactory({wrapper, dataHook});
-      driver.mouseEnter();
-
-      return resolveIn(30).then(() => {
-        const tooltipComponent = wrapper.find(Tooltip).instance();
-
-        // we need to patch it due to _getContainer is using inside setTimeout
-        // and we can't catch an async err outside
-        const _getContainer = tooltipComponent._getContainer.bind(tooltipComponent);
-        let isError = false;
-        tooltipComponent._getContainer = () => {
-          try {
-            return _getContainer();
-          } catch (e) {
-            isError = true;
-          }
-        };
-
-        tooltipComponent.hide();
-        wrapper.unmount();
-
-        return resolveIn(10).then(() => {
-          expect(isError).toBeFalsy();
-
-          return resolveIn(10);
-        });
-      });
-    });
-  });
 });
 
 function resolveIn(timeout) {

--- a/stories/Tooltip/Composite/PopoverMenuRegressionTest.js
+++ b/stories/Tooltip/Composite/PopoverMenuRegressionTest.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import {storiesOf} from '@storybook/react';
+
+import PopoverMenu from 'wix-style-react/PopoverMenu';
+import PopoverMenuItem from 'wix-style-react/PopoverMenuItem';
+import {TESTS_PREFIX} from '../../storyCategories';
+
+class TestComponent extends React.Component {
+  state = {
+    menus: [0]
+  }
+
+  handleDeleteMenuItem = deletedItemId => {
+    this.setState({
+      menus: this.state.menus.filter(id => id !== deletedItemId)
+    });
+  };
+
+  render() {
+    return (
+      <div style={{marginLeft: 100, marginTop: 100}}>
+        {this.state.menus.map(key => (
+          <PopoverMenu
+            dataHook={`popover-${key}`}
+            key={key}
+            placement="bottom"
+            appendToParent
+            >
+            <PopoverMenuItem
+              dataHook={`popover-item-${key}`}
+              text="Delete"
+              onClick={() => this.handleDeleteMenuItem(key)}
+              />
+          </PopoverMenu>
+        ))}
+      </div>
+    );
+  }
+}
+
+const kind = `${TESTS_PREFIX}/7. Tooltip`;
+
+storiesOf(kind, module)
+  .add('7.3. Popover Menu', () => (
+    <TestComponent/>
+  ));


### PR DESCRIPTION
### What changed
Hi,
I moved code that removes tooltip from the DOM out of `lazyHide` method and reuse it in `componentWillUnmount'

### Why it changed
We need this to handle the case with popover:
https://github.com/wix/wix-style-react/blob/master/src/PopoverMenu/PopoverMenu.js#L52

More details about the issue here: https://github.com/wix/wix-style-react/issues/2113
---

- [x] Change is tested
- [ ] Change is documented
- [ ] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)
