### PR TITLE
<DropdownLayout/> - change the divider's data-hook

### DIFF
--- a/src/DropdownLayout/DropdownLayout.js
+++ b/src/DropdownLayout/DropdownLayout.js
@@ -219,7 +219,7 @@ class DropdownLayout extends WixComponent {
   renderOption({option, idx}) {
     const {value, id, disabled, title, overrideStyle, linkTo} = option;
     if (value === DIVIDER_OPTION_VALUE) {
-      return this.renderDivider(idx, `dropdown-item-${id || idx}`);
+      return this.renderDivider(idx, `dropdown-divider-${id || idx}`);
     }
 
     const content = this.renderItem({

--- a/src/DropdownLayout/DropdownLayout.spec.js
+++ b/src/DropdownLayout/DropdownLayout.spec.js
@@ -86,11 +86,11 @@ describe('DropdownLayout', () => {
     expect(driver.optionsLength()).toBe(7);
     expect(driver.optionContentAt(0)).toBe('Option 1');
     expect(driver.isOptionADivider(4)).toBeTruthy();
-    expect(driver.optionByHook('dropdown-item-divider1').isDivider()).toBeTruthy();
+    expect(driver.optionByHook('dropdown-divider-divider1').isDivider()).toBeTruthy();
     expect(driver.optionContentAt(5)).toBe('Option 4');
 
     expect(driver.isOptionADivider(6)).toBeTruthy();
-    expect(driver.optionByHook('dropdown-item-6').isDivider()).toBeTruthy();
+    expect(driver.optionByHook('dropdown-divider-6').isDivider()).toBeTruthy();
   });
 
   it('should not hover any option by default', () => {


### PR DESCRIPTION
Fixes #2034.

This could break existing tests, so it may be better to have this in the next major version.