### PR TITLE
<RadioGroup/> - add missing functionality to the testKit (isRadioDisabled)

### DIFF
--- a/src/RadioGroup/RadioGroup.driver.js
+++ b/src/RadioGroup/RadioGroup.driver.js
@@ -19,6 +19,7 @@ const radioGroupDriverFactory = ({element, wrapper, component}) => {
     getRadioAtIndex: index => radios[index],
     getSelectedValue: () => selectedRadio() ? selectedRadio().childNodes[0].value : null,
     // TODO: We should deprecate getClassOfLabelAt(). Css tests should be in e2e tests.
+    isRadioDisabled: index => radioButtons[index].disabled,
     getClassOfLabelAt: index => labels[index].className,
     isVerticalDisplay: () => isClassExists(element, 'vertical'),
     isHorizontalDisplay: () => isClassExists(element, 'horizontal'),

--- a/src/RadioGroup/RadioGroup.driver.js
+++ b/src/RadioGroup/RadioGroup.driver.js
@@ -18,8 +18,8 @@ const radioGroupDriverFactory = ({element, wrapper, component}) => {
     getRadioValueAt: index => radioButtons[index].value,
     getRadioAtIndex: index => radios[index],
     getSelectedValue: () => selectedRadio() ? selectedRadio().childNodes[0].value : null,
-    // TODO: We should deprecate getClassOfLabelAt(). Css tests should be in e2e tests.
     isRadioDisabled: index => radioButtons[index].disabled,
+    // TODO: We should deprecate getClassOfLabelAt(). Css tests should be in e2e tests.
     getClassOfLabelAt: index => labels[index].className,
     isVerticalDisplay: () => isClassExists(element, 'vertical'),
     isHorizontalDisplay: () => isClassExists(element, 'horizontal'),

--- a/src/RadioGroup/RadioGroup.e2e.js
+++ b/src/RadioGroup/RadioGroup.e2e.js
@@ -60,7 +60,7 @@ describe('RadioGroup', () => {
     eyes.it('should show focus styles when navigated by keyboard', async () => {
       await waitForVisibilityOf(radioGroupDriver.element(), 'Cannot find RadioGroup');
         // TODO: replace with forEachAsync
-      for (let index = 0; index < ; index++) {
+      for (let index = 0; index < NUM_OF_BUTTONS_IN_EXAMPLE; index++) {
         const driver = flattenInternalDriver(groupDriver.getButtonDriver(index));
         await expectNotFocused(`button ${index} - before`, driver);
         await pressTab();

--- a/src/RadioGroup/RadioGroup.e2e.js
+++ b/src/RadioGroup/RadioGroup.e2e.js
@@ -60,7 +60,7 @@ describe('RadioGroup', () => {
     eyes.it('should show focus styles when navigated by keyboard', async () => {
       await waitForVisibilityOf(radioGroupDriver.element(), 'Cannot find RadioGroup');
         // TODO: replace with forEachAsync
-      for (let index = 0; index < NUM_OF_BUTTONS_IN_EXAMPLE; index++) {
+      for (let index = 0; index < ; index++) {
         const driver = flattenInternalDriver(groupDriver.getButtonDriver(index));
         await expectNotFocused(`button ${index} - before`, driver);
         await pressTab();

--- a/src/RadioGroup/RadioGroup.spec.js
+++ b/src/RadioGroup/RadioGroup.spec.js
@@ -25,6 +25,16 @@ describe('RadioGroup', () => {
     expect(driver.getRadioValueAt(0)).toBe('1');
   });
 
+  it('should return true if a radio button is disabled and false otherwise', () => {
+    const disabledRadios = [1, 2];
+    const driver = createDriver(elementToRender({disabledRadios}));
+    expect(driver.isRadioDisabled(0)).toBe(true);
+    expect(driver.isRadioDisabled(1)).toBe(true);
+    expect(driver.isRadioDisabled(2)).toBe(false);
+    expect(driver.isRadioDisabled(3)).toBe(false);
+  });
+
+
   it('should check the option that matches the initial value', () => {
     const value = 2;
     const driver = createDriver(elementToRender({value}));

--- a/stories/RadioGroup.story.js
+++ b/stories/RadioGroup.story.js
@@ -24,6 +24,16 @@ const exampleChildren = [
   }
 ];
 
+const exampleOptions = [
+  {
+    label: 'none disabled',
+    value: []
+  }, {
+    label: 'with disabled options',
+    value: [1, 2]
+  }
+];
+
 export const NUM_OF_BUTTONS_IN_EXAMPLE = exampleChildren[0].value.length;
 
 export default {
@@ -42,6 +52,7 @@ export default {
   }),
 
   exampleProps: {
+    disabledRadios: exampleOptions,
     children: exampleChildren,
     onChange: value => value
   }


### PR DESCRIPTION
### What changed
RadioGroup testKit driver 
added missing functionality 
...

### Why it changed
from WSR storybook RadioGroup testKit:
this function did not exist on the testKit.

isRadioDisabled | index | bool | fulfilled if RadioButton in group has attribute disabled
...
---

- [x] Change is tested
- [x] Change is documented
- [ ] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
