### PR TITLE
<Typography/> - convert  old Typography usage (from `.js` only)

### DIFF
--- a/.storybook/stories.js
+++ b/.storybook/stories.js
@@ -114,7 +114,7 @@ import '../stories/Tag.story.js'; // 12.5 Tag
 import '../stories/Highlighter.story.js'; // Highlighter
 
 // Components API
-import '../stories/FormField.story.js';
+import '../stories/FormField/FormField.story.js';
 import '../stories/Layout/index.story.js';
 import '../stories/Layout';
 

--- a/src/DataTable/DataTable.js
+++ b/src/DataTable/DataTable.js
@@ -1,7 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import styles from './DataTable.scss';
-import typography from '../Typography/Typography.scss';
 import classNames from 'classnames';
 import InfiniteScroll from './InfiniteScroll';
 import SortByArrowUp from '../new-icons/system/SortByArrowUp';
@@ -212,7 +211,7 @@ class DataTable extends React.Component {
 
   renderCell = (rowData, column, rowNum, colNum) => {
     const classes = classNames(
-      {[typography.t1]: this.props.newDesign},
+      {[this.style.tdText]: this.props.newDesign},
       {[this.style.important]: column.important},
       {[this.style.largeVerticalPadding]: this.props.rowVerticalPadding === 'large'},
       {[this.style.mediumVerticalPadding]: this.props.rowVerticalPadding !== 'large'});
@@ -331,7 +330,7 @@ class TableHeader extends Component {
       <th
         style={style}
         key={colNum}
-        className={classNames({[typography.t4]: this.props.newDesign})}
+        className={classNames({[this.style.thText]: this.props.newDesign})}
         {...optionalHeaderCellProps}
         >
         <div className={this.style.thContainer}>

--- a/src/DataTable/DataTable.scss
+++ b/src/DataTable/DataTable.scss
@@ -1,5 +1,5 @@
 @import '../common';
-@import '../typography';
+@import '../typography-helpers';
 
 $headerShadow: inset 0 1px 0 0 $B30, inset 0 -1px 0 0 $B30;
 $columnShadow: inset 0 -1px 0 0 $D60;

--- a/src/DataTable/DataTable.scss
+++ b/src/DataTable/DataTable.scss
@@ -1,4 +1,5 @@
 @import '../common';
+@import '../typography';
 
 $headerShadow: inset 0 1px 0 0 $B30, inset 0 -1px 0 0 $B30;
 $columnShadow: inset 0 -1px 0 0 $D60;
@@ -46,6 +47,10 @@ $rowShadow: inset 0 1px 0 0 $D70;
       margin-left: 6px;
     }
   }
+
+  &.th-text {
+    @include Text($weight: normal, $size: small);
+  }
 }
 
 
@@ -62,6 +67,10 @@ $rowShadow: inset 0 1px 0 0 $D70;
   &.mediumVerticalPadding {
     padding-top: 18px;
     padding-bottom: 18px;
+  }
+
+  &.td-text:not(.details) {
+    @include Text($weight: thin, $size: medium);
   }
 }
 

--- a/src/EndorseContentLayout/EndorseContentLayout.js
+++ b/src/EndorseContentLayout/EndorseContentLayout.js
@@ -1,14 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
 
 import styles from './styles.scss';
-import typography from '../../src/Typography';
+import Heading from '../Heading';
+import Text from '../Text';
 
 const EndorseContentLayout = ({head, content, primaryCta, secondaryCta}) =>
   <div className={styles.root}>
-    { head && <div className={classnames(styles.head, typography.h1)}>{head}</div> }
-    { content && <div className={classnames(styles.content, typography.t1)}>{content}</div> }
+    { head && <Heading className={styles.head} appearance="H1">{head}</Heading> }
+    { content && <Text className={styles.content} size="medium" weight="thin">{content}</Text> }
     { primaryCta && <div className={styles.primaryCta}>{primaryCta}</div> }
     { secondaryCta && <div className={styles.secondaryCta}>{secondaryCta}</div> }
   </div>;

