### PR TITLE
[WIP] - migrate component-test Heading driver to Unidriver syntax

### DIFF
--- a/src/Heading/Heading.driver.js
+++ b/src/Heading/Heading.driver.js
@@ -1,15 +1,17 @@
 import {StylableDOMUtil} from '@stylable/dom-test-kit';
 import style from './Heading.st.css';
+import {baseUniDriverFactory} from 'wix-ui-test-utils/base-driver';
 
-const headingDriverFactory = factoryParams => {
+const headingDriverFactory = base => {
   const stylableDOMUtil = new StylableDOMUtil(style);
-  const {element} = factoryParams;
-
   return {
-    exists: () => !!element,
-    getText: () => element.innerHTML,
-    getAppearance: () => stylableDOMUtil.getStyleState(element, 'appearance'),
-    isLight: () => stylableDOMUtil.hasStyleState(element, 'light')
+    ...baseUniDriverFactory(base),
+    getText: async () => await base.getNative().innerHTML,
+    getAppearance: async () => await stylableDOMUtil.getStyleState(await base.getNative(), 'appearance'),
+    isLight: async () => {
+      const element = await base.getNative();
+      return stylableDOMUtil.hasStyleState(element, 'light');
+    }
   };
 };
 

--- a/src/Heading/Heading.driver.js
+++ b/src/Heading/Heading.driver.js
@@ -11,7 +11,8 @@ const headingDriverFactory = base => {
     isLight: async () => {
       const element = await base.getNative();
       return stylableDOMUtil.hasStyleState(element, 'light');
-    }
+    },
+    element: async () => await base.getNative()
   };
 };
 

--- a/src/Heading/Heading.driver.js
+++ b/src/Heading/Heading.driver.js
@@ -6,13 +6,10 @@ const headingDriverFactory = base => {
   const stylableDOMUtil = new StylableDOMUtil(style);
   return {
     ...baseUniDriverFactory(base),
-    getText: async () => await base.getNative().innerHTML,
-    getAppearance: async () => await stylableDOMUtil.getStyleState(await base.getNative(), 'appearance'),
-    isLight: async () => {
-      const element = await base.getNative();
-      return stylableDOMUtil.hasStyleState(element, 'light');
-    },
-    element: async () => await base.getNative()
+    getText: () => base.text(),
+    getAppearance: async () => stylableDOMUtil.getStyleState(await base.getNative(), 'appearance'),
+    isLight: async () => stylableDOMUtil.hasStyleState(await base.getNative(), 'light'),
+    element: () => base.getNative()
   };
 };
 

--- a/src/Heading/Heading.e2e.js
+++ b/src/Heading/Heading.e2e.js
@@ -4,7 +4,6 @@ import {headingTestkitFactory} from '../../testkit/protractor';
 import {tooltipTestkitFactory} from 'wix-ui-core/dist/src/testkit/protractor';
 import autoExampleDriver from 'wix-storybook-utils/AutoExampleDriver';
 import {APPEARANCES} from './Heading';
