### PR TITLE
fix(Tooltip): remove event.stopPropagation

### DIFF
--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -396,9 +396,8 @@ class Tooltip extends WixComponent {
     this._hideOrShow('focus');
   }
 
-  _onClick(event) {
+  _onClick() {
     this._hideOrShow('click');
-    event.stopPropagation();
   }
 
   _onMouseEnter() {


### PR DESCRIPTION
there are cases when event bubbling is expected but does not happen
because of this line

https://github.com/wix/wix-style-react/commit/4d34669c7#r30580075
https://github.com/wix/wix-style-react/pull/2031#discussion_r219475350
