### PR TITLE
<DropdownLayout/> - add `isInContainer` prop

### DIFF
--- a/src/DropdownLayout/DropdownLayout.js
+++ b/src/DropdownLayout/DropdownLayout.js
@@ -191,14 +191,14 @@ class DropdownLayout extends WixComponent {
   }
 
   render() {
-    const {options, visible, dropDirectionUp, tabIndex, fixedHeader, fixedFooter, withArrow, onMouseEnter, onMouseLeave, isInContainer} = this.props;
+    const {options, visible, dropDirectionUp, tabIndex, fixedHeader, fixedFooter, withArrow, onMouseEnter, onMouseLeave, inContainer} = this.props;
     const contentContainerClassName = classNames({
       [styles.contentContainer]: true,
       [styles.shown]: visible,
       [styles.up]: dropDirectionUp,
       [styles.down]: !dropDirectionUp,
       [styles.withArrow]: withArrow,
-      [styles.containerStyles]: !isInContainer
+      [styles.containerStyles]: !inContainer
     });
 
     return (
@@ -359,7 +359,7 @@ DropdownLayout.propTypes = {
   onMouseLeave: PropTypes.func,
   itemHeight: PropTypes.oneOf(['small', 'big']),
   selectedHighlight: PropTypes.bool,
-  isInContainer: PropTypes.bool
+  inContainer: PropTypes.bool
 };
 
 DropdownLayout.defaultProps = {
@@ -370,7 +370,7 @@ DropdownLayout.defaultProps = {
   closeOnSelect: true,
   itemHeight: 'small',
   selectedHighlight: true,
-  isInContainer: false
+  inContainer: false
 };
 
 DropdownLayout.NONE_SELECTED_ID = NOT_HOVERED_INDEX;

--- a/src/DropdownLayout/DropdownLayout.js
+++ b/src/DropdownLayout/DropdownLayout.js
@@ -191,13 +191,14 @@ class DropdownLayout extends WixComponent {
   }
 
   render() {
-    const {options, visible, dropDirectionUp, tabIndex, fixedHeader, fixedFooter, withArrow, onMouseEnter, onMouseLeave} = this.props;
+    const {options, visible, dropDirectionUp, tabIndex, fixedHeader, fixedFooter, withArrow, onMouseEnter, onMouseLeave, isInContainer} = this.props;
     const contentContainerClassName = classNames({
       [styles.contentContainer]: true,
       [styles.shown]: visible,
       [styles.up]: dropDirectionUp,
       [styles.down]: !dropDirectionUp,
-      [styles.withArrow]: withArrow
+      [styles.withArrow]: withArrow,
+      [styles.containerStyles]: !isInContainer
     });
 
     return (
@@ -357,7 +358,8 @@ DropdownLayout.propTypes = {
   onMouseEnter: PropTypes.func,
   onMouseLeave: PropTypes.func,
   itemHeight: PropTypes.oneOf(['small', 'big']),
-  selectedHighlight: PropTypes.bool
+  selectedHighlight: PropTypes.bool,
+  isInContainer: PropTypes.bool
 };
 
 DropdownLayout.defaultProps = {
@@ -367,7 +369,8 @@ DropdownLayout.defaultProps = {
   maxHeightPixels: 260,
   closeOnSelect: true,
   itemHeight: 'small',
-  selectedHighlight: true
+  selectedHighlight: true,
+  isInContainer: false
 };
 
 DropdownLayout.NONE_SELECTED_ID = NOT_HOVERED_INDEX;

--- a/src/DropdownLayout/DropdownLayout.scss
+++ b/src/DropdownLayout/DropdownLayout.scss
@@ -28,8 +28,6 @@ $arrowDownShadow: -3px -3px 8px rgba(0, 0, 0, .1);
 .content-container {
   background: $D80;
   border: none;
-  border-radius: 8px;
-  box-shadow: $Shadow30;
   display: none;
   opacity: 0;
   height: 0;
@@ -38,7 +36,6 @@ $arrowDownShadow: -3px -3px 8px rgba(0, 0, 0, .1);
   display: none;
   width: 100%;
   z-index: 6;
-  position: absolute;
   left: 0;
 
   -webkit-touch-callout: none;
@@ -46,6 +43,12 @@ $arrowDownShadow: -3px -3px 8px rgba(0, 0, 0, .1);
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+
+  &.containerStyles {
+    border-radius: 8px;
+    box-shadow: $Shadow30;
+    position: absolute;
+  }
 }
 
 .content-container.shown {

--- a/src/DropdownLayout/README.md
+++ b/src/DropdownLayout/README.md
@@ -25,6 +25,7 @@
 | onMouseEnter | func | - | - | Callback function called whenever the user entered with the mouse to the dropdown layout|
 | onMouseLeave | func | - | - | Callback function called whenever the user exited with the mouse from the dropdown layout|
 | selectedHighlight | bool | true | - | Whether the selected option will be highlighted when dropdown reopened|
+| isInContainer | bool | false | - | Whether the `<DropdownLayout/>` is in a container component. If `true`, some styles such as shadows, positioning and padding will be *disabled*, meaning the container component is responsible for these styles. |
 
 ## Option
 

--- a/src/DropdownLayout/README.md
+++ b/src/DropdownLayout/README.md
@@ -25,7 +25,7 @@
 | onMouseEnter | func | - | - | Callback function called whenever the user entered with the mouse to the dropdown layout|
 | onMouseLeave | func | - | - | Callback function called whenever the user exited with the mouse from the dropdown layout|
 | selectedHighlight | bool | true | - | Whether the selected option will be highlighted when dropdown reopened|
-| isInContainer | bool | false | - | Whether the `<DropdownLayout/>` is in a container component. If `true`, some styles such as shadows, positioning and padding will be *disabled*, meaning the container component is responsible for these styles. |
+| inContainer | bool | false | - | Whether the `<DropdownLayout/>` is in a container component. If `true`, some styles such as shadows, positioning and padding will be *disabled*, meaning the container component is responsible for these styles. |
 
 ## Option
 

--- a/stories/DropdownLayout/ExampleControlledInContainer.js
+++ b/stories/DropdownLayout/ExampleControlledInContainer.js
@@ -1,0 +1,38 @@
+import React, {Component} from 'react';
+import DropdownLayout from 'wix-style-react/DropdownLayout';
+
+const options = [
+  {id: 1, value: 'Option 1'},
+  {id: 2, value: 'Option 2'},
+  {id: 3, value: 'Option 3'},
+  {id: 4, value: 'Option 4'}
+];
+
+const containerStyles = {
+  width: 300,
+  display: 'inline-block',
+  lineHeight: '22px',
+  margin: 10,
+  border: '1px solid rgba(0, 0, 0, 0.6)',
+  borderRadius: 6,
+  overflow: 'auto',
+  boxShadow: '0 0 6px rgba(0, 0, 0, 0.6)',
+  padding: '6px 0'
+};
+
+class ControlledExample extends Component {
+  render() {
+    return (
+      <div style={containerStyles}>
+        <DropdownLayout
+          visible
+          options={options}
+          isInContainer
+          selectedId={2}
+          />
+      </div>
+    );
+  }
+}
+
+export default () => <ControlledExample/>;

--- a/stories/DropdownLayout/ExampleControlledInContainer.js
+++ b/stories/DropdownLayout/ExampleControlledInContainer.js
@@ -27,7 +27,7 @@ class ControlledExample extends Component {
         <DropdownLayout
           visible
           options={options}
-          isInContainer
+          inContainer
           selectedId={2}
           />
       </div>

--- a/stories/DropdownLayout/index.js
+++ b/stories/DropdownLayout/index.js
@@ -22,6 +22,9 @@ import ExampleControlledRaw from '!raw-loader!./ExampleControlled';
 import ExampleControlledWithButtons from './ExampleControlledWithButtons';
 import ExampleControlledRawWithButtons from '!raw-loader!./ExampleControlledWithButtons';
 
+import ExampleControlledInContainer from './ExampleControlledInContainer';
+import ExampleControlledInContainerRaw from '!raw-loader!./ExampleControlledInContainer';
+
 import ExampleTheme from './ExampleTheme';
 import ExampleThemeRaw from '!raw-loader!./ExampleTheme';
 
@@ -59,6 +62,10 @@ storiesOf('11. Pickers and Selectors', module)
 
         <CodeExample title="Controlled" code={ExampleControlledRaw}>
           <ExampleControlled/>
+        </CodeExample>
+
+        <CodeExample title="With custom container styles" code={ExampleControlledInContainerRaw}>
+          <ExampleControlledInContainer/>
         </CodeExample>
 
         <CodeExample title="Controlled with buttons" code={ExampleControlledRawWithButtons}>


### PR DESCRIPTION
### What changed

Added an `isInContainer` prop to `<DropdownLayout/>`. When this props is set to `true`, the container styles of the dropdown are disabled.

This is good when needing to styles to dropdown container - instead of using ugly css selectors to target the container, you can wrap the `<DropdownLayout/>` in a `<div>` and apply the styles to it.

### Why it changed

Needed for https://github.com/wix/wix-style-react/pull/2219.

---

- [ ] Change is tested
- [ ] Change is documented
- [ ] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
