### PR TITLE
<SortableList/> - disable drag for specific list items

### DIFF
--- a/src/DragAndDrop/Draggable/Draggable.js
+++ b/src/DragAndDrop/Draggable/Draggable.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import identity from 'lodash/identity';
 
 import WixComponent from '../../BaseComponents/WixComponent';
 import DraggableSource from './components/DraggableSource';
@@ -7,9 +8,19 @@ import DraggableTarget from './components/DraggableTarget';
 
 export class Draggable extends WixComponent {
   render() {
-    return (
+    const { item, id } = this.props;
+    return this.props.disabled ? (
+      this.props.renderItem({
+        ...this.props,
+        isPlaceHolder: false,
+        isPreview: false,
+        connectHandle: identity,
+        item,
+        id
+      })
+    ) : (
       <DraggableTarget {...this.props}>
-        <DraggableSource {...this.props}/>
+        <DraggableSource {...this.props} />
       </DraggableTarget>
     );
   }
@@ -39,7 +50,9 @@ Draggable.propTypes = {
   /** callback for drag start */
   onDragStart: PropTypes.func,
   /** callback for drag end */
-  onDragEnd: PropTypes.func
+  onDragEnd: PropTypes.func,
+  /** Disabled Drag and Drop Item */
+  disabled: PropTypes.bool
 };
 
 export default Draggable;

--- a/src/DragAndDrop/Draggable/Draggable.js
+++ b/src/DragAndDrop/Draggable/Draggable.js
@@ -8,7 +8,7 @@ import DraggableTarget from './components/DraggableTarget';
 
 export class Draggable extends WixComponent {
   render() {
-    const { item, id } = this.props;
+    const {item, id} = this.props;
     return this.props.disabled ? (
       this.props.renderItem({
         ...this.props,
@@ -20,7 +20,7 @@ export class Draggable extends WixComponent {
       })
     ) : (
       <DraggableTarget {...this.props}>
-        <DraggableSource {...this.props} />
+        <DraggableSource {...this.props}/>
       </DraggableTarget>
     );
   }

--- a/src/SortableList/SortableList.js
+++ b/src/SortableList/SortableList.js
@@ -111,6 +111,7 @@ export default class SortableList extends WixComponent {
               <Draggable
                 {...common}
                 key={`${item.id}-${index}-${this.props.containerId}`}
+                disabled={item.disabled}
                 id={item.id}
                 index={index}
                 item={item}
@@ -142,7 +143,7 @@ SortableList.propTypes = {
     inside of renderItem callback
   */
   dragPreview: PropTypes.bool,
-  /** list of items with {id: any} */
+  /** list of items with {id: any, disabled:bool} */
   items: PropTypes.array,
   /** callback for drag start */
   onDragStart: PropTypes.func,

--- a/stories/DragAndDrop/Introduction/IntroductionExample.js
+++ b/stories/DragAndDrop/Introduction/IntroductionExample.js
@@ -9,24 +9,31 @@ import styles from './IntroductionExample.scss';
 export default class IntroductionExample extends React.Component {
   constructor() {
     super();
-    this.state = {items: [
-      {
-        id: 'a',
-        text: 'Item 1'
-      },
-      {
-        id: 'b',
-        text: 'Item 2'
-      },
-      {
-        id: 'c',
-        text: 'Item 3'
-      },
-      {
-        id: 'd',
-        text: 'Item 4'
-      }
-    ]};
+    this.state = {
+      items: [
+        {
+          id: 'a',
+          text: 'Item 1'
+        },
+        {
+          id: 'b',
+          text: 'Item 2'
+        },
+        {
+          id: 'c',
+          text: 'Item 3'
+        },
+        {
+          id: 'd',
+          text: 'Item 4'
+        },
+        {
+          id: 'e',
+          text: 'Disabled Item 5',
+          disabled: true
+        }
+      ]
+    };
   }
 
   handleDrop = ({removedIndex, addedIndex}) => {
@@ -65,4 +72,3 @@ export default class IntroductionExample extends React.Component {
     );
   }
 }
-

--- a/stories/DragAndDrop/Introduction/IntroductionExample.js
+++ b/stories/DragAndDrop/Introduction/IntroductionExample.js
@@ -26,11 +26,6 @@ export default class IntroductionExample extends React.Component {
         {
           id: 'd',
           text: 'Item 4'
-        },
-        {
-          id: 'e',
-          text: 'Disabled Item 5',
-          disabled: true
         }
       ]
     };

--- a/stories/DragAndDrop/SortableList/SingleAreaList/SingleAreaList.js
+++ b/stories/DragAndDrop/SortableList/SingleAreaList/SingleAreaList.js
@@ -10,8 +10,11 @@ import styles from './SingleAreaList.scss';
 const generateId = () => Math.floor((Math.random() * 100000));
 
 export default class SingleAreaList extends React.Component {
+
+  //These are just example props for the documentation
   static propTypes = {
-    withHandle: PropTypes.bool
+    withHandle: PropTypes.bool,
+    withDisabledItems: PropTypes.bool
   };
 
   state = {
@@ -26,7 +29,8 @@ export default class SingleAreaList extends React.Component {
       },
       {
         id: generateId(),
-        text: 'Item 3'
+        text: `Item 3${this.props.withDisabledItems ? ' disabled' : ''}`,
+        disabled: this.props.withDisabledItems
       },
       {
         id: generateId(),

--- a/stories/DragAndDrop/SortableList/SingleAreaList/index.js
+++ b/stories/DragAndDrop/SortableList/SingleAreaList/index.js
@@ -24,5 +24,9 @@ export default () => (
     <CodeExample title="SortableList with handle" code={SingleAreaListRawCombined}>
       <SingleAreaList withHandle/>
     </CodeExample>
+
+    <CodeExample title="SortableList with disabled items" code={SingleAreaListRawCombined}>
+      <SingleAreaList withDisabledItems/>
+    </CodeExample>
   </div>
 );


### PR DESCRIPTION
### What changed
Added disabled prop to draggable item
...

### Why it changed
Needed in order to have static elements in a DnD list for Price Quotes (Table header) or Trash like components
...

---

- [ ] Change is tested
- [ ] Change is documented
- [ ] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
