### PR TITLE
<InputWithOptions/>- fix bug to allow re-selection of the same option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Types of changes:
 - `<SectionHelper/>` - add box-sizing to not break styles [#2202](https://github.com/wix/wix-style-react/pull/2202)
 - `<Tooltip/>` - fix tooltip jumping [#2225](https://github.com/wix/wix-style-react/pull/2225)
 - `<ButtonLayout/>` - remove border from button focus [#2234](https://github.com/wix/wix-style-react/pull/2234)
+- `<InputWithOptions/>` - fix inability to re-select the same option after typing something 
 
 ### Changed
 - `<ButtonLayout/>` - update typography [#2198](https://github.com/wix/wix-style-react/pull/2198)
@@ -32,6 +33,7 @@ Types of changes:
 
 ## Removed
 - Remove dead code `src/Backoffice/ButtonLayout` (was never in use) [#2231](https://github.com/wix/wix-style-react/pull/2231)
+- `<InputWithOptions/>` - remove `selectedId` prop (it's an internal state)
 
 ### Docs
 - `<Badge/>` - migrate story to autodocs [#2221](https://github.com/wix/wix-style-react/pull/2221)

--- a/src/InputWithOptions/InputWithOptions.js
+++ b/src/InputWithOptions/InputWithOptions.js
@@ -23,11 +23,13 @@ class InputWithOptions extends WixComponent {
 
   constructor(props) {
     super(props);
+    const selectedOptionId = this._getOptionIdByValue(this.props.value);
     this.state = {
       inputValue: props.value || '',
       showOptions: false,
       lastOptionsShow: 0,
-      isEditing: false
+      isEditing: false,
+      selectedOptionId
     };
 
     this._onSelect = this._onSelect.bind(this);
@@ -45,6 +47,16 @@ class InputWithOptions extends WixComponent {
     this._onInputClicked = this._onInputClicked.bind(this);
     this.closeOnSelect = this.closeOnSelect.bind(this);
     this.onCompositionChange = this.onCompositionChange.bind(this);
+    this._getOptionIdByValue = this._getOptionIdByValue.bind(this);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.value !== this.props.value) {
+      const selectedOptionId = this._getOptionIdByValue(nextProps.value);
+      this.setState({
+        selectedOptionId
+      });
+    }
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -102,7 +114,7 @@ class InputWithOptions extends WixComponent {
 
   _renderDropdownLayout() {
     const inputOnlyProps = omit(['tabIndex'], Input.propTypes);
-    const dropdownProps = Object.assign(omit(Object.keys(inputOnlyProps).concat(['dataHook']), this.props), this.dropdownAdditionalProps());
+    const dropdownProps = Object.assign(omit(Object.keys(inputOnlyProps).concat(['dataHook', 'selectedId']), this.props), this.dropdownAdditionalProps());
 
     const customStyle = {marginLeft: this.props.dropdownOffsetLeft};
 
@@ -118,6 +130,7 @@ class InputWithOptions extends WixComponent {
         <DropdownLayout
           ref={dropdownLayout => this.dropdownLayout = dropdownLayout}
           {...dropdownProps}
+          selectedId={this.state.selectedOptionId}
           options={this._processOptions(dropdownProps.options)}
           theme={this.props.theme}
           visible={isDropdownLayoutVisible}
@@ -191,15 +204,23 @@ class InputWithOptions extends WixComponent {
     if (isSelectedOption) {
       this.setState({showOptions: false});
     } else if (onSelect) {
+      this.setState({selectedOptionId: option.id});
       onSelect(this.props.highlight ? this.props.options.find(opt => opt.id === option.id) : option);
     }
   }
 
   _onChange(event) {
-    this.setState({inputValue: event.target.value});
+    const {value} = event.target;
+    const selectedOptionId = this._getOptionIdByValue(value);
+    this.setState({inputValue: value, selectedOptionId});
     if (this.props.onChange) {
       this.props.onChange(event);
     }
+  }
+
+  _getOptionIdByValue(value) {
+    const option = this.props.options.find(opt => opt.value === value);
+    return option ? option.id : null;
   }
 
   _onInputClicked(event) {

--- a/src/InputWithOptions/README.md
+++ b/src/InputWithOptions/README.md
@@ -9,7 +9,6 @@
 | options | array | [] | - | Array of objects to display as options when focused. Objects can include *text* and *node*. If the text is `-`, a divider will be rendered at that position. |
 | onSelect | func | noop | - | Callback when the user selects one of the selections. Called with the selection. |
 | onManuallyInput | func | noop | - | Callback when the user pressed the Enter key or Tab key after he wrote in the Input field - meaning the user selected something not in the list, this function will return a suggested option as the second parameter if found one |
-| selectedId | string/number | - | - | The id of the selected option in the list |
 | closeOnSelect | bool | true | - | Should the options container close on selection |
 | inputElement | element | - | - | Set the component input element |
 | disabled | bool | false | - |  when set to true this component is disabled |
@@ -20,7 +19,7 @@
 | dropdownWidth | string | - | - | An optional custom width for the dropdown |
 | dropdownOffsetLeft | string | 0 | - | An optional horizontal offset to the dropdown |
 | highlight | bool | false | - | Enables highlighting |
-| ***All of the Input's and DropdownLayout Props are also available for this component*** | | | | |
+| ***All of the Input's and DropdownLayout Props (except for `selectedId`) are also available for this component*** | | | | |
 
 ## Functions
 

--- a/stories/InputWithOptions/ExampleControlled.js
+++ b/stories/InputWithOptions/ExampleControlled.js
@@ -22,8 +22,7 @@ class ControlledInputWithOptions extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      value: '',
-      selectedId: -1
+      value: options[4].value
     };
   }
 
@@ -57,7 +56,6 @@ class ControlledInputWithOptions extends React.Component {
     return (
       <InputWithOptions
         options={options.filter(predicate)}
-        selectedId={this.state.selectedId}
         value={this.state.value}
         onChange={onChange}
         onSelect={onSelect}


### PR DESCRIPTION
…option

### What changed
fix inability to re-select the same option after typing something
remove `selectedId` prop (it's an internal state)
### Why it changed
if you chose an option from the dropdown, typed something, and tried to re-select that option, it wouldn't let you.

also, the `selectedId` prop of `inputWithOption` relates to internal state and shouldn't be exposed to the user (there's no practical use case for selecting an option from the dropdown if the value in the input box is different)

---

- [ ] Change is tested
- [X] Change is documented
- [ ] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
