### PR TITLE
<FormField/> add horizontal prop

### DIFF
--- a/src/FormField/FormField.js
+++ b/src/FormField/FormField.js
@@ -46,6 +46,9 @@ class FormField extends React.Component {
     /** whether to display an asterisk (*) or not */
     required: PropTypes.bool,
 
+    /** whether to render the field content horizontally */
+    horizontal: PropTypes.bool,
+
     /** display info icon with tooltip. Node from this prop is content of tooltip */
     infoContent: PropTypes.node,
 
@@ -93,13 +96,13 @@ class FormField extends React.Component {
   };
 
   render() {
-    const {label, required, infoContent, dataHook, id} = this.props;
+    const {label, required, horizontal, infoContent, dataHook, id} = this.props;
     const {lengthLeft} = this.state;
 
     return (
       <div
         data-hook={dataHook}
-        className={styles.root}
+        className={classnames(styles.root, {[styles.horizontal]: horizontal})}
         >
         { label &&
         <div

--- a/src/FormField/FormField.scss
+++ b/src/FormField/FormField.scss
@@ -16,6 +16,20 @@
   flex: 1 0 100%;
 }
 
+.root.horizontal {
+  flex-wrap: nowrap;
+  align-content: center;
+
+  .label {
+    margin-right: 40px;
+    margin-bottom: 0;
+  }
+
+  .children {
+    flex: 1 0 auto;
+  }
+}
+
 .childrenWithoutLabel {
   flex: 1 0 auto;
 }

--- a/stories/FormField/FormField.story.js
+++ b/stories/FormField/FormField.story.js
@@ -68,6 +68,7 @@ export default {
     children: childrenExamples[0].value,
     label: 'This is an input:',
     required: true,
+    horizontal: false,
     infoContent: 'I help you to fill info',
     id: 'formFieldId'
   },


### PR DESCRIPTION
### What changed
Added `horizontal` property and style to <FormField/>


### Why it changed
- we have classic form fields in Price Quotes, but they are in need of a horizontal layout
- it makes sense to have this simple variation


- [ ] Change is tested
- [x] Change is documented
- [ ] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
