### PR TITLE
<DropdownLayout/> - add `disableSpacing` property to an option

### DIFF
--- a/src/BadgeSelectItemBuilder/BadgeSelectItem.st.css
+++ b/src/BadgeSelectItemBuilder/BadgeSelectItem.st.css
@@ -16,6 +16,10 @@
   -st-states: skin(string);
   white-space: nowrap;
   line-height: 24px;
+
+  padding: 6px 24px 6px 20px;
+  display: flex;
+  align-items: center;
 }
 
 .marker {

--- a/src/BadgeSelectItemBuilder/BadgeSelectItemBuilder.js
+++ b/src/BadgeSelectItemBuilder/BadgeSelectItemBuilder.js
@@ -30,5 +30,6 @@ BadgeOption.propTypes = {
 
 export const badgeSelectItemBuilder = ({id, text, skin}) => ({
   id,
-  value: <BadgeOption skin={skin} text={text}/>
+  value: <BadgeOption skin={skin} text={text}/>,
+  disableSpacing: true
 });

--- a/src/DropdownLayout/DropdownLayout.js
+++ b/src/DropdownLayout/DropdownLayout.js
@@ -226,7 +226,7 @@ class DropdownLayout extends WixComponent {
   }
 
   renderOption({option, idx}) {
-    const {value, id, disabled, title, overrideStyle, linkTo} = option;
+    const {value, id, disabled, title, overrideStyle, linkTo, disableSpacing} = option;
     if (value === DIVIDER_OPTION_VALUE) {
       return this.renderDivider(idx, `dropdown-divider-${id || idx}`);
     }
@@ -241,6 +241,7 @@ class DropdownLayout extends WixComponent {
       disabled: disabled || title,
       title,
       overrideStyle,
+      disableSpacing,
       dataHook: `dropdown-item-${id}`,
       tabIndex
     });
@@ -254,11 +255,12 @@ class DropdownLayout extends WixComponent {
     return (<div key={idx} className={styles.divider} data-hook={dataHook}/>);
   }
 
-  renderItem({option, idx, selected, hovered, disabled, title, overrideStyle, dataHook, tabIndex}) {
+  renderItem({option, idx, selected, hovered, disabled, title, overrideStyle, disableSpacing, dataHook, tabIndex}) {
     const {itemHeight, selectedHighlight} = this.props;
 
     const optionClassName = classNames({
       [styles.option]: !overrideStyle,
+      [styles.spacing]: !disableSpacing,
       [styles.selected]: selected && !overrideStyle && selectedHighlight,
       wixstylereactSelected: selected && overrideStyle, //global class for items that use the overrideStyle
       [styles.hovered]: hovered && !overrideStyle,
@@ -345,7 +347,8 @@ DropdownLayout.propTypes = {
         PropTypes.string
       ]).isRequired,
       disabled: PropTypes.bool,
-      overrideStyle: PropTypes.bool
+      overrideStyle: PropTypes.bool,
+      disableSpacing: PropTypes.bool
     }),
 
     // A divider option without an id

--- a/src/DropdownLayout/DropdownLayout.scss
+++ b/src/DropdownLayout/DropdownLayout.scss
@@ -87,7 +87,6 @@ $arrowDownShadow: -3px -3px 8px rgba(0, 0, 0, .1);
   overflow: hidden;
   text-overflow: ellipsis;
   text-align: left;
-  padding: 6px 20px 6px 24px;
   @include FontLight();
 
   font-size: 16px;
@@ -95,15 +94,19 @@ $arrowDownShadow: -3px -3px 8px rgba(0, 0, 0, .1);
   cursor: pointer;
 
   width: 100%;
-  display: flex;
-  align-items: center;
 
-  &.small-height {
-    min-height: $option_height;
-  }
+  &.spacing {
+    padding: 6px 20px 6px 24px;
+    display: flex;
+    align-items: center;
 
-  &.big-height {
-    min-height: $big_option_hight;
+    &.small-height {
+      min-height: $option_height;
+    }
+
+    &.big-height {
+      min-height: $big_option_hight;
+    }
   }
 
   &.title {

--- a/src/DropdownLayout/README.md
+++ b/src/DropdownLayout/README.md
@@ -37,3 +37,4 @@
 | title | bool | false | - | Whether this option is a title or not |
 | linkTo | string | - | - | When provided the option will be an anchor to the given value |
 | overrideStyle | bool | false | - | When this is on, no external style will be added to this option, only the internal node style, for further information see the examples |
+| disableSpacing | bool | false | - | When set to `true`, the padding of the option will be disabled. This is useful when `value` is a node, that sets the option padding by itself. |


### PR DESCRIPTION
### What changed

Added a property to an option object called `disableSpacing`. When `true`, the spacing-related styles (`padding`, `display`, `align-items`) for the option will be disabled.

This is useful for builders that need to set a different spacing for an option. The builder can set `disableSpacing` and add its own styles in the root div.

### Why it changed

Resolves https://github.com/wix/wix-style-react/issues/2338.

---

- [ ] Change is tested
- [ ] Change is documented
- [ ] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
