### PR TITLE
<TableActionCell/> -  allow passing PopoverMenu props

### DIFF
--- a/src/TableActionCell/TableActionCell.e2e.js
+++ b/src/TableActionCell/TableActionCell.e2e.js
@@ -2,22 +2,35 @@ import eyes from 'eyes.it';
 import {createStoryUrl, waitForVisibilityOf, scrollToElement} from 'wix-ui-test-utils/protractor';
 
 import {storySettings} from '../../stories/TableActionCell/storySettings';
+import {tableActionCellTestkitFactory} from '../../testkit/protractor';
 
-const byDataHook = dataHook => $(`[data-hook="${dataHook}"]`);
 const hoverElement = element => browser.actions().mouseMove(element).perform();
 
 describe('Table Action Cell', () => {
   const storyUrl = createStoryUrl({kind: storySettings.kind, story: storySettings.storyName});
 
   const verifyItem = async dataHook => {
-    const element = byDataHook(dataHook);
+    const driver = tableActionCellTestkitFactory({dataHook});
+    const element = driver.element();
 
     await waitForVisibilityOf(element, `Cannot find ${dataHook}`);
     await scrollToElement(element);
 
-    await eyes.checkWindow(dataHook);
+    // Check idle
+    await eyes.checkWindow(`${dataHook} idle`);
+
+    // Check hovered
     hoverElement(element);
-    await eyes.checkWindow(dataHook);
+    await eyes.checkWindow(`${dataHook} hovered`);
+
+    // Check with PopoverMenu opened; It may not be present in all of the
+    // examples, hence the try/catch block.
+    try {
+      await driver.getHiddenActionsPopoverMenu().click();
+      await eyes.checkWindow(`${dataHook} PopoverMenu opened`);
+    } catch (e) {
+      // ignored
+    }
   };
 
   const examples = {
@@ -25,6 +38,7 @@ describe('Table Action Cell', () => {
     'White primary action': 'story-primary-white',
     'Primary and secondary actions': 'story-primary-secondary',
     'Primary and hidden secondary actions': 'story-primary-hidden-secondary',
+    'With custom PopoverMenu props': 'story-popover-menu-props',
     'Always visible secondary actions': 'story-always-visible-secondary',
     'Only secondary actions': 'story-only-secondary',
     'Only visible secondary actions': 'story-only-visible-secondary',

--- a/src/TableActionCell/TableActionCell.js
+++ b/src/TableActionCell/TableActionCell.js
@@ -49,9 +49,14 @@ function renderVisibleActions(actions) {
   ));
 }
 
-function renderHiddenActions(actions) {
+function renderHiddenActions(actions, popoverMenuProps) {
   return (
-    <PopoverMenu buttonTheme="icon-greybackground" dataHook="table-action-cell-popover-menu" appendToParent>
+    <PopoverMenu
+      buttonTheme="icon-greybackground"
+      dataHook="table-action-cell-popover-menu"
+      appendToParent
+      {...popoverMenuProps}
+      >
       {actions.map(({text, icon, onClick, disabled}, index) => (
         <PopoverMenuItem
           key={index}
@@ -80,7 +85,8 @@ const TableActionCell = props => {
     primaryAction,
     secondaryActions,
     numOfVisibleSecondaryActions,
-    alwaysShowSecondaryActions
+    alwaysShowSecondaryActions,
+    popoverMenuProps
   } = props;
 
   const visibleActions = secondaryActions.slice(0, numOfVisibleSecondaryActions);
@@ -104,7 +110,7 @@ const TableActionCell = props => {
       {hiddenActions.length > 0 && (
         <div onClick={e => e.stopPropagation()}>
           <HoverSlot display="always">
-            {renderHiddenActions(hiddenActions)}
+            {renderHiddenActions(hiddenActions, popoverMenuProps)}
           </HoverSlot>
         </div>
       )}
@@ -153,7 +159,10 @@ TableActionCell.propTypes = {
   numOfVisibleSecondaryActions: PropTypes.number,
 
    /** Whether to show the secondary action also when not hovering the row */
-  alwaysShowSecondaryActions: PropTypes.bool
+  alwaysShowSecondaryActions: PropTypes.bool,
+
+  /** Props being passed to the secondary actions' <PopoverMenu/> */
+  popoverMenuProps: PropTypes.shape(PopoverMenu.propTypes)
 };
 
 TableActionCell.defaultProps = {

--- a/stories/TableActionCell/TableActionCell.story.js
+++ b/stories/TableActionCell/TableActionCell.story.js
@@ -19,6 +19,9 @@ import PrimarySecondaryExampleRaw from '!raw-loader!./examples/PrimarySecondaryE
 import PrimarySecondaryHiddenExample from './examples/PrimarySecondaryHiddenExample';
 import PrimarySecondaryHiddenExampleRaw from '!raw-loader!./examples/PrimarySecondaryHiddenExample';
 
+import PopoverMenuPropsExample from './examples/PopoverMenuPropsExample';
+import PopoverMenuPropsExampleRaw from '!raw-loader!./examples/PopoverMenuPropsExample';
+
 import AlwaysVisibleSecondaryExample from './examples/AlwaysVisibleSecondaryExample';
 import AlwaysVisibleSecondaryExampleRaw from '!raw-loader!./examples/AlwaysVisibleSecondaryExample';
 
@@ -115,6 +118,12 @@ export default {
       <div className={style.example}>
         <CodeExample title="Primary action and hidden secondary action" code={PrimarySecondaryHiddenExampleRaw}>
           <PrimarySecondaryHiddenExample/>
+        </CodeExample>
+      </div>
+
+      <div className={style.example}>
+        <CodeExample title="With custom PopoverMenu props" code={PopoverMenuPropsExampleRaw}>
+          <PopoverMenuPropsExample/>
         </CodeExample>
       </div>
 

--- a/stories/TableActionCell/examples/AlwaysVisibleSecondaryExample.js
+++ b/stories/TableActionCell/examples/AlwaysVisibleSecondaryExample.js
@@ -9,8 +9,8 @@ const Example = () => (
     <TableActionCell
       dataHook="story-always-visible-secondary"
       secondaryActions={[
-        {text: 'Duplicate', icon: <Duplicate/>, onClick: () => window.alert('Duplicate action was diviggered.')},
-        {text: 'Print', icon: <Print/>, onClick: () => window.alert('Print action was diviggered.')}
+        {text: 'Duplicate', icon: <Duplicate/>, onClick: () => window.alert('Duplicate action was triggered.')},
+        {text: 'Print', icon: <Print/>, onClick: () => window.alert('Print action was triggered.')}
       ]}
       numOfVisibleSecondaryActions={2}
       alwaysShowSecondaryActions

--- a/stories/TableActionCell/examples/OnlySecondaryExample.js
+++ b/stories/TableActionCell/examples/OnlySecondaryExample.js
@@ -9,9 +9,9 @@ const Example = () => (
     <TableActionCell
       dataHook="story-only-secondary"
       secondaryActions={[
-        {text: 'Download', icon: <Download/>, onClick: () => window.alert('Download action was diviggered.')},
-        {text: 'Duplicate', icon: <Duplicate/>, onClick: () => window.alert('Duplicate action was diviggered.')},
-        {text: 'Print', icon: <Print/>, onClick: () => window.alert('Print action was diviggered.')}
+        {text: 'Download', icon: <Download/>, onClick: () => window.alert('Download action was triggered.')},
+        {text: 'Duplicate', icon: <Duplicate/>, onClick: () => window.alert('Duplicate action was triggered.')},
+        {text: 'Print', icon: <Print/>, onClick: () => window.alert('Print action was triggered.')}
       ]}
       numOfVisibleSecondaryActions={2}
       />

--- a/stories/TableActionCell/examples/OnlyVisibleSecondaryExample.js
+++ b/stories/TableActionCell/examples/OnlyVisibleSecondaryExample.js
@@ -9,8 +9,8 @@ const Example = () => (
     <TableActionCell
       dataHook="story-only-visible-secondary"
       secondaryActions={[
-        {text: 'Download', icon: <Download/>, onClick: () => window.alert('Download action was diviggered.')},
-        {text: 'Duplicate', icon: <Duplicate/>, onClick: () => window.alert('Duplicate action was diviggered.')}
+        {text: 'Download', icon: <Download/>, onClick: () => window.alert('Download action was triggered.')},
+        {text: 'Duplicate', icon: <Duplicate/>, onClick: () => window.alert('Duplicate action was triggered.')}
       ]}
       numOfVisibleSecondaryActions={2}
       />

--- a/stories/TableActionCell/examples/PopoverMenuPropsExample.js
+++ b/stories/TableActionCell/examples/PopoverMenuPropsExample.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import TableActionCell from 'wix-style-react/TableActionCell';
+import {Star, Download, Duplicate, Print} from 'wix-style-react/new-icons';
+
+import style from '../TableActionCell.story.st.css';
+
+const Example = () => (
+  <div className={style.exampleRow}>
+    <TableActionCell
+      dataHook="story-popover-menu-props"
+      primaryAction={{
+        text: 'Edit',
+        theme: 'fullblue',
+        onClick: () => window.alert('Primary action was triggered!')
+      }}
+      secondaryActions={[
+        {text: 'Star', icon: <Star/>, onClick: () => window.alert('Star action was triggered.')},
+        {text: 'Download', icon: <Download/>, onClick: () => window.alert('Download action was triggered.')},
+        {text: 'Duplicate', icon: <Duplicate/>, onClick: () => window.alert('Duplicate action was triggered.')},
+        {text: 'Print', icon: <Print/>, onClick: () => window.alert('Print action was triggered.')}
+      ]}
+      numOfVisibleSecondaryActions={0}
+      popoverMenuProps={{
+        placement: 'bottom'
+      }}
+      />
+  </div>
+);
+
+export default Example;

--- a/stories/TableActionCell/examples/PrimarySecondaryExample.js
+++ b/stories/TableActionCell/examples/PrimarySecondaryExample.js
@@ -11,13 +11,13 @@ const Example = () => (
       primaryAction={{
         text: 'Edit',
         theme: 'whiteblue',
-        onClick: () => window.alert('Primary action was diviggered!')
+        onClick: () => window.alert('Primary action was triggered!')
       }}
       secondaryActions={[
-        {text: 'Star', icon: <Star/>, onClick: () => window.alert('Star action was diviggered.')},
-        {text: 'Download', icon: <Download/>, onClick: () => window.alert('Download action was diviggered.')},
-        {text: 'Duplicate', icon: <Duplicate/>, onClick: () => window.alert('Duplicate action was diviggered.')},
-        {text: 'Print', icon: <Print/>, onClick: () => window.alert('Print action was diviggered.')}
+        {text: 'Star', icon: <Star/>, onClick: () => window.alert('Star action was triggered.')},
+        {text: 'Download', icon: <Download/>, onClick: () => window.alert('Download action was triggered.')},
+        {text: 'Duplicate', icon: <Duplicate/>, onClick: () => window.alert('Duplicate action was triggered.')},
+        {text: 'Print', icon: <Print/>, onClick: () => window.alert('Print action was triggered.')}
       ]}
       numOfVisibleSecondaryActions={1}
       />

--- a/stories/TableActionCell/examples/PrimarySecondaryHiddenExample.js
+++ b/stories/TableActionCell/examples/PrimarySecondaryHiddenExample.js
@@ -11,13 +11,13 @@ const Example = () => (
       primaryAction={{
         text: 'Edit',
         theme: 'fullblue',
-        onClick: () => window.alert('Primary action was diviggered!')
+        onClick: () => window.alert('Primary action was triggered!')
       }}
       secondaryActions={[
-        {text: 'Star', icon: <Star/>, onClick: () => window.alert('Star action was diviggered.')},
-        {text: 'Download', icon: <Download/>, onClick: () => window.alert('Download action was diviggered.')},
-        {text: 'Duplicate', icon: <Duplicate/>, onClick: () => window.alert('Duplicate action was diviggered.')},
-        {text: 'Print', icon: <Print/>, onClick: () => window.alert('Print action was diviggered.')}
+        {text: 'Star', icon: <Star/>, onClick: () => window.alert('Star action was triggered.')},
+        {text: 'Download', icon: <Download/>, onClick: () => window.alert('Download action was triggered.')},
+        {text: 'Duplicate', icon: <Duplicate/>, onClick: () => window.alert('Duplicate action was triggered.')},
+        {text: 'Print', icon: <Print/>, onClick: () => window.alert('Print action was triggered.')}
       ]}
       numOfVisibleSecondaryActions={0}
       />

--- a/stories/TableActionCell/examples/PrimarySecondaryRTLExample.js
+++ b/stories/TableActionCell/examples/PrimarySecondaryRTLExample.js
@@ -12,13 +12,13 @@ const Example = () => (
         primaryAction={{
           text: 'Edit',
           theme: 'whiteblue',
-          onClick: () => window.alert('Primary action was diviggered!')
+          onClick: () => window.alert('Primary action was triggered!')
         }}
         secondaryActions={[
-          {text: 'Star', icon: <Star/>, onClick: () => window.alert('Star action was diviggered.')},
-          {text: 'Download', icon: <Download/>, onClick: () => window.alert('Download action was diviggered.')},
-          {text: 'Duplicate', icon: <Duplicate/>, onClick: () => window.alert('Duplicate action was diviggered.')},
-          {text: 'Print', icon: <Print/>, onClick: () => window.alert('Print action was diviggered.')}
+          {text: 'Star', icon: <Star/>, onClick: () => window.alert('Star action was triggered.')},
+          {text: 'Download', icon: <Download/>, onClick: () => window.alert('Download action was triggered.')},
+          {text: 'Duplicate', icon: <Duplicate/>, onClick: () => window.alert('Duplicate action was triggered.')},
+          {text: 'Print', icon: <Print/>, onClick: () => window.alert('Print action was triggered.')}
         ]}
         numOfVisibleSecondaryActions={1}
         />

--- a/stories/TableActionCell/examples/PrimaryWhiteExample.js
+++ b/stories/TableActionCell/examples/PrimaryWhiteExample.js
@@ -10,7 +10,7 @@ const Example = () => (
       primaryAction={{
         text: 'Edit',
         theme: 'whiteblue',
-        onClick: () => window.alert('Primary action was diviggered!')
+        onClick: () => window.alert('Primary action was triggered!')
       }}
       />
   </div>


### PR DESCRIPTION
### What changed

* Allow passing props to the `<PopoverMenu/>` using the `popoverMenuProps` prop in the `<TableActionCell/>`.
* Improved e2e tests to also `checkWindow` when the popover menu is opened.

cc: @david-pe 

### Why it changed

...

---

- [ ] Change is tested
- [ ] Change is documented
- [ ] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
