### PR TITLE
<MultiSelect/> - support reorderable tags

### DIFF
--- a/src/MultiSelect/InputWithTags.js
+++ b/src/MultiSelect/InputWithTags.js
@@ -7,6 +7,8 @@ import styles from './InputWithTags.scss';
 import omit from 'omit';
 import classNames from 'classnames';
 import isUndefined from 'lodash/isUndefined';
+import SortableList from '../SortableList/SortableList';
+import defaultDndStyles from '../../dnd-styles';
 
 class InputWithTags extends React.Component {
   constructor(props) {
@@ -14,6 +16,8 @@ class InputWithTags extends React.Component {
     this.focus = this.focus.bind(this);
     this.blur = this.blur.bind(this);
     this.select = this.select.bind(this);
+    this.handleHover = this.handleHover.bind(this);
+    this.renderReorderableTag = this.renderReorderableTag.bind(this);
 
     this.state = {inputValue: '', inputHasFocus: false, hasHover: false};
   }
@@ -52,6 +56,7 @@ class InputWithTags extends React.Component {
     const {
       tags,
       onRemoveTag,
+      onReorder,
       placeholder,
       error,
       errorMessage,
@@ -65,7 +70,7 @@ class InputWithTags extends React.Component {
     const isSelectMode = mode === 'select';
 
     const className = classNames({
-      [styles.tagsContainer]: true,
+      [styles.inputWithTagsContainer]: true,
       [styles.disabled]: disabled,
       [styles.error]: error,
       [styles.empty]: !tags.length,
@@ -99,18 +104,28 @@ class InputWithTags extends React.Component {
       rowMultiplier = 35;
     }
     const maxHeight = this.props.maxHeight || this.props.maxNumRows * rowMultiplier || 'initial';
-
     return (
       <div
         className={className}
         style={{maxHeight}}
         onClick={() => this.handleClick()}
-        onMouseOver={() => this.handleHover()}
-        onMouseOut={() => this.handleHover()}
+        onMouseOver={onReorder ? null : this.handleHover}
+        onMouseOut={onReorder ? null : this.handleHover}
         data-hook={this.props.dataHook}
         >
-        {tags.map(({label, ...rest}) => <Tag key={rest.id} disabled={disabled} onRemove={onRemoveTag} {...rest}>{label}</Tag>)}
-        <span className={classNames(styles.input, {[styles.emptyInput]: !tags.length})} data-hook="inner-input-with-tags">
+        {onReorder ?
+          <SortableList
+            contentClassName={styles.tagsContainer}
+            items={tags}
+            onDrop={onReorder}
+            renderItem={this.renderReorderableTag}
+            /> : tags.map(({label, ...rest}) =>
+              <Tag key={rest.id} disabled={disabled} onRemove={onRemoveTag} {...rest}>{label}</Tag>)
+        }
+        <span
+          className={classNames(styles.input, {[styles.emptyInput]: !tags.length})}
+          data-hook="inner-input-with-tags"
+          >
           <div className={styles.hiddenDiv} style={{fontSize}}>
             {this.state.inputValue}
           </div>
@@ -150,6 +165,30 @@ class InputWithTags extends React.Component {
     );
   }
 
+  renderReorderableTag({item: {id, label, ...itemProps}, previewStyles, isPlaceholder, isPreview, ...rest}) {
+    const {onRemoveTag, disabled} = this.props;
+    const classes = classNames({
+      [defaultDndStyles.itemPlaceholder]: isPlaceholder,
+      [styles.draggedTagPlaceholder]: isPlaceholder,
+      [defaultDndStyles.itemPreview]: isPreview,
+      [styles.draggedTag]: isPreview
+    });
+
+    return (
+      <div style={previewStyles}>
+        <Tag
+          id={id} disabled={disabled}
+          className={classes}
+          isPlaceholder={isPlaceholder}
+          onRemove={onRemoveTag} {...itemProps}
+          {...rest}
+          >
+          {label}
+        </Tag>
+      </div>
+    );
+  }
+
   focus() {
     this.input.focus();
   }
@@ -172,6 +211,7 @@ class InputWithTags extends React.Component {
 InputWithTags.propTypes = {
   onRemoveTag: PropTypes.func,
   tags: PropTypes.array,
+  onReorder: PropTypes.func,
   maxHeight: PropTypes.string,
   maxNumRows: PropTypes.number,
   onKeyDown: PropTypes.func,
@@ -190,7 +230,8 @@ InputWithTags.propTypes = {
 };
 
 InputWithTags.defaultProps = {
-  onRemoveTag: () => {},
+  onRemoveTag: () => {
+  },
   tags: [],
   placeholder: '',
   delimiters: []

--- a/src/MultiSelect/InputWithTags.js
+++ b/src/MultiSelect/InputWithTags.js
@@ -8,7 +8,7 @@ import omit from 'omit';
 import classNames from 'classnames';
 import isUndefined from 'lodash/isUndefined';
 import SortableList from '../SortableList/SortableList';
-import defaultDndStyles from '../../dnd-styles';
+import defaultDndStyles from '../dnd-styles';
 
 class InputWithTags extends React.Component {
   constructor(props) {

--- a/src/MultiSelect/InputWithTags.js
+++ b/src/MultiSelect/InputWithTags.js
@@ -179,7 +179,6 @@ class InputWithTags extends React.Component {
         <Tag
           id={id} disabled={disabled}
           className={classes}
-          isPlaceholder={isPlaceholder}
           onRemove={onRemoveTag} {...itemProps}
           {...rest}
           >

--- a/src/MultiSelect/InputWithTags.scss
+++ b/src/MultiSelect/InputWithTags.scss
@@ -44,7 +44,7 @@
   height: 0;
 }
 
-.tagsContainer {
+.inputWithTagsContainer {
   width: 100%;
   @include FontThin();
   border: 1px solid $B30;
@@ -85,4 +85,26 @@
 
 .hasHover:not(.hasFocus) {
   background: $B50;
+}
+
+.tagsContainer {
+  cursor: pointer;
+  display: flex;
+  flex-wrap: wrap;
+
+  .draggedTag {
+    background-color: transparentize($B30, 0.2);
+  }
+
+  .draggedTagPlaceholder {
+    background-color: $D60;
+
+    &:hover {
+      background-color: $D60
+    }
+
+    * {
+      visibility: hidden;
+    }
+  }
 }

--- a/src/MultiSelect/MultiSelect.js
+++ b/src/MultiSelect/MultiSelect.js
@@ -52,6 +52,7 @@ class MultiSelect extends InputWithOptions {
     return {
       inputElement: (
         <InputWithTags
+          onReorder={this.props.onReorder}
           maxNumRows={this.props.maxNumRows}
           mode={this.props.mode}
           />
@@ -197,7 +198,8 @@ MultiSelect.propTypes = {
   delimiters: PropTypes.array,
   mode: PropTypes.string,
   error: PropTypes.bool,
-  errorMessage: PropTypes.string
+  errorMessage: PropTypes.string,
+  onReorder: PropTypes.func
 };
 
 MultiSelect.defaultProps = {

--- a/src/MultiSelect/MultiSelect.spec.js
+++ b/src/MultiSelect/MultiSelect.spec.js
@@ -363,7 +363,7 @@ describe('MultiSelect', () => {
         />
     );
     getTagDriverByTagId('Alabama').dragTo(getTagDriverByTagId('California3').element);
-    expect(onReorder).toBeCalled();
+    expect(onReorder).toBeCalledWith({removedIndex: 0, addedIndex: 2});
 
     expect(getTagLabelAt(0)).toBe('California3');
     expect(getTagLabelAt(2)).toBe('Alabama');

--- a/src/MultiSelect/MultiSelect.spec.js
+++ b/src/MultiSelect/MultiSelect.spec.js
@@ -72,7 +72,10 @@ describe('MultiSelect', () => {
 
   it('should not lose Focus or close the list on selection with tab press', () => {
     const onSelect = jest.fn();
-    const {driver, inputDriver, dropdownLayoutDriver} = createDriver(<MultiSelect options={options} onSelect={onSelect}/>);
+    const {driver, inputDriver, dropdownLayoutDriver} = createDriver(<MultiSelect
+      options={options}
+      onSelect={onSelect}
+      />);
     driver.focus();
     driver.pressDownKey();
     driver.pressTabKey();
@@ -85,7 +88,10 @@ describe('MultiSelect', () => {
     const onSelect = jest.fn();
     const onChange = jest.fn();
     const {driver, inputDriver, dropdownLayoutDriver} = createDriver(
-      <MultiSelect value={options[0].value} options={options} delimiters={[',']} onSelect={onSelect} onChange={onChange}/>
+      <MultiSelect
+        value={options[0].value} options={options} delimiters={[',']} onSelect={onSelect}
+        onChange={onChange}
+        />
     );
     driver.focus();
     inputDriver.trigger('keyDown', {key: ','});
@@ -137,7 +143,10 @@ describe('MultiSelect', () => {
     const onSelect = jest.fn();
     const onChange = jest.fn();
     const {driver, inputDriver, dropdownLayoutDriver} = createDriver(
-      <MultiSelect value={options[0].value} options={options} delimiters={[';']} onSelect={onSelect} onChange={onChange}/>
+      <MultiSelect
+        value={options[0].value} options={options} delimiters={[';']} onSelect={onSelect}
+        onChange={onChange}
+        />
     );
     driver.focus();
     inputDriver.trigger('keyDown', {key: ';'});
@@ -234,7 +243,10 @@ describe('MultiSelect', () => {
   describe('onManuallyCalled', () => {
     it('should be called after Enter is pressed and input is not empty', () => {
       const onManuallyInput = jest.fn();
-      const {driver, inputDriver} = createDriver(<MultiSelect options={options} onManuallyInput={onManuallyInput} value="custom value"/>);
+      const {driver, inputDriver} = createDriver(<MultiSelect
+        options={options} onManuallyInput={onManuallyInput}
+        value="custom value"
+        />);
 
       driver.focus();
       inputDriver.enterText('custom value');
@@ -245,7 +257,10 @@ describe('MultiSelect', () => {
 
     it('should be called after delimiter is pressed and input is not empty', () => {
       const onManuallyInput = jest.fn();
-      const {driver, inputDriver} = createDriver(<MultiSelect options={options} onManuallyInput={onManuallyInput} value="custom value"/>);
+      const {driver, inputDriver} = createDriver(<MultiSelect
+        options={options} onManuallyInput={onManuallyInput}
+        value="custom value"
+        />);
 
       driver.focus();
       inputDriver.enterText('custom value');
@@ -329,12 +344,43 @@ describe('MultiSelect', () => {
     expect(onSelect).toBeCalledWith([{id: options[0].id, label: options[0].value}]);
   });
 
+  // TODO: dnd testkit is missing - once it's available, this test has to be completed and run
+  xit('should allow reordering the tags', () => {
+    const tags = [
+      {label: 'Alabama', id: 'Alabama'},
+      {label: 'California2', id: 'California2'},
+      {label: 'California3', id: 'California3'},
+      {label: 'California4', id: 'California4'}
+    ];
+    const onReorder = jest.fn();
+    const {driver: {getTagLabelAt, getTagDriverByTagId}} = createDriver(
+      <MultiSelect
+        draggable
+        options={options}
+        tags={tags}
+        onReorder={onReorder}
+        autoFocus
+        />
+    );
+    getTagDriverByTagId('Alabama').dragTo(getTagDriverByTagId('California3').element);
+    expect(onReorder).toBeCalled();
+
+    expect(getTagLabelAt(0)).toBe('California3');
+    expect(getTagLabelAt(2)).toBe('Alabama');
+  });
+
   describe('testkit', () => {
     it('should exist', () => {
       const div = document.createElement('div');
       const dataHook = 'myDataHook';
       const tags = [{id: 'Alabama', label: 'Alabama'}];
-      const wrapper = div.appendChild(ReactTestUtils.renderIntoDocument(<div><MultiSelect dataHook={dataHook} tags={tags}/></div>));
+      const wrapper = div.appendChild(ReactTestUtils.renderIntoDocument(
+        <div>
+          <MultiSelect
+            dataHook={dataHook}
+            tags={tags}
+            />
+        </div>));
       const multiSelectTestkit = multiSelectTestkitFactory({wrapper, dataHook});
       expect(multiSelectTestkit.driver.exists()).toBeTruthy();
       expect(multiSelectTestkit.inputDriver.exists()).toBeTruthy();

--- a/src/MultiSelect/README.md
+++ b/src/MultiSelect/README.md
@@ -12,6 +12,7 @@
 | onSelect | func | - | - | Callback function called whenever the user selects a single option or multiple options (with copy paste). The function receives array of values as an argument. |
 | onManuallyInput | func | noop | - | Callback when the user pressed the Enter key or Tab key (or any given delimiter) after he wrote in the Input field - meaning the user selected something not in the list |
 | onRemoveTag | func | - | + | A callback function to be called when a tag should be removed|
+| onReorder | func | - | - | When this callback function is set, tags can be reordered. The expected callback signature is `({addedIndex: number, removedIndex: number}) => void`|
 | tags | array of objects | - | + | The tags. tags are just set of selected suggestions|
 | placeholder | string | - | - | the placeholder for the input|
 | id | string or number | '' | - | An identifier of the component |

--- a/src/Tag/Tag.driver.js
+++ b/src/Tag/Tag.driver.js
@@ -10,6 +10,7 @@ const tagDriverFactory = ({element, wrapper, component}) => {
   const contentWithoutThumb = element.querySelector('span');
 
   return {
+    element: () => element,
     exists: () => !!element,
     isLarge: () => isClassExists(element, 'large'),
     isStandardTheme: () => isClassExists(element, 'standardTheme'),

--- a/src/Tag/Tag.driver.js
+++ b/src/Tag/Tag.driver.js
@@ -10,7 +10,6 @@ const tagDriverFactory = ({element, wrapper, component}) => {
   const contentWithoutThumb = element.querySelector('span');
 
   return {
-    element: () => element,
     exists: () => !!element,
     isLarge: () => isClassExists(element, 'large'),
     isStandardTheme: () => isClassExists(element, 'standardTheme'),

--- a/src/Tag/Tag.js
+++ b/src/Tag/Tag.js
@@ -11,14 +11,15 @@ import Typography from '../Typography';
   */
 class Tag extends WixComponent {
   render() {
-    const {id, children, thumb, removable, onClick, onRemove, size, wrap, disabled, theme, maxWidth} = this.props;
+    const {id, children, thumb, removable, onClick, onRemove, size, wrap, disabled, theme, maxWidth, className} = this.props;
 
-    const className = classNames({
+    const classes = classNames({
       [styles.tag]: true,
       [styles.large]: size === 'large',
       [styles.tagWrap]: wrap,
       [styles.disabled]: disabled,
-      [styles[`${theme}Theme`]]: true
+      [styles[`${theme}Theme`]]: true,
+      [className]: className
     });
 
     const innerClassName = classNames({
@@ -31,7 +32,7 @@ class Tag extends WixComponent {
     return (
       <span
         data-hook="tag"
-        className={className}
+        className={classes}
         disabled={disabled}
         id={id}
         title={title}
@@ -85,7 +86,16 @@ Tag.propTypes = {
   maxWidth: PropTypes.number,
 
   /** Whether to display ellipsis (...) for long content */
-  wrap: PropTypes.bool
+  wrap: PropTypes.bool,
+
+  /** Whether this tag is a placeholder for another  */
+  isPlaceholder: PropTypes.bool,
+
+  /** Whether this tag is being dragged  */
+  isPreview: PropTypes.bool,
+
+  /* Standard className which has preference over any other intrinsic classes  */
+  className: PropTypes.string
 };
 
 Tag.defaultProps = {

--- a/src/Tag/Tag.js
+++ b/src/Tag/Tag.js
@@ -88,12 +88,6 @@ Tag.propTypes = {
   /** Whether to display ellipsis (...) for long content */
   wrap: PropTypes.bool,
 
-  /** Whether this tag is a placeholder for another  */
-  isPlaceholder: PropTypes.bool,
-
-  /** Whether this tag is being dragged  */
-  isPreview: PropTypes.bool,
-
   /* Standard className which has preference over any other intrinsic classes  */
   className: PropTypes.string
 };

--- a/stories/MultiSelect/ExampleReorderable.js
+++ b/stories/MultiSelect/ExampleReorderable.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import MultiSelect from 'wix-style-react/MultiSelect';
+import styles from './ExampleStandard.scss';
+
+export const options = [
+  {value: 'Alabama', id: 'Alabama', tag: {label: 'Alabama'}},
+  {value: 'Alaska', id: 'Alaska'},
+  {value: <div className={styles.option}><div>Arizona</div><div className={styles.thumb}/></div>, id: 'Arizona', tag: {label: 'Arizona', thumb: <div className={styles.thumb}/>}},
+  {value: 'Arkansas', id: 'Arkansas'},
+  {value: 'California', id: 'California'},
+  {value: 'California2', id: 'California2'},
+  {value: 'California3', id: 'California3'},
+  {value: 'California4', id: 'California4'},
+  {value: 'California5', id: 'California5'},
+  {value: 'California6', id: 'California6'},
+  {value: 'California7', id: 'California7'},
+  {id: 'Divider', value: '-'},
+  {value: 'Two words', id: 'Two words'}
+];
+
+export const valueParser = option => option.tag ? option.tag.label : option.value;
+
+class ExampleReorderable extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      tags: [],
+      options,
+      inputValue: ''
+    };
+  }
+
+  getValue = option => typeof option.value === 'string' ? option.value : option.value.props.children[0].props.children;
+
+  handleOnSelect = tags => Array.isArray(tags) ?
+    this.setState({tags: [...this.state.tags, ...tags]}) :
+    this.setState({tags: [...this.state.tags, tags]});
+
+  handleOnRemoveTag = tagId => this.setState({tags: this.state.tags.filter(currTag => currTag.id !== tagId)});
+
+  handleOnChange = event => this.setState({inputValue: event.target.value});
+
+  predicate = option => this.getValue(option).toLowerCase().includes(this.state.inputValue.toLowerCase());
+
+  render() {
+    const {tags} = this.state;
+    return (
+      <div>
+        <div className={styles.main}>
+          <MultiSelect
+            tags={this.state.tags}
+            onSelect={this.handleOnSelect}
+            onRemoveTag={this.handleOnRemoveTag}
+            onReorder={({addedIndex, removedIndex}) => {
+              const nextTags = tags.slice();
+              nextTags.splice(addedIndex, 0, ...nextTags.splice(removedIndex, 1));
+              this.setState({
+                tags: nextTags
+              });
+              console.log(`Dragged tag ${removedIndex} to ${addedIndex}`);
+            }}
+            onChange={this.handleOnChange}
+            onManuallyInput={() => console.log('NOW')}
+            options={this.state.options}
+            value={this.state.inputValue}
+            predicate={this.predicate}
+            valueParser={valueParser}
+            />
+        </div>
+      </div>
+    );
+  }
+}
+
+export default ExampleReorderable;

--- a/stories/MultiSelect/ExampleReorderable.js
+++ b/stories/MultiSelect/ExampleReorderable.js
@@ -58,10 +58,9 @@ class ExampleReorderable extends React.Component {
               this.setState({
                 tags: nextTags
               });
-              console.log(`Dragged tag ${removedIndex} to ${addedIndex}`);
             }}
             onChange={this.handleOnChange}
-            onManuallyInput={() => console.log('NOW')}
+            onManuallyInput={() => {}}
             options={this.state.options}
             value={this.state.inputValue}
             predicate={this.predicate}

--- a/stories/MultiSelect/index.js
+++ b/stories/MultiSelect/index.js
@@ -17,6 +17,8 @@ import ExampleReadOnly from './ExampleReadOnly';
 import ExampleReadOnlyRaw from '!raw-loader!./ExampleReadOnly';
 import ExampleReadOnlyWithError from './ExampleReadOnlyWithError';
 import ExampleReadOnlyWithErrorRaw from '!raw-loader!./ExampleReadOnlyWithError';
+import ExampleReorderable from './ExampleReorderable';
+import ExampleReorderableRaw from '!raw-loader!./ExampleReorderable';
 
 storiesOf('3. Inputs', module)
   .add('3.8 Tags', () => (
@@ -28,6 +30,12 @@ storiesOf('3. Inputs', module)
         <CodeExample title="Standard" code={ExampleStandardRaw}>
           <div style={{maxWidth: 720}}>
             <ExampleStandard/>
+          </div>
+        </CodeExample>
+
+        <CodeExample title="Reorderable" code={ExampleReorderableRaw}>
+          <div style={{maxWidth: 720}}>
+            <ExampleReorderable/>
           </div>
         </CodeExample>
 


### PR DESCRIPTION
### What changed

Used the new `<SortableList/>` dnd to make `<MultiSelect/>` optionally reorderable

### Why it changed

It's a missing feature for `<MultiSelect/>` (3.8)

note the single test for the feature was put under ignore as there's no testkit for dnd yet.

---

- [ ] Change is tested
- [X] Change is documented
- [ ] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
