### PR TITLE
support focus(options) inside input with options

### DIFF
--- a/src/InputWithOptions/InputWithOptions.js
+++ b/src/InputWithOptions/InputWithOptions.js
@@ -251,8 +251,8 @@ class InputWithOptions extends WixComponent {
     }
   }
 
-  focus() {
-    this.input.focus();
+  focus(options = {}) {
+    this.input.focus(options);
   }
 
   blur() {


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus

it will allow to pass a param called 'preventScroll'

