### PR TITLE
docs: split D&D and SortableList styles

### DIFF
--- a/src/SortableList/API.md
+++ b/src/SortableList/API.md
@@ -86,7 +86,7 @@ Some details about complex props
   state(maybe we want to rotate it a little, or hide something),
   so you able to style your item by cheking isPreview.
   - `id` - an id from item that you render
-  - `previewStyles` - styles that coming from SotableList, `you always need to apply` them on your root div, inside of renderItem
+  - `previewStyles` - styles that coming from SortableList, `you always need to apply` them on your root div, inside of renderItem
   - `item` - item that you are render
 
   Example without handle:

--- a/stories/DragAndDrop/DragAndDrop.js
+++ b/stories/DragAndDrop/DragAndDrop.js
@@ -8,7 +8,7 @@ import Badge from 'wix-style-react/Badge';
 
 import SortableListReadme from './../../src/SortableList/README.md';
 import SortableListReadmeAPI from './../../src/SortableList/API.md';
-import {SingleAreaList, MultiAreaList, MultiAreaListWithSortableColumns} from './SortableList';
+import {SingleAreaList, MultiAreaList, MultiAreaListWithSortableColumns, Styles as SortableListStyles} from './SortableList';
 
 import Introduction from './Introduction';
 import Styles from './Styles';
@@ -29,6 +29,7 @@ storiesOf('WIP/Drag And Drop/SortableList', module)
       <Markdown source={SortableListReadmeAPI}/>
     </div>
   ))
+  .add('Styles', () => <SortableListStyles/>)
   .add('Single Area List', () => <SingleAreaList/>)
   .add('Multi Area List', () => <MultiAreaList/>)
   .add('Multi Area List with sortable columns', () => <MultiAreaListWithSortableColumns/>);

