### PR TITLE
`<Heading/>` & `<Text/>` - Apply (proxy) ellipsis only of children is a string

### DIFF
--- a/src/Heading/ProxyHeading.js
+++ b/src/Heading/ProxyHeading.js
@@ -7,7 +7,7 @@ import ellipsedStyle from '../common/EllipsedTooltip/EllipsedTooltip.st.css';
 
 const EllipsedHeading = withEllipsedTooltip({showTooltip: true})(Heading);
 
-const ProxyHeading = ({ellipsis, ...props}) => ellipsis ?
+const ProxyHeading = ({ellipsis, ...props}) => ellipsis && typeof props.children === 'string' ?
   <EllipsedHeading {...ellipsedStyle('root', {}, props)} {...props}/> :
   <Heading {...props}/>;
 

--- a/src/Text/ProxyText.js
+++ b/src/Text/ProxyText.js
@@ -7,7 +7,7 @@ import ellipsedStyle from '../common/EllipsedTooltip/EllipsedTooltip.st.css';
 
 const EllipsedText = withEllipsedTooltip({showTooltip: true})(Text);
 
-const ProxyText = ({ellipsis, ...props}) => ellipsis ?
+const ProxyText = ({ellipsis, ...props}) => ellipsis && typeof props.children === 'string' ?
   <EllipsedText {...ellipsedStyle('root', {}, props)} {...props}/> :
   <Text {...props}/>;
 


### PR DESCRIPTION
@Faradey27 
Does this sound right to you?

Motivation is only to avoid unexpected side-effects when passing a React Node (not a string),
assuming that ellipsis doesn't really work on it.
If there are cases where passing a node would still work, then maybe we shouldn't have this restriction (to have a `string` child).