### PR TITLE
<Page/> - update implementation of getChildrenObject

### DIFF
--- a/src/Page/Page.js
+++ b/src/Page/Page.js
@@ -356,20 +356,20 @@ Page.propTypes = {
 
 function getChildrenObject(children) {
   return React.Children.toArray(children).reduce((acc, child) => {
-    switch (child.type) {
-      case Page.Header : {
+    switch (child.type.displayName) {
+      case 'Page.Header' : {
         acc.PageHeader = child;
         break;
       }
-      case Page.Content : {
+      case 'Page.Content' : {
         acc.PageContent = child;
         break;
       }
-      case Page.FixedContent : {
+      case 'Page.FixedContent' : {
         acc.PageFixedContent = child;
         break;
       }
-      case Page.Tail : {
+      case 'Page.Tail' : {
         acc.PageTail = child;
         break;
       }


### PR DESCRIPTION
### What changed

The helper function `getChildrenObject` in `<Page/>` used the component's function reference in order to verify the children's type. This method of comparison is broken when using `react-hot-loader`.

The updated implementation uses to child's `displayName` property for comparison.

### Why it changed

Fixes #2028.

---

- [ ] Change is tested
- [ ] Change is documented
- [ ] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
