### PR TITLE
`<Page/>`: Use displayName rather than reference for prop validation

### DIFF
--- a/src/Page/Page.js
+++ b/src/Page/Page.js
@@ -344,10 +344,10 @@ Page.propTypes = {
     }
 
     if (
-      children[key].type !== Page.Header &&
-      children[key].type !== Page.Content &&
-      children[key].type !== Page.FixedContent &&
-      children[key].type !== Page.Tail
+      children[key].type.displayName !== Page.Header.displayName &&
+      children[key].type.displayName !== Page.Content.displayName &&
+      children[key].type.displayName !== Page.FixedContent.displayName &&
+      children[key].type.displayName !== Page.Tail.displayName
     ) {
       return new Error(`Page: Invalid Prop children, unknown child ${children[key].type}`);
     }


### PR DESCRIPTION
### What changed

Using components' `displayName` property to perform prop validation for `<Page/>`, instead of the children's references.

This is a followup PR for https://github.com/wix/wix-style-react/pull/2134.

### Why it changed

Validation using component references breaks when using HMR.
