### PR TITLE
<InputWithOptions/> - "refactor" onKeyDown event

### DIFF
--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -68,17 +68,6 @@ class Dropdown extends InputWithOptions {
     this.setState({value: this.props.valueParser(option), selectedId: option.id});
     super._onSelect(option);
   }
-
-  _onFocus() {
-    if (this.props.disabled) {
-      return;
-    }
-    this._focused = true;
-    this.setState({isEditing: false});
-    if (this.props.onFocus) {
-      this.props.onFocus();
-    }
-  }
 }
 
 Dropdown.propTypes = InputWithOptions.propTypes;

--- a/src/DropdownLayout/DropdownLayout.js
+++ b/src/DropdownLayout/DropdownLayout.js
@@ -124,6 +124,12 @@ class DropdownLayout extends WixComponent {
     this.options.scrollTop = (newHovered - 2) * 35;
   }
 
+  /**
+   * Handle keydown events for the DropdownLayout, mostly for accessibility
+   *
+   * @param {SyntheticEvent} event - The keydown event triggered by React
+   * @returns {boolean} - Whether the event was handled by the component
+   */
   _onKeyDown(event) {
     if (!this.props.visible || this.props.isComposing) {
       return false;

--- a/src/InputWithOptions/InputWithOptions.js
+++ b/src/InputWithOptions/InputWithOptions.js
@@ -28,7 +28,6 @@ class InputWithOptions extends WixComponent {
   /**
    * Returns a list of keys that should cause the DropdownLayout to be opened.
    *
-   * @param {Object} options
    * @returns {KeyboardEvent.key[]}
    */
   getKeysForOpening() {


### PR DESCRIPTION
### What changed

This PR *partially* resolves https://github.com/wix/wix-style-react/issues/2300. It enables to open the DropdownLayout when the Enter key is pressed, and improves to readability of the a11y-related logic (mainly in `InputWithOptions#_onKeyDown`), by adding some comments that explain the behaviour.

However, it does not solve the issue where the DropdownLayout is being open when pressing Shift, Cmd, Alt/Option, and most of the keys that do not cause the input value to change. According to the a11y guidelines, the dropdown should open when the user start typing into the input.

@shlomitc maybe it'll be better to also fix the `Shift` in this PR before we merge this?

### Why it changed

https://github.com/wix/wix-style-react/issues/2300

---

- [ ] Change is tested
- [ ] Change is documented
- [ ] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