--- a/stories/DragAndDrop/SortableList/SingleAreaList/SingleAreaList.js
+++ b/stories/DragAndDrop/SortableList/SingleAreaList/SingleAreaList.js
@@ -12,7 +12,8 @@ const generateId = () => Math.floor((Math.random() * 100000));
 export default class SingleAreaList extends React.Component {
   static propTypes = {
     withHandle: PropTypes.bool
-  }
+  };
+
   state = {
     items: [
       {
@@ -36,7 +37,7 @@ export default class SingleAreaList extends React.Component {
         text: 'Item 5'
       }
     ]
-  }
+  };
 
   handleDrop = ({removedIndex, addedIndex}) => {
     const nextItems = [...this.state.items];

--- a/stories/DragAndDrop/SortableList/Styles/Styles.js
+++ b/stories/DragAndDrop/SortableList/Styles/Styles.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import Markdown from 'wix-storybook-utils/Markdown';
+
+import Styles from './Styles.md';
+
+export default () => (
+  <div>
+    <Markdown source={Styles}/>
+  </div>
+);

--- a/stories/DragAndDrop/SortableList/Styles/Styles.md
+++ b/stories/DragAndDrop/SortableList/Styles/Styles.md
@@ -1,0 +1,63 @@
+# Styles
+`<SortableList/>` provides mainly the sorting drag and drop behavior, but it also has mandatory styles which are required to be applied in order to set to set the correct positioning for item that you drag.
+Also, as `<SortableList/>` can not fit all possible styles, it give you the freedom to apply your styles to make it look as you wish.
+
+  To see how styles are used and extended please refer to the **Single Item** code example.
+
+## Default styles
+The default styles should be consumed from the common `dnd-styles` entry and sent in the following:
+* `className` - will be applied to the root div of the component.
+* `contentClassName` - will be applied to the first parent of list items. This is helpful when you need some padding between items.
+* Inside the `renderItem` returned element
+
+## Mandatory (inline) styles
+You, the consumer, must apply some styles in certain cases to make sure drag and drop behavior works well.
+There styles will be passed to the `renderItem` callback function you provide to the component in the named parameter `previewStyles` as one of it's parameters.
+
+We do not recommend to modify this object or to merge it with another inline styles, prefer css classes for other modifications.
+
+### Usage example:
+```js
+renderItem={({previewStyles}) => (
+  <div style={previewStyles}>
+    your item
+  </div>
+)}
+```
+
+## Conditional styles
+As the `renderItem` callback function returns is a renderer to all items scenarios, it is also responsible to render the preview and placeholder of the item.
+The provided parameters `isPlaceholder`, `isPreview` will help you understand which style is required.
+
+## Customized styles
+we suggest using the [`classnames`](https://github.com/JedWatson/classnames) package to combine both mandatory and additional styles
+
+### Example
+```js
+...
+import dndStyles from 'wix-style-react/dnd-styles';
+import styles from './custom-styles.scss'
+import classNames from 'classnames';
+...
+export default () =>
+  <SortableList
+    className={classNames(dndStyles.list, styles.list)}
+    contentClassName={styles.content}
+    renderItem={({isPlaceholder, isPreview, previewStyles}) => (
+      const classes = classNames(
+        dndStyles.item,
+        styles.item,
+        {
+          [classNames(dndStyles.itemPlaceholder, styles.itemPlaceholder)]: isPlaceholder,
+          [classNames(dndStyles.itemPreview, styles.itemPreview)]: isPreview
+        }
+      );
+      return (
+        <div className={classes} style={previewStyles}>
+          your item
+        </div>
+      )
+    )}
+    {...otherProps}
+  />
+```

--- a/stories/DragAndDrop/SortableList/Styles/index.js
+++ b/stories/DragAndDrop/SortableList/Styles/index.js
@@ -1,0 +1,1 @@
+export {default} from './Styles';

--- a/stories/DragAndDrop/SortableList/index.js
+++ b/stories/DragAndDrop/SortableList/index.js
@@ -1,3 +1,4 @@
 export {default as SingleAreaList} from './SingleAreaList';
 export {default as MultiAreaList} from './MultiAreaList';
 export {default as MultiAreaListWithSortableColumns} from './MultiAreaListWithSortableColumns';
+export {default as Styles} from './Styles';

--- a/stories/DragAndDrop/Styles/Styles.js
+++ b/stories/DragAndDrop/Styles/Styles.js
@@ -1,11 +1,37 @@
 import React from 'react';
 
 import Markdown from 'wix-storybook-utils/Markdown';
+import CodeExample from 'wix-storybook-utils/CodeExample';
+
+import ItemExample from './examples/Item';
+import ItemExampleRaw from '!raw-loader!./examples/Item';
+import ItemPlaceholderExample from './examples/ItemPlaceholder';
+import ItemPlaceholderExampleRaw from '!raw-loader!./examples/ItemPlaceholder';
+import ItemPreviewExample from './examples/ItemPreview';
+import ItemPreviewExampleRaw from '!raw-loader!./examples/ItemPreview';
+import ListExample from './examples/List';
+import ListExampleRaw from '!raw-loader!./examples/List';
 
 import Styles from './Styles.md';
 
 export default () => (
   <div>
     <Markdown source={Styles}/>
+
+    <CodeExample title="dndStyles.item" code={ItemExampleRaw}>
+      <ItemExample/>
+    </CodeExample>
+
+    <CodeExample title="dndStyles.itemPlaceholder" code={ItemPlaceholderExampleRaw}>
+      <ItemPlaceholderExample/>
+    </CodeExample>
+
+    <CodeExample title="dndStyles.itemPreview" code={ItemPreviewExampleRaw}>
+      <ItemPreviewExample/>
+    </CodeExample>
+
+    <CodeExample title="dndStyles.list" code={ListExampleRaw}>
+      <ListExample/>
+    </CodeExample>
   </div>
 );

--- a/stories/DragAndDrop/Styles/Styles.md
+++ b/stories/DragAndDrop/Styles/Styles.md
@@ -18,8 +18,8 @@ Your component should use these styles and extend with any custom styles if need
 
  - `list` - defines the structure of items list.
  - `item` - defines a single item resets. should be applied to the root of your item
- - `itemPlaceholder` - defines how an item placeholder should look when raised. should be applied to the root of your item in placeholder mode
- - `itemPreview` - defines how an item should look when is dragged (fly). should be applied to the root of your item in preview mode
+ - `itemPlaceholder` - defines how an item's placeholder (the empty section after dragging) looks like. should be applied to the root of your item in placeholder mode
+ - `itemPreview` - defines how an item should look while it is dragged. should be applied to the root of your item in preview mode
 
 
 ## Still missing (TODO)

--- a/stories/DragAndDrop/Styles/Styles.md
+++ b/stories/DragAndDrop/Styles/Styles.md
@@ -1,90 +1,24 @@
 # Styles
-SortableList accept such style props:
- * `className` - will be applied to the root div of `<SortableList/>` component
- * `contentClassName` - will be applied to the first parent of items, that `<SortableList/>` received
 
-Also, with renderItem callback you are able to do render and style `<SortableList/>` items as you want
+As `wix-style-react` provides the building block for creating draggable lists, it also provide the common useful styles.
 
-##### Example
+
+## Importing
 ```js
-  <SortableList
-    className="my-class-for-sortable-list"
-    contentClassName="my-class-for-sortable-list-content"
-    renderItem={({isPlaceholder, isPreview, id, previewStyles, item}) => (
-      const classes = classNames(
-        'my-class-for-item',
-        {
-          'my-class-for-item-in-placeholder-state': isPlaceholder,
-          'my-class-for-item-in-preview-state': isPreview
-        }
-      );
-      return (
-        <div className={classes} style={previewStyles}>
-          {item.text}
-        </div>
-      )
-    )}
-    {...otherProps}
-  />
+import dndStyles from 'wix-style-react/dnd-styles';
 ```
 
-# Default styles
-We propose always to use default styles which you can import in such way
-```js
-  import dndStyles from 'wix-style-react/dnd-styles';
-```
-dndStyles has:
- - `dndStyles.list` - class that should be send to `<SortableList/>` root
- - `dndStyles.item` - class that should be applied to the root of your item
- - `dndStyles.itemPlaceholder` - class that should be applied to the root of your item in placeholder mode
- - `dndStyles.itemPreview` - class that should be applied to the root of your item in preview mode
+`dndStyles` is an object containing the default class names.
 
- ##### Example
-```js
-  ...
-  import dndStyles from 'wix-style-react/dnd-styles';
-  ...
+Your component should use these styles and extend with any custom styles if needed.
 
-  <SortableList
-    className={`my-class-for-sortable-list ${dndStyles.list}`}
-    contentClassName="my-class-for-sortable-list-content"
-    renderItem={({isPlaceholder, isPreview, id, previewStyles, item}) => (
-      const classes = classNames(
-        `my-class-for-item ${dndStyles.item}`,
-        {
-          [`my-class-for-item-in-placeholder-state ${dndStyles.itemPlaceholder}`]: isPlaceholder,
-          [`my-class-for-item-in-preview-state ${dndStyles.itemPreview}`]: isPreview
-        }
-      );
-      return (
-        <div className={classes} style={previewStyles}>
-          {item.text}
-        </div>
-      )
-    )}
-    {...otherProps}
-  />
-```
+## Styles API
 
-# Inline styles for item
-```js
-renderItem={({isPlaceholder, isPreview, id, previewStyles, item}) => (
-  const classes = classNames(
-    `my-class-for-item ${dndStyles.item}`,
-    {
-      [`my-class-for-item-in-placeholder-state ${dndStyles.itemPlaceholder}`]: isPlaceholder,
-      [`my-class-for-item-in-preview-state ${dndStyles.itemPreview}`]: isPreview
-    }
-  );
-  return (
-    <div className={classes} style={previewStyles}>
-      {item.text}
-    </div>
-  )
-)}
-```
+`dndStyles` is consists of:
 
-renderItem accept `previewStyles` as one of the parameters, `previewStyles`
-need to be applied to the root of your item, it required to allow d&d engine to set correct position for item that you drag.
+ - `list` - defines the structure of items list.
+ - `item` - defines a single item resets. should be applied to the root of your item
+ - `itemPlaceholder` - defines how an item placeholder should look when raised. should be applied to the root of your item in placeholder mode
+ - `itemPreview` - defines how an item should look when is dragged (fly). should be applied to the root of your item in preview mode
 
-We do not recommend to modify this object or to merge it with another inline styles.
+## Examples

--- a/stories/DragAndDrop/Styles/Styles.md
+++ b/stories/DragAndDrop/Styles/Styles.md
@@ -21,4 +21,8 @@ Your component should use these styles and extend with any custom styles if need
  - `itemPlaceholder` - defines how an item placeholder should look when raised. should be applied to the root of your item in placeholder mode
  - `itemPreview` - defines how an item should look when is dragged (fly). should be applied to the root of your item in preview mode
 
+
+## Still missing (TODO)
+- `handle`
+
 ## Examples

--- a/stories/DragAndDrop/Styles/examples/Item.js
+++ b/stories/DragAndDrop/Styles/examples/Item.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import dndStyles from 'wix-style-react/dnd-styles';
+
+export default () => (
+  <div className={dndStyles.item}>
+    a simple item
+  </div>
+);

--- a/stories/DragAndDrop/Styles/examples/ItemPlaceholder.js
+++ b/stories/DragAndDrop/Styles/examples/ItemPlaceholder.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import dndStyles from 'wix-style-react/dnd-styles';
+
+export default () => (
+  <div className={dndStyles.itemPlaceholder}>
+    a simple item
+  </div>
+);

--- a/stories/DragAndDrop/Styles/examples/ItemPreview.js
+++ b/stories/DragAndDrop/Styles/examples/ItemPreview.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import dndStyles from 'wix-style-react/dnd-styles';
+
+export default () => (
+  <div className={dndStyles.itemPreview}>
+    a simple item
+  </div>
+);

--- a/stories/DragAndDrop/Styles/examples/List.js
+++ b/stories/DragAndDrop/Styles/examples/List.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import dndStyles from 'wix-style-react/dnd-styles';
+
+export default () => (
+  <div className={dndStyles.list}>
+    <div>a simple item</div>
+    <div>a simple item</div>
+  </div>
+);


### PR DESCRIPTION
@Faradey27 - I split the content and revised it a little bit. Please review that it is right.

It looks to me like there are few issues in the common `dndStyles`:
- `item` - css removes the cursor sign completely with `user-select: none`, so I can't mark the text at all.
- `placholder` - supposed to be `D60`
- `preview` - currently it doesn't have any styles but ideally it would be setting 95% opacity on the item. 

We don't have to fix it in this PR, just let me know what you think