### PR TITLE
<SideMenu/> - fix infinite loop when using React 16

### DIFF
--- a/src/SideMenu/DrillView/DrillView.js
+++ b/src/SideMenu/DrillView/DrillView.js
@@ -213,7 +213,7 @@ class SideMenuDrill extends React.Component {
     this.isAnimating = false;
     if (this.queuedUpdate) {
       this.queuedUpdate = false;
-      this.forceUpdate()
+      this.forceUpdate();
     }
   }
 

--- a/src/SideMenu/DrillView/DrillView.js
+++ b/src/SideMenu/DrillView/DrillView.js
@@ -198,9 +198,10 @@ class SideMenuDrill extends React.Component {
       </div>
     );
   }
-
   shouldComponentUpdate() {
-    this.setState({isWaitingForAnimation: true});
+    if (this.isAnimating) {
+      this.queuedUpdate = true;
+    }
     return !this.isAnimating;
   }
 
@@ -209,10 +210,10 @@ class SideMenuDrill extends React.Component {
   }
 
   animationComplete() {
-    const {isWaitingForAnimation} = this.state;
     this.isAnimating = false;
-    if (isWaitingForAnimation) {
-      this.setState({isWaitingForAnimation: false});
+    if (this.queuedUpdate) {
+      this.queuedUpdate = false;
+      this.forceUpdate()
     }
   }
 


### PR DESCRIPTION
### What changed
Removed the `setState` inside `shouldComponentUpdate`
...

### Why it changed
Because it created an infinite loop (breaks React16 specifically)
...

---

- [v ] Change is tested
- [ ] Change is documented
- [ ] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