-
 import {storySettings} from '../../stories/Heading/storySettings';
 
 describe('Heading', () => {
@@ -16,33 +15,34 @@ describe('Heading', () => {
     afterEach(() => autoExampleDriver.reset());
 
     eyes.it('children prop', async () => {
-      const dataHook = 'storybook-heading';
+      const dataHook = storySettings.dataHook;
       const driver = headingTestkitFactory({dataHook});
-      await waitForVisibilityOf(driver.element(), 'Cannot find Heading');
+      await waitForVisibilityOf(await driver.element(), 'Cannot find Heading');
 
-      expect(driver.getText()).toBe('Hey there, good looking');
+      expect(await driver.getText()).toBe('Hey there, good looking');
     });
 
     eyes.it('appearance prop', async () => {
       const dataHook = storySettings.dataHook;
       const driver = headingTestkitFactory({dataHook});
+      await waitForVisibilityOf(await driver.element(), 'Cannot find Heading');
 
-      Object.keys(APPEARANCES).forEach(async appearance => {
-        await autoExampleDriver.setProps({appearance});
-        await waitForVisibilityOf(driver.element(), 'Cannot find Heading');
+      for (const appearance of Object.keys(APPEARANCES)) {
+        await autoExampleDriver.setProps({appearance, 'data-hook': storySettings.dataHook});
+        await waitForVisibilityOf(await driver.element(), 'Cannot find Heading');
         await eyes.checkWindow(appearance);
-      });
+      }
     });
 
     eyes.it('light prop', async () => {
       const dataHook = storySettings.dataHook;
       const driver = headingTestkitFactory({dataHook});
 
-      await waitForVisibilityOf(driver.element(), 'Cannot find Heading');
+      await waitForVisibilityOf(await driver.element(), 'Cannot find Heading');
       await eyes.checkWindow('dark');
 
       await autoExampleDriver.setProps({light: true});
-      await waitForVisibilityOf(driver.element(), 'Cannot find Heading');
+      await waitForVisibilityOf(await driver.element(), 'Cannot find Heading');
       await eyes.checkWindow('light');
     });
   });
@@ -53,7 +53,7 @@ describe('Heading', () => {
       const dataHook = storySettings.dataHook;
       const driver = headingTestkitFactory({dataHook});
       const tooltipDriver = tooltipTestkitFactory({dataHook});
-      await waitForVisibilityOf(driver.element(), 'Cannot find Heading');
+      await waitForVisibilityOf(await driver.element(), 'Cannot find Heading');
       expect(tooltipDriver.isContentElementExists()).toBeFalsy();
       await tooltipDriver.mouseEnter();
       expect(tooltipDriver.isContentElementExists()).toBeFalsy();
@@ -64,7 +64,7 @@ describe('Heading', () => {
       const dataHook = 'heading-with-ellipses';
       const driver = headingTestkitFactory({dataHook});
       const tooltipDriver = tooltipTestkitFactory({dataHook});
-      await waitForVisibilityOf(driver.element(), 'Cannot find Heading');
+      await waitForVisibilityOf(await driver.element(), 'Cannot find Heading');
       expect(tooltipDriver.isContentElementExists()).toBeFalsy();
       await tooltipDriver.mouseEnter();
       expect(tooltipDriver.isContentElementExists()).toBeTruthy();

--- a/src/Heading/Heading.protractor.driver.js
+++ b/src/Heading/Heading.protractor.driver.js
@@ -1,8 +1,0 @@
-export const headingDriverFactory = component => ({
-  /** returns the component element */
-  element: () => component,
-  /** returns the component's text */
-  getText: async () => component.getText()
-});
-
-export default headingDriverFactory;

--- a/src/Heading/Heading.puppeteer.driver.js
+++ b/src/Heading/Heading.puppeteer.driver.js
@@ -1,2 +1,0 @@
-import textDriverFactory from '../Text/Text.puppeteer.driver';
-export default textDriverFactory;

--- a/src/Heading/Heading.spec.js
+++ b/src/Heading/Heading.spec.js
@@ -1,37 +1,37 @@
 import React from 'react';
 import headingDriverFactory from './Heading.driver';
 import Heading from './Heading';
-import {createDriverFactory} from 'wix-ui-test-utils/driver-factory';
-import {isEnzymeTestkitExists} from 'wix-ui-test-utils/enzyme';
-import {isTestkitExists} from 'wix-ui-test-utils/vanilla';
+import {createUniDriverFactory} from 'wix-ui-test-utils/uni-driver-factory';
+import {isUniEnzymeTestkitExists} from 'wix-ui-test-utils/enzyme';
+import {isUniTestkitExists} from 'wix-ui-test-utils/vanilla';
 import {mount} from 'enzyme';
 import {headingTestkitFactory} from '../../testkit';
 import {headingTestkitFactory as enzymeHeadingTestkitFactory} from '../../testkit/enzyme';
 
 describe('Heading', () => {
-  const createDriver = createDriverFactory(headingDriverFactory);
+  const createDriver = createUniDriverFactory(headingDriverFactory);
 
   describe('light prop', () => {
-    it('should be dark by default', () => {
+    it('should be dark by default', async () => {
       const wrapper = createDriver(<Heading>Hello</Heading>);
-      expect(wrapper.isLight()).toBe(false);
+      expect(await wrapper.isLight()).toBe(false);
     });
 
-    it('should be light', () => {
+    it('should be light', async () => {
       const wrapper = createDriver(<Heading light>Hello</Heading>);
-      expect(wrapper.isLight()).toBe(true);
+      expect(await wrapper.isLight()).toBe(true);
     });
   });
 
   describe('testkit', () => {
-    it('should exist', () => {
-      expect(isTestkitExists(<Heading>Hello World</Heading>, headingTestkitFactory)).toBe(true);
+    it('should exist', async () => {
+      expect(await isUniTestkitExists(<Heading>Hello World</Heading>, headingTestkitFactory)).toBe(true);
     });
   });
 
   describe('enzyme testkit', () => {
-    it('should exist', () => {
-      expect(isEnzymeTestkitExists(<Heading>Hello World</Heading>, enzymeHeadingTestkitFactory, mount)).toBe(true);
+    it('should exist', async () => {
+      expect(await isUniEnzymeTestkitExists(<Heading>Hello World</Heading>, enzymeHeadingTestkitFactory, mount)).toBe(true);
     });
   });
 });

--- a/testkit/enzyme.js
+++ b/testkit/enzyme.js
@@ -1,4 +1,4 @@
-import {enzymeTestkitFactoryCreator} from 'wix-ui-test-utils/enzyme';
+import {enzymeTestkitFactoryCreator, enzymeUniTestkitFactoryCreator} from 'wix-ui-test-utils/enzyme';
 
 import inputDriverFactory from '../src/Input/Input.driver';
 export const inputTestkitFactory = enzymeTestkitFactoryCreator(inputDriverFactory);
@@ -211,7 +211,7 @@ import emptyStateDriverFactory from '../src/EmptyState/EmptyState.driver';
 export const emptyStateTestkitFactory = enzymeTestkitFactoryCreator(emptyStateDriverFactory);
 
 import headingDriverFactory from '../src/Heading/Heading.driver';
-export const headingTestkitFactory = enzymeTestkitFactoryCreator(headingDriverFactory);
+export const headingTestkitFactory = enzymeUniTestkitFactoryCreator(headingDriverFactory);
 
 import textDriverFactory from '../src/Text/Text.driver';
 export const textTestkitFactory = enzymeTestkitFactoryCreator(textDriverFactory);

--- a/testkit/index.js
+++ b/testkit/index.js
@@ -1,4 +1,4 @@
-import {testkitFactoryCreator} from 'wix-ui-test-utils/vanilla';
+import {testkitFactoryCreator, uniTestkitFactoryCreator} from 'wix-ui-test-utils/vanilla';
 
 import inputDriverFactory from '../src/Input/Input.driver';
 export const inputTestkitFactory = testkitFactoryCreator(inputDriverFactory);
@@ -214,7 +214,7 @@ import emptyStateDriverFactory from '../src/EmptyState/EmptyState.driver';
 export const emptyStateTestkitFactory = testkitFactoryCreator(emptyStateDriverFactory);
 
 import headingDriverFactory from '../src/Heading/Heading.driver';
-export const headingTestkitFactory = testkitFactoryCreator(headingDriverFactory);
+export const headingTestkitFactory = uniTestkitFactoryCreator(headingDriverFactory);
 
 import textDriverFactory from '../src/Text/Text.driver';
 export const textTestkitFactory = testkitFactoryCreator(textDriverFactory);

--- a/testkit/protractor.js
+++ b/testkit/protractor.js
@@ -1,6 +1,6 @@
 import 'regenerator-runtime/runtime';
 /*eslint no-duplicate-imports: 0*/
-import {protractorTestkitFactoryCreator} from 'wix-ui-test-utils/protractor';
+import {protractorTestkitFactoryCreator, protractorUniTestkitFactoryCreator} from 'wix-ui-test-utils/protractor';
 
 // here for historical reasons, should probably deprecate it
 export {waitForVisibilityOf, scrollToElement} from 'wix-ui-test-utils/protractor';
@@ -155,8 +155,8 @@ export const textTestkitFactory = protractorTestkitFactoryCreator(textDriverFact
 import messageBoxFunctionalLayoutDriverFactory from '../src/MessageBox/MessageBoxFunctionalLayout.protractor.driver';
 export const messageBoxFunctionalLayoutTestkitFactory = protractorTestkitFactoryCreator(messageBoxFunctionalLayoutDriverFactory);
 
-import headingDriverFactory from '../src/Heading/Heading.protractor.driver';
-export const headingTestkitFactory = protractorTestkitFactoryCreator(headingDriverFactory);
+import headingDriverFactory from '../src/Heading/Heading.driver';
+export const headingTestkitFactory = protractorUniTestkitFactoryCreator(headingDriverFactory);
 
 import sectionHelperDriverFactory from '../src/SectionHelper/SectionHelper.protractor.driver';
 export const sectionHelperTestkitFactory = protractorTestkitFactoryCreator(sectionHelperDriverFactory);

--- a/testkit/puppeteer.js
+++ b/testkit/puppeteer.js
@@ -1,5 +1,5 @@
 import 'regenerator-runtime/runtime';
-import {puppeteerTestkitFactoryCreator} from 'wix-ui-test-utils/puppeteer';
+import {puppeteerTestkitFactoryCreator, puppeteerUniTestkitFactoryCreator} from 'wix-ui-test-utils/puppeteer';
 
 import inputDriverFactory from '../src/Input/Input.puppeteer.driver';
 export const inputTestkitFactory = puppeteerTestkitFactoryCreator(inputDriverFactory);
@@ -13,8 +13,8 @@ export const formFieldTestkitFactory = puppeteerTestkitFactoryCreator(formFieldD
 import tableDriverFactory from '../src/Table/Table.puppeteer.driver';
 export const tableTestkitFactory = puppeteerTestkitFactoryCreator(tableDriverFactory);
 
-import headingDriverFactory from '../src/Heading/Heading.puppeteer.driver';
-export const headingTestkitFactory = puppeteerTestkitFactoryCreator(headingDriverFactory);
+import headingDriverFactory from '../src/Heading/Heading.driver';
+export const headingTestkitFactory = puppeteerUniTestkitFactoryCreator(headingDriverFactory);
 
 import textDriverFactory from '../src/Text/Text.puppeteer.driver';
 export const textTestkitFactory = puppeteerTestkitFactoryCreator(textDriverFactory);


### PR DESCRIPTION
This pr is an example of how to migrate a component to use the unidriver pattern.
The thing is that this is a breaking change since every driver method is now async, and our consumers are using the methods today in a sync way.