### PR TITLE
<DatePicker/> Move z-index prop to the correct element in css

### DIFF
--- a/src/DatePicker/DatePicker.scss
+++ b/src/DatePicker/DatePicker.scss
@@ -4,8 +4,11 @@
   display: inline-block;
 }
 
-.date-picker-calendar {
+.calendar-root {
   z-index: 1;
+}
+
+.date-picker-calendar {
   :global .DayPicker {
     @include popoverTheme;
   }


### PR DESCRIPTION
### What changed

Minor styling fix for DatePicker component

### Why it changed

![screen shot 2018-10-01 at 4 19 41 pm](https://user-images.githubusercontent.com/10046613/46290940-df2f0600-c595-11e8-9d4c-6674d388621c.png)

`.calendarRoot` class exists in component JSX, but removed from styles.
Seems it got lost accidentally in this PR:
https://github.com/wix/wix-style-react/commit/8efe9fae798db43d3d32d8be4b9a18f53060536d#diff-9eea5f00ca05f3d2e814a03694c881e1L7