### PR TITLE
<Tooltip/> - add a new `showArrow` prop

### DIFF
--- a/src/Tooltip/README.TESTKIT.md
+++ b/src/Tooltip/README.TESTKIT.md
@@ -29,6 +29,7 @@ beforeAll(() => {
 | hasErrorTheme | - | boolean | true if the tooltip itself uses error theme | 
 | hasDarkTheme | - | boolean | true if the tooltip itself uses dark theme | 
 | hasLightTheme | - | boolean | true if the tooltip itself uses light theme | 
+| hasArrow | - | boolean | true if the tooltip has an arrow | 
 | getTooltipWrapper | - | element | return the wrapper that wraps the tooltip itself and the tooltip element | 
 | getChildren | - | element | return the tooltip children | 
 | getPlacement | - | string | return the tooltip placement | 

--- a/src/Tooltip/Tooltip.driver.js
+++ b/src/Tooltip/Tooltip.driver.js
@@ -44,6 +44,7 @@ const tooltipDriverFactory = ({element, wrapper}) => {
     hasDarkTheme: () => !!bodyOrWrapper.querySelector('.dark'),
     hasLightTheme: () => !!bodyOrWrapper.querySelector('.light'),
     hasAnimationClass: () => !!bodyOrWrapper.querySelector('.fadeIn'),
+    hasArrow: () => !!bodyOrWrapper.querySelector('[data-hook="tooltip-arrow"]'),
     getTooltipWrapper: getTooltipContent,
     getChildren: () => element.innerHTML,
     getPlacement: () => {

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -100,7 +100,10 @@ class Tooltip extends WixComponent {
     shouldUpdatePosition: PropTypes.bool,
 
     /** Show Tooltip Immediately - with no delay and no animation */
-    showImmediately: PropTypes.bool
+    showImmediately: PropTypes.bool,
+
+    /** Show an arrow shape */
+    showArrow: PropTypes.bool
   };
 
   static defaultProps = {
@@ -124,7 +127,8 @@ class Tooltip extends WixComponent {
     textAlign: 'left',
     relative: false,
     shouldUpdatePosition: false,
-    showImmediately: false
+    showImmediately: false,
+    showArrow: true
   };
 
   _childNode = null;
@@ -224,6 +228,7 @@ class Tooltip extends WixComponent {
           textAlign={this.props.textAlign}
           lineHeight={this.props.lineHeight}
           color={this.props.color}
+          showArrow={this.props.showArrow}
           >
           {this.props.content}
         </TooltipContent>);

--- a/src/Tooltip/Tooltip.spec.js
+++ b/src/Tooltip/Tooltip.spec.js
@@ -343,6 +343,29 @@ describe('Tooltip', () => {
     });
   });
 
+  describe('showArrow prop', () => {
+    const props = {
+      ..._props,
+      content: 'This is the content'
+    };
+
+    it('should have an arrow by default', () => {
+      const driver = createDriver(<Tooltip {...props}>{children}</Tooltip>);
+      driver.mouseEnter();
+      return resolveIn(30).then(() => {
+        expect(driver.hasArrow()).toBeTruthy();
+      });
+    });
+
+    it('should not show an arrow if `showArrow` is set to false', () => {
+      const driver = createDriver(<Tooltip {...props} showArrow={false}>{children}</Tooltip>);
+      driver.mouseEnter();
+      return resolveIn(30).then(() => {
+        expect(driver.hasArrow()).toBeFalsy();
+      });
+    });
+  });
+
   describe('testkit', () => {
 
     const createTooltipTestkitDriver = props => {

--- a/src/Tooltip/TooltipContent.js
+++ b/src/Tooltip/TooltipContent.js
@@ -71,7 +71,10 @@ class TooltipContent extends Component {
     lineHeight: PropTypes.string,
 
     /** Show Tooltip Immediately - with no delay and no animation */
-    showImmediately: PropTypes.bool
+    showImmediately: PropTypes.bool,
+
+    /** Show an arrow shape */
+    showArrow: PropTypes.bool
   };
 
   static defaultProps = {
@@ -79,7 +82,8 @@ class TooltipContent extends Component {
     arrowPlacement: 'bottom',
     maxWidth: '204px',
     size: 'normal',
-    textAlign: 'center'
+    textAlign: 'center',
+    showArrow: true
   };
 
   render() {
@@ -100,7 +104,8 @@ class TooltipContent extends Component {
       padding,
       color,
       lineHeight,
-      showImmediately
+      showImmediately,
+      showArrow
     } = this.props;
 
     return (
@@ -109,7 +114,14 @@ class TooltipContent extends Component {
           <div className={classnames({[styles[`bounce-${arrowPlacement}`]]: bounce})}>
             <div ref={ref => this.tooltip = ref} className={classnames(styles.tooltip, styles[theme], styles[size])} style={{maxWidth, minWidth, textAlign, padding, lineHeight, color}}>
               <div data-hook="tooltip-content">{children}</div>
-              <div className={classnames(styles.arrow, styles[arrowPlacement])} style={arrowStyle}/>
+
+              {showArrow && (
+                <div
+                  data-hook="tooltip-arrow"
+                  className={classnames(styles.arrow, styles[arrowPlacement])}
+                  style={arrowStyle}
+                  />
+              )}
             </div>
           </div>
         </div>

--- a/stories/Tooltip/Composite/ExampleTooltip.js
+++ b/stories/Tooltip/Composite/ExampleTooltip.js
@@ -22,7 +22,8 @@ class ExampleTooltip extends Component {
     onHideText: 'onHide triggered',
     moveBy: {x: 0, y: 0},
     shouldUpdatePosition: false,
-    showImmediately: false
+    showImmediately: false,
+    showArrow: true
   };
 
   render() {
@@ -123,6 +124,16 @@ class ExampleTooltip extends Component {
           </div>
 
           <div className={styles.option}>
+            <Label>Show Arrow</Label>
+            <div className={styles.flex}>
+              <ToggleSwitch
+                checked={this.state.showArrow}
+                onChange={() => this.setState({showArrow: !this.state.showArrow})}
+                />
+            </div>
+          </div>
+
+          <div className={styles.option}>
             <Label>Move By</Label>
             <div className={styles.flex}>
               <Label>x
@@ -159,6 +170,7 @@ class ExampleTooltip extends Component {
               shouldUpdatePosition={this.state.shouldUpdatePosition}
               showImmediately={this.state.showImmediately}
               moveBy={this.state.moveBy}
+              showArrow={this.state.showArrow}
               />
           </div>
         </div>

--- a/stories/Tooltip/Composite/Template.js
+++ b/stories/Tooltip/Composite/Template.js
@@ -21,7 +21,8 @@ export class Template extends Component {
     onHide: Tooltip.propTypes.onHide,
     shouldUpdatePosition: Tooltip.propTypes.shouldUpdatePosition,
     showImmediately: Tooltip.propTypes.showImmediately,
-    moveBy: Tooltip.propTypes.moveBy
+    moveBy: Tooltip.propTypes.moveBy,
+    showArrow: Tooltip.propTypes.showArrow
   };
 
   componentDidUpdate(props) {
@@ -55,6 +56,7 @@ export class Template extends Component {
         shouldUpdatePosition={this.props.shouldUpdatePosition}
         showImmediately={this.props.showImmediately}
         moveBy={this.props.moveBy}
+        showArrow={this.props.showArrow}
         >
         {this.getTooltipTarget()}
       </Tooltip>


### PR DESCRIPTION
This PR adds a new `showArrow` prop to `<Tooltip/>`. It is set to `true` by default. Setting it to `false` will cause the tooltip to not render the little arrow pointing to the target.

`showArrow`:

![screen shot 2018-09-05 at 14 20 47](https://user-images.githubusercontent.com/11786506/45090080-f43f8300-b116-11e8-89fe-519630ff6a60.png)

`showArrow={false}`:

![screen shot 2018-09-05 at 14 20 56](https://user-images.githubusercontent.com/11786506/45090087-fa356400-b116-11e8-966e-8d13f0ce307f.png)

Resolves https://github.com/wix-private/wsr-issues/issues/247.