--- a/src/EndorseContentLayout/EndorseContentLayout.spec.js
+++ b/src/EndorseContentLayout/EndorseContentLayout.spec.js
@@ -1,11 +1,13 @@
 import React from 'react';
+import {mount} from 'enzyme';
 
-import EndorseContentLayout from './EndorseContentLayout.driver';
+import EndorseContentLayoutDriver from './EndorseContentLayout.driver';
+import EndorseContentLayout from './EndorseContentLayout';
 
 describe('EndorseContentLayout', () => {
   let driver;
 
-  beforeEach(() => driver = new EndorseContentLayout());
+  beforeEach(() => driver = new EndorseContentLayoutDriver());
 
   it('should render', () => {
     driver.when.created();
@@ -14,12 +16,15 @@ describe('EndorseContentLayout', () => {
 
   const componentsToRender = ['head', 'content', 'primaryCta', 'secondaryCta'];
 
-  it('should render children components from props', () => {
-    componentsToRender
-      .forEach(c => {
-        driver.when.created({[c]: <div>hey hope you render</div>});
-        expect(driver.get[c]().text()).toBe('hey hope you render');
-      });
+  componentsToRender
+  .forEach(c => {
+    it(`should render node as ${c}`, () => {
+      const props = {[c]: <div>hey hope you render</div>};
+      const wrapper = mount(<EndorseContentLayout {...props}/>);
+      driver.component = wrapper;
+      const text = driver.get[c]().at(0).text();
+      expect(text).toBe('hey hope you render');
+    });
   });
 
   it('should not render anything when prop not given', () => {

--- a/src/FormField/FormField.e2e.js
+++ b/src/FormField/FormField.e2e.js
@@ -1,11 +1,12 @@
 import eyes from 'eyes.it';
-import {formFieldTestkitFactory} from '../../testkit/protractor';
-import {waitForVisibilityOf} from 'wix-ui-test-utils/protractor';
+import {formFieldTestkitFactory, inputTestkitFactory} from '../../testkit/protractor';
+import {waitForVisibilityOf, scrollToElement} from 'wix-ui-test-utils/protractor';
 import {getStoryUrl} from '../../test/utils/storybook-helpers';
 import autoExampleDriver from 'wix-storybook-utils/AutoExampleDriver';
 
 const storyUrl = getStoryUrl('Components', 'FormField');
 const driver = formFieldTestkitFactory({dataHook: 'storybook-formfield'});
+
 
 describe('FormField', () => {
   beforeAll(() =>
@@ -27,5 +28,22 @@ describe('FormField', () => {
     await autoExampleDriver.setProps({infoContent: 'hello'});
     await waitForVisibilityOf(driver.element(), 'Cannot find FormField component');
     expect(await driver.isInfoIconVisible()).toBe(true);
+  });
+
+  eyes.it('should render info icon given infoContent prop', async () => {
+    await autoExampleDriver.setProps({infoContent: 'hello'});
+    await waitForVisibilityOf(driver.element(), 'Cannot find FormField component');
+    expect(await driver.isInfoIconVisible()).toBe(true);
+  });
+
+  eyes.it('should render length count', async () => {
+    console.log('111');
+    const formFieldDriver = formFieldTestkitFactory({dataHook: 'storybook-formfield-length-count'});
+    const inputDriver = inputTestkitFactory({dataHook: 'storybook-formfield-length-count-input'});
+    const element = formFieldDriver.element();
+    await scrollToElement(element);
+    await eyes.checkRegionByElement(element, 'count is zero');
+    await inputDriver.enterText('11111-11111');
+    await inputDriver.enterText('11111-11111-11111-11111');
   });
 });

--- a/src/FormField/FormField.js
+++ b/src/FormField/FormField.js
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Label from 'wix-style-react/Label';
 import Tooltip from 'wix-style-react/Tooltip';
+import Text, {SKINS} from '../Text';
 
 import InfoIcon from '../common/InfoIcon';
-import typography from '../Typography';
 import styles from './FormField.scss';
 
 const asterisk =
@@ -15,12 +15,16 @@ const asterisk =
     children="*"
     />);
 
-const charactersLeft = lengthLeft =>
-  (<div
-    data-hook="formfield-counter"
-    className={classnames(styles.counter, lengthLeft >= 0 ? typography.t4_4 : typography.t4_5)}
-    children={lengthLeft}
-    />);
+const charactersLeft = lengthLeft => {
+  const colorProps = lengthLeft >= 0 ? {light: true, secondary: true} : {skin: SKINS.error};
+  return (
+    <Text
+      size="small" weight="normal" {...colorProps}
+      data-hook="formfield-counter"
+      className={styles.counter}
+      children={lengthLeft}
+      />);
+};
 
 class FormField extends React.Component {
   static displayName = 'FormField';

--- a/src/Input/Input.scss
+++ b/src/Input/Input.scss
@@ -1,5 +1,6 @@
 @import '../common.scss';
 @import './InputMixins.scss';
+@import '../typography.scss';
 
 $gap: 6px;
 $double-gap: 12px;
@@ -465,6 +466,9 @@ $material-gap: 8px;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
+
+  @include Text($weight: thin, $size: medium, $secondary: true);
+
 }
 
 .loaderContainer {

--- a/src/Input/Input.scss
+++ b/src/Input/Input.scss
@@ -1,6 +1,6 @@
 @import '../common.scss';
 @import './InputMixins.scss';
-@import '../typography.scss';
+@import '../typography-helpers.scss';
 
 $gap: 6px;
 $double-gap: 12px;

--- a/src/Input/ThemedInput.js
+++ b/src/Input/ThemedInput.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
 import Input from './Input';
-import Typography from '../Typography';
 
 import styles from './Input.scss';
 
@@ -58,7 +57,7 @@ class ThemedInput extends Input {
         data-hook={dataHook}
         >
         {(theme === 'amaterial') &&
-        <label className={classNames(styles.materialTitle, Typography.t1_1)} htmlFor={id}>{title}</label>}
+        <label className={styles.materialTitle} htmlFor={id}>{title}</label>}
         {super.render({placeholder})}
         {(theme === 'material') && <div className={`${styles.bar} ${styles.barBlack}`}/>}
         {(theme === 'amaterial') && <div className={`${styles.bar} ${styles.barBlue}`}/>}

--- a/src/Loader/Loader.js
+++ b/src/Loader/Loader.js
@@ -10,7 +10,7 @@ import FormFieldErrorSmall from '../new-icons/system/FormFieldErrorSmall';
 import ToggleOn from '../new-icons/system/ToggleOn';
 import CircleLoaderCheck from '../new-icons/system/CircleLoaderCheck';
 import CircleLoaderCheckSmall from '../new-icons/system/CircleLoaderCheckSmall';
-import Typography from '../Typography';
+import Heading from '../Heading';
 
 const arcsAngles = {
   tiny: {
@@ -138,7 +138,7 @@ export default class Loader extends WixComponent {
         {
           shouldShowText && text &&
           <div className={css.text}>
-            <span className={Typography.t5} data-hook="loader-text">{this.props.text}</span>
+            <Heading appearance="H6" dataHook="loader-text">{this.props.text}</Heading>
           </div>
         }
       </div>

--- a/src/RadioGroup/RadioButton/RadioButton.js
+++ b/src/RadioGroup/RadioButton/RadioButton.js
@@ -5,9 +5,9 @@ import classnames from 'classnames';
 
 import WixComponent from '../../BaseComponents/WixComponent';
 
-import typography, {convertFromUxLangToCss} from '../../Typography';
 import styles from '../RadioGroup.scss';
 import {withFocusable, focusableStates} from '../../common/Focusable';
+import Text from '../../Text';
 
 class RadioButton extends WixComponent {
   static displayName = 'RadioGroup.Radio';
@@ -109,7 +109,6 @@ class RadioButton extends WixComponent {
           htmlFor={this.id}
           className={
             classnames(
-              typography[convertFromUxLangToCss(disabled ? 'T1.4' : 'T1.1')],
               {
                 [styles.vcenter]: vAlign === 'center',
                 [styles.vtop]: vAlign === 'top'
@@ -127,7 +126,9 @@ class RadioButton extends WixComponent {
 
           { children &&
             <div className={styles.children} data-hook="radiobutton-children">
-              {children}
+              <Text size="medium" weight="thin" secondary light={disabled}>
+                {children}
+              </Text>
             </div>
           }
         </label>

--- a/src/RadioGroup/RadioGroup.driver.js
+++ b/src/RadioGroup/RadioGroup.driver.js
@@ -18,6 +18,7 @@ const radioGroupDriverFactory = ({element, wrapper, component}) => {
     getRadioValueAt: index => radioButtons[index].value,
     getRadioAtIndex: index => radios[index],
     getSelectedValue: () => selectedRadio() ? selectedRadio().childNodes[0].value : null,
+    // TODO: We should deprecate getClassOfLabelAt(). Css tests should be in e2e tests.
     getClassOfLabelAt: index => labels[index].className,
     isVerticalDisplay: () => isClassExists(element, 'vertical'),
     isHorizontalDisplay: () => isClassExists(element, 'horizontal'),

--- a/src/RadioGroup/RadioGroup.e2e.js
+++ b/src/RadioGroup/RadioGroup.e2e.js
@@ -13,27 +13,22 @@ describe('RadioGroup', () => {
 
   beforeAll(() => browser.get(storyUrl));
 
-  afterEach(() => {
-    autoExampleDriver.reset();
+  afterEach(async () => {
+    await autoExampleDriver.remount();
   });
 
-  eyes.it('should select the second option in a group', () => {
-    waitForVisibilityOf(radioGroupDriver.element(), 'Cannot find RadioGroup')
-      .then(() => {
-        radioGroupDriver.selectByIndex(1).click();
-        expect(radioGroupDriver.isRadioChecked(1)).toBe(true);
-      });
+  eyes.it('should select the second option in a group', async () => {
+    await waitForVisibilityOf(radioGroupDriver.element(), 'Cannot find RadioGroup');
+    radioGroupDriver.selectByIndex(1).click();
+    expect(radioGroupDriver.isRadioChecked(1)).toBe(true);
   });
 
-  eyes.it('should not select disabled option', () => {
-    autoExampleDriver.setProps({disabledRadios: [4]});
-
-    waitForVisibilityOf(radioGroupDriver.element(), 'Cannot find RadioGroup')
-      .then(() => {
-        expect(radioGroupDriver.isRadioDisabled(3)).toBe(true);
-        browser.actions().mouseMove(radioGroupDriver.getRadioAtIndex(3)).click();
-        expect(radioGroupDriver.isRadioChecked(3)).toBe(false);
-      });
+  eyes.it('should not select disabled option', async () => {
+    await autoExampleDriver.setProps({disabledRadios: [4]});
+    await waitForVisibilityOf(radioGroupDriver.element(), 'Cannot find RadioGroup');
+    expect(radioGroupDriver.isRadioDisabled(3)).toBe(true);
+    browser.actions().mouseMove(radioGroupDriver.getRadioAtIndex(3)).click();
+    expect(radioGroupDriver.isRadioChecked(3)).toBe(false);
   });
 
   describe('Focus tests', () => {
@@ -62,49 +57,38 @@ describe('RadioGroup', () => {
       expect(await driver.hasFocusVisibleState()).toBe(false, `${prefix}hasFocusVisibleState`);
     };
 
-    beforeEach(() => {
-      // Needed in order to reset the focus state
-      browser.get(storyUrl);
-    });
-
     eyes.it('should show focus styles when navigated by keyboard', async () => {
-      waitForVisibilityOf(radioGroupDriver.element(), 'Cannot find RadioGroup')
-        .then(async () => {
+      await waitForVisibilityOf(radioGroupDriver.element(), 'Cannot find RadioGroup');
         // TODO: replace with forEachAsync
-          for (let index = 0; index < NUM_OF_BUTTONS_IN_EXAMPLE; index++) {
-            const driver = flattenInternalDriver(groupDriver.getButtonDriver(index));
-            await expectNotFocused(`button ${index} - before`, driver);
-            await pressTab();
-            await expectFocusedByKeyboard(`button ${index} - after`, driver);
-            index === 0 && await eyes.checkWindow(`button ${index} with focus-visible`);
-          }
-        });
+      for (let index = 0; index < NUM_OF_BUTTONS_IN_EXAMPLE; index++) {
+        const driver = flattenInternalDriver(groupDriver.getButtonDriver(index));
+        await expectNotFocused(`button ${index} - before`, driver);
+        await pressTab();
+        await expectFocusedByKeyboard(`button ${index} - after`, driver);
+        index === 0 && await eyes.checkWindow(`button ${index} with focus-visible`);
+      }
     });
 
     it('should to be selected but NOT to show focus styles when clicked by mouse', async () => {
-      waitForVisibilityOf(radioGroupDriver.element(), 'Cannot find RadioGroup')
-        .then(async () => {
+      await waitForVisibilityOf(radioGroupDriver.element(), 'Cannot find RadioGroup');
         // TODO: replace with forEachAsync
-          for (let index = 0; index < NUM_OF_BUTTONS_IN_EXAMPLE; index++) {
-            const driver = flattenInternalDriver(groupDriver.getButtonDriver(index));
-            await expectNotFocused(`button ${index} - before`, driver);
-            await driver.clickRoot();
-            expect(await radioGroupDriver.isRadioChecked(index)).toBe(true);
-            await expectFocusedByMouse(`button ${index} - after`, driver);
-          }
-        });
+      for (let index = 0; index < NUM_OF_BUTTONS_IN_EXAMPLE; index++) {
+        const driver = flattenInternalDriver(groupDriver.getButtonDriver(index));
+        await expectNotFocused(`button ${index} - before`, driver);
+        await driver.clickRoot();
+        expect(await radioGroupDriver.isRadioChecked(index)).toBe(true);
+        await expectFocusedByMouse(`button ${index} - after`, driver);
+      }
     });
 
     eyes.it('should show focus styles on first item (selected)', async () => {
       await autoExampleDriver.setProps({value: 1});
-      await waitForVisibilityOf(radioGroupDriver.element(), 'Cannot find RadioGroup')
-        .then(async () => {
-          const driver = flattenInternalDriver(groupDriver.getButtonDriver(0));
-          expect(await radioGroupDriver.isRadioChecked(0)).toBe(true);
-          await expectNotFocused(`button 0 - before`, driver);
-          await pressTab();
-          await expectFocusedByKeyboard(`button 0 - after`, driver);
-        });
+      await waitForVisibilityOf(radioGroupDriver.element(), 'Cannot find RadioGroup');
+      const driver = flattenInternalDriver(groupDriver.getButtonDriver(0));
+      expect(await radioGroupDriver.isRadioChecked(0)).toBe(true);
+      await expectNotFocused(`button 0 - before`, driver);
+      await pressTab();
+      await expectFocusedByKeyboard(`button 0 - after`, driver);
     });
   });
 });

--- a/src/RadioGroup/RadioGroup.spec.js
+++ b/src/RadioGroup/RadioGroup.spec.js
@@ -123,18 +123,6 @@ describe('RadioGroup', () => {
     });
   });
 
-  describe('label appearance', () => {
-    it('should be T1.1 by default', () => {
-      const driver = createDriver(elementToRender());
-      expect(driver.getClassOfLabelAt(0)).toContain('t1_1');
-    });
-
-    it('should be T1.4 when disabled', () => {
-      const driver = createDriver(elementToRender({disabled: true}));
-      expect(driver.getClassOfLabelAt(0)).toContain('t1_4');
-    });
-  });
-
   describe('testkit', () => {
     it('should exist', () => {
       expect(isTestkitExists(<RadioGroup/>, radioGroupTestkitFactory)).toBe(true);

--- a/src/Selector/ProgressBar/ProgressBar.js
+++ b/src/Selector/ProgressBar/ProgressBar.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import WixComponent from '../../BaseComponents/WixComponent';
 import s from './ProgressBar.scss';
-import Typography from '../../Typography';
+import Heading from '../../Heading';
 
 class ProgressBar extends WixComponent {
   static propTypes = {
@@ -12,7 +12,7 @@ class ProgressBar extends WixComponent {
   render() {
     return (
       <div className={s['progress-bar']}>
-        <span className={Typography.t5}>{`${this.props.progress}%`}</span>
+        <Heading appearance="H6">{`${this.props.progress}%`}</Heading>
         <span className={s.bar}>
           <span className={s['bar-value']} style={{width: this.props.progress + '%'}}/>
           <span className={s['bar-leftover']} style={{width: (100 - this.props.progress) + '%'}}/>

--- a/src/Tag/Tag.js
+++ b/src/Tag/Tag.js
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import styles from './Tag.scss';
 import CloseButton from '../CloseButton';
 import WixComponent from '../BaseComponents/WixComponent';
-import Typography from '../Typography';
+import Text from '../Text';
 
 /**
   * A Tag component
@@ -22,8 +22,7 @@ class Tag extends WixComponent {
     });
 
     const innerClassName = classNames({
-      [styles.innerTagWrap]: wrap,
-      [Typography.t4]: true
+      [styles.innerTagWrap]: wrap
     });
 
     const title = wrap ? children : '';
@@ -41,7 +40,11 @@ class Tag extends WixComponent {
         }}
         >
         {thumb && <span className={styles.thumb}>{thumb}</span>}
-        <span className={innerClassName}>{children}</span>
+        <span className={innerClassName}>
+          <Text size="small" weight="normal">
+            {children}
+          </Text>
+        </span>
         {removable && !disabled && <a
           className={styles.tagRemoveButton}
           onClick={event => {

--- a/src/Text/Text.js
+++ b/src/Text/Text.js
@@ -3,25 +3,7 @@ import {oneOf, bool, string, any} from 'prop-types';
 import style from './Text.st.css';
 import deprecationLog from '../utils/deprecationLog';
 import omit from 'lodash/omit';
-
-export const SIZES = {
-  tiny: 'tiny',
-  small: 'small',
-  medium: 'medium'
-};
-
-export const SKINS = {
-  standard: 'standard',
-  error: 'error',
-  success: 'success',
-  premium: 'premium'
-};
-
-export const WEIGHTS = {
-  thin: 'thin',
-  normal: 'normal',
-  bold: 'bold'
-};
+import {SKINS, SIZES, WEIGHTS} from './constants';
 
 const Text = ({size, secondary, skin, light, bold, weight, tagName, children, ...rest}) => {
   if (bold !== undefined) {

--- a/src/Text/Text.spec.js
+++ b/src/Text/Text.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import textDriverFactory from './Text.driver';
 import Text from './';
-import {SIZES, SKINS, WEIGHTS} from './Text';
+import {SIZES, SKINS, WEIGHTS} from './constants';
 import {createDriverFactory} from 'wix-ui-test-utils/driver-factory';
 import {isEnzymeTestkitExists} from 'wix-ui-test-utils/enzyme';
 import {isTestkitExists} from 'wix-ui-test-utils/vanilla';

--- a/src/Text/constants.js
+++ b/src/Text/constants.js
@@ -1,0 +1,18 @@
+export const SIZES = {
+  tiny: 'tiny',
+  small: 'small',
+  medium: 'medium'
+};
+
+export const SKINS = {
+  standard: 'standard',
+  error: 'error',
+  success: 'success',
+  premium: 'premium'
+};
+
+export const WEIGHTS = {
+  thin: 'thin',
+  normal: 'normal',
+  bold: 'bold'
+};

--- a/src/Text/index.js
+++ b/src/Text/index.js
@@ -1,1 +1,2 @@
 export {default} from './ProxyText';
+export * from './constants';

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -223,7 +223,6 @@ class Tooltip extends WixComponent {
       const theme = this.props.popover ? popoverConfig.theme : this.props.theme;
 
       const arrowPlacement = {top: 'bottom', left: 'right', right: 'left', bottom: 'top'};
-      console.log(this.props.placement, 'what we send');
       const position = this.props.relative ? 'relative' : 'absolute';
       const tooltip = (
         <TooltipContent

--- a/src/typography-helpers.scss
+++ b/src/typography-helpers.scss
@@ -40,7 +40,7 @@ $typography_headers: (
   
   @if $light {
     color: nth($colors, 2);
-  } else {
+  } @else {
     color: nth($colors, 1);
   }
 }

--- a/stories/FieldWithSelectionComposite/FieldWithSelectionTemplate.js
+++ b/stories/FieldWithSelectionComposite/FieldWithSelectionTemplate.js
@@ -8,8 +8,8 @@ import Checkbox from '../../src/Checkbox';
 import Label from '../../src/Label';
 import Dropdown from '../../src/Dropdown';
 import RadioGroup from '../../src/RadioGroup';
+import Text from '../../src/Text';
 
-import typography, {convertFromUxLangToCss} from '../../src/Typography';
 import StorySettings from './StorySettings';
 
 const options = [
@@ -60,9 +60,9 @@ export default class Form extends Component {
             checked={this.state.checkboxValue}
             onChange={e => this.setState({checkboxValue: e.target.checked})}
             >
-            <span className={typography[convertFromUxLangToCss('T3.1')]}>
+            <Text weight="thin" size="small" secondary>
               Test
-            </span>
+            </Text>
           </Checkbox>
         );
         break;

--- a/stories/FormField/ExampleWithLengthCount.js
+++ b/stories/FormField/ExampleWithLengthCount.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import FormField from 'wix-style-react/FormField';
+import Input from 'wix-style-react/Input';
+
+export default () => (
+  <FormField label="Tweet" dataHook="storybook-formfield-length-count">
+    {({setCharactersLeft}) =>
+      <Input
+        dataHook="storybook-formfield-length-count-input"
+        onChange={event => setCharactersLeft(20 - event.target.value.length)}
+        />
+    }
+  </FormField>
+);

--- a/stories/FormField/FormField.story.js
+++ b/stories/FormField/FormField.story.js
@@ -1,11 +1,16 @@
 import React from 'react';
 
+import CodeExample from 'wix-storybook-utils/CodeExample';
+
 import FormField from 'wix-style-react/FormField';
 import Input from 'wix-style-react/Input';
 import InputArea from 'wix-style-react/InputArea';
 import RichTextArea from 'wix-style-react/RichTextArea';
 import DatePicker from 'wix-style-react/DatePicker';
 import Dropdown from 'wix-style-react/Dropdown';
+
+import ExampleWithLengthCount from './ExampleWithLengthCount';
+import ExampleWithLengthCountRaw from '!raw-loader!./ExampleWithLengthCount';
 
 const ID = 'formFieldId';
 
@@ -56,7 +61,7 @@ export default {
   category: 'Components',
   storyName: 'FormField',
   component: FormField,
-  componentPath: '../src/FormField',
+  componentPath: '../../src/FormField',
 
   componentProps: {
     dataHook: 'storybook-formfield',
@@ -70,5 +75,13 @@ export default {
   exampleProps: {
     children: childrenExamples,
     infoTooltipProps: [{label: 'placement left', value: {placement: 'left'}}]
-  }
+  },
+  examples: (
+    <CodeExample title="With Length Count" code={ExampleWithLengthCountRaw}>
+      <div style={{width: '500px'}}>
+        <ExampleWithLengthCount/>
+      </div>
+    </CodeExample>
+
+  )
 };

--- a/stories/Text/index.story.js
+++ b/stories/Text/index.story.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Text from 'wix-style-react/Text';
-import {SIZES, SKINS, WEIGHTS} from '../../src/Text/Text';
+import {SIZES, SKINS, WEIGHTS} from '../../src/Text';
 
 import CodeExample from 'wix-storybook-utils/CodeExample';
 


### PR DESCRIPTION
- [x] EndorseContentLayout - refactor
- [x] FormField - refactor  (Add e2e test)
- [x] ThemedInput - use mixin
- [x] RadioButton - use `<Text/>` - updated disabled color
- [x] Loader - update `t5`->`h6`
- [x] ProgressBar - update `t5`->`h6` (Is this component deprecated?)
- [x] DataTable - [Refactor] Either add new Typography classes and use them (currently we have only mixins), or use `<Text/>` component, but that needs a performance check. Finally decided to use the mixins.
- [x] FieldWithSelection story
- [x] Tag