### PR TITLE
[WIP] <DataTable/> - updates to the sorting behaviour

### DIFF
--- a/src/DataTable/DataTable.driver.js
+++ b/src/DataTable/DataTable.driver.js
@@ -25,7 +25,7 @@ const dataTableDriverFactory = ({element, wrapper, component}) => {
   const getHeaderCell = index => getHeader().querySelectorAll('th')[index];
   const getSortableTitle = index => element.querySelector(`th [data-hook="${index}_title"]`);
   const getTitleInfoIcon = index => element.querySelector(`th [data-hook="${index}_info_tooltip"]`);
-  const getSortableTitleArrowDesc = index => element.querySelector(`th [data-hook="${index}_title"]  [data-hook="sort_arrow_dec"]`);
+  const getSortableTitleArrowDesc = index => element.querySelector(`th [data-hook="${index}_title"]  [data-hook="active_arrow_desc"]`);
 
   return {
     getRow,

--- a/src/DataTable/DataTable.js
+++ b/src/DataTable/DataTable.js
@@ -308,7 +308,7 @@ class TableHeader extends Component {
 
     // When the cell is active, we want to preserve the *previous* state after
     // the click
-    const isCurrentCellActive = this.state.activeHeaderCell === colNum;
+    const isCurrentCellActive = sortIconDirectionOnHover && this.state.activeHeaderCell === colNum;
 
     const activeDirection = sortIconDirection;
     const hiddenDirection = isCurrentCellActive ?
@@ -413,7 +413,7 @@ class TableHeader extends Component {
       );
 
       // "Disable" the hover effect when using the legacy `sortDescending` property
-      sortIconDirectionOnHover = sortIconDirection;
+      sortIconDirectionOnHover = undefined;
 
       deprecationLog(
         'Property `sortDescending` of Table\'s `columns` prop is deprecated; use `sortIconDirection` instead.'

--- a/src/DataTable/DataTable.js
+++ b/src/DataTable/DataTable.js
@@ -268,8 +268,21 @@ class TableHeader extends Component {
     newDesign: PropTypes.bool
   };
 
+  state = {
+    // This state property indicates what header cell is currently active. A
+    // cell becomes "active" when it is clicked, and stops being active when
+    // the mouse leaves it.
+    activeHeaderCell: -1
+  }
+
   get style() {
     return styles;
+  }
+
+  setActiveHeaderCell = colNum => {
+    this.setState({
+      activeHeaderCell: colNum
+    });
   }
 
   renderSortingArrow = (column, colNum) => {
@@ -301,6 +314,10 @@ class TableHeader extends Component {
       return null;
     }
 
+    // When the cell is active, we want to preserve the *previous* state after
+    // the click
+    const isCurrentCellActive = this.state.activeHeaderCell === colNum;
+
     return (
       <span
         data-hook={`${colNum}_title`}
@@ -308,6 +325,9 @@ class TableHeader extends Component {
         >
         {ActiveSortingArrow && (
           <ActiveSortingArrow
+            style={{
+              display: isCurrentCellActive ? 'inherit' : undefined
+            }}
             height={12}
             className={this.style.activeSortingArrow}
             data-hook={`active_arrow_${sortingIconDirection}`}
@@ -315,6 +335,9 @@ class TableHeader extends Component {
         )}
         {HiddenSortingArrow && (
           <HiddenSortingArrow
+            style={{
+              display: isCurrentCellActive ? 'none' : undefined
+            }}
             height={12}
             className={this.style.hiddenSortingArrow}
             data-hook={`active_arrow_${sortingIconDirection}`}
@@ -378,10 +401,17 @@ class TableHeader extends Component {
       [this.style.thText]: this.props.newDesign
     });
 
-    const optionalHeaderCellProps = {};
+    let optionalHeaderCellProps = {};
 
     if (column.sortable) {
-      optionalHeaderCellProps.onClick = () => this.props.onSortClick && this.props.onSortClick(column, colNum);
+      optionalHeaderCellProps = {
+        ...optionalHeaderCellProps,
+        onClick: () => {
+          this.setActiveHeaderCell(colNum);
+          this.props.onSortClick && this.props.onSortClick(column, colNum);
+        },
+        onMouseLeave: () => this.setActiveHeaderCell(-1)
+      };
     }
 
     let sortingIconDirection = column.sortingIconDirection;

--- a/src/DataTable/DataTable.js
+++ b/src/DataTable/DataTable.js
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import InfiniteScroll from './InfiniteScroll';
 import SortByArrowUp from '../new-icons/system/SortByArrowUp';
 import SortByArrowDown from '../new-icons/system/SortByArrowDown';
+import CloseLarge from '../new-icons/system/CloseLarge';
 import {Animator} from 'wix-animations';
 import InfoCircle from 'wix-ui-icons-common/InfoCircle';
 import Tooltip from '../Tooltip/Tooltip';
@@ -320,7 +321,11 @@ class TableHeader extends Component {
       sortIconDirectionOnHover || sortIconDirection;
 
     const ActiveSortingArrow = this.getSortingArrow(activeDirection);
-    const HiddenSortingArrow = this.getSortingArrow(hiddenDirection);
+    const HiddenSortingArrow = this.getSortingArrow(hiddenDirection) || (
+      // Show the close icon when we don't have an icon to show (sorting
+      // direction is `none`), but only if the cell is not active
+      isCurrentCellActive ? null : CloseLarge
+    );
 
     if (!ActiveSortingArrow && !HiddenSortingArrow) {
       return null;

--- a/src/DataTable/DataTable.js
+++ b/src/DataTable/DataTable.js
@@ -300,6 +300,10 @@ class TableHeader extends Component {
   renderSortingArrow = (column, colNum) => {
     const {sortIconDirection, sortIconDirectionOnHover} = column;
 
+    if (!sortIconDirection && !sortIconDirectionOnHover) {
+      return;
+    }
+
     // Support old design
     if (!this.props.newDesign) {
       const sortDirectionClassName = sortIconDirection === 'desc' ? this.style.sortArrowAsc : this.style.sortArrowDesc;

--- a/src/DataTable/DataTable.scss
+++ b/src/DataTable/DataTable.scss
@@ -64,6 +64,17 @@ $rowShadow: inset 0 1px 0 0 $D70;
   &.th-text {
     @include Text($weight: normal, $size: small);
   }
+
+  // Sorting arrows
+  .activeSortingArrow,
+  &:hover .hiddenSortingArrow{
+    display: inherit;
+  }
+
+  &:hover .activeSortingArrow,
+  .hiddenSortingArrow{
+    display: none;
+  }
 }
 
 

--- a/src/DataTable/DataTable.scss
+++ b/src/DataTable/DataTable.scss
@@ -67,16 +67,15 @@ $rowShadow: inset 0 1px 0 0 $D70;
 
   // Sorting arrows
   .activeSortingArrow,
-  &:hover .hiddenSortingArrow{
+  &:hover .hiddenSortingArrow {
     display: inherit;
   }
 
   &:hover .activeSortingArrow,
-  .hiddenSortingArrow{
+  .hiddenSortingArrow {
     display: none;
   }
 }
-
 
 .table td {
   @include Text($weight: thin, $size: small, $secondary: true);

--- a/stories/Table/Table.story.js
+++ b/stories/Table/Table.story.js
@@ -26,6 +26,9 @@ import TableEmptyStateExampleRaw from '!raw-loader!./TableEmptyStateExample';
 import {TableColumnAlignmentExample} from './TableColumnAlignmentExample';
 import TableColumnAlignmentExampleRaw from '!raw-loader!./TableColumnAlignmentExample';
 
+import {TableSortingExample} from './TableSortingExample';
+import TableSortingExampleRaw from '!raw-loader!./TableSortingExample';
+
 const data = [
   {firstName: 'Meghan', lastName: 'Bishop'},
   {firstName: 'Sara', lastName: 'Porter'},
@@ -108,6 +111,11 @@ export default {
         <div className={s.example}>
           <CodeExample title="Table with column alignments" code={TableColumnAlignmentExampleRaw}>
             <TableColumnAlignmentExample/>
+          </CodeExample>
+        </div>
+        <div className={s.example}>
+          <CodeExample title="Table with sorting" code={TableSortingExampleRaw}>
+            <TableSortingExample/>
           </CodeExample>
         </div>
       </div>

--- a/stories/Table/TableSortingExample.js
+++ b/stories/Table/TableSortingExample.js
@@ -1,0 +1,158 @@
+import React from 'react';
+import {Table} from 'wix-style-react/Table';
+import {
+  TableToolbar,
+  ItemGroup,
+  Item,
+  Title
+} from 'wix-style-react/TableToolbar';
+
+import Card from 'wix-style-react/Card';
+
+export class TableSortingExample extends React.Component {
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      sortedColumn: -1,
+      sortingDirection: 'none',
+
+      data: [
+        {name: 'Cyan Towls', visible: false, onSale: false, price: '$145.99'},
+        {name: 'Apple Towels', visible: true, onSale: false, price: '$22.99'},
+        {name: 'Red Slippers', visible: false, onSale: false, price: '$1,265.69'},
+        {name: 'Marble Slippers', visible: false, onSale: false, price: '$125,265.00'}
+      ]
+    };
+  }
+
+  getNextSortingDirection(dir = 'none') {
+    const nextDirs = {
+      none: 'asc',
+      asc: 'desc',
+      desc: 'none'
+    };
+
+    return nextDirs[dir];
+  }
+
+  getSortingProperties(colNum) {
+    const {sortedColumn, sortingDirection} = this.state;
+
+    const isCurentlySorted = sortedColumn === colNum;
+
+    return {
+      sortable: true,
+      sortIconDirection: isCurentlySorted ? sortingDirection : 'none',
+      sortIconDirectionOnHover: isCurentlySorted ? this.getNextSortingDirection(sortingDirection) : this.getNextSortingDirection()
+    };
+  }
+
+  handleSortClick(colNum) {
+    const {sortedColumn, sortingDirection} = this.state;
+
+    const isCurentlySorted = sortedColumn === colNum;
+
+    this.setState({
+      sortedColumn: colNum,
+      sortingDirection: isCurentlySorted ? this.getNextSortingDirection(sortingDirection) : this.getNextSortingDirection()
+    });
+  }
+
+  getSortedData() {
+    const {sortedColumn, sortingDirection, data} = this.state;
+
+    if (sortingDirection === 'none') {
+      return data;
+    }
+
+    const fields = {
+      0: 'name',
+      3: 'price'
+    };
+
+    const fieldToSortBy = fields[sortedColumn];
+    const desc = sortingDirection === 'desc';
+
+    const newData = [...data];
+
+    // Currently comparing strings
+    newData.sort((a, b) => {
+      let res = 0;
+
+      if (a[fieldToSortBy] < b[fieldToSortBy]) {
+        res = -1;
+      } else if (a[fieldToSortBy] > b[fieldToSortBy]) {
+        res = 1;
+      }
+
+      return desc ? res : res * -1;
+    });
+
+    return newData;
+  }
+
+  render() {
+    return (
+      <Card>
+        <Table
+          dataHook="story-table-column-alignment-example"
+          data={this.getSortedData()}
+          itemsPerPage={20}
+          onSortClick={(column, colNum) => this.handleSortClick(colNum)}
+          columns={[
+            {
+              title: 'Name',
+              render: row => <span>{row.name}</span>,
+              width: '30%',
+              minWidth: '150px',
+              ...this.getSortingProperties(0)
+            },
+            {
+              title: 'Visibility',
+              render: row => (
+                <span>{row.visible ? 'Visible' : 'Hidden'}</span>
+              ),
+              width: '20%',
+              minWidth: '100px'
+            },
+            {
+              title: 'On Sale',
+              render: row => (
+                <span>{row.onSale ? 'On sale' : 'Not on sale'}</span>
+              ),
+              width: '20%',
+              minWidth: '100px',
+              infoTooltipProps: {
+                content: 'I am a Tooltip!'
+              }
+            },
+            {
+              title: 'Price',
+              render: row => <span>{row.price}</span>,
+              width: '20%',
+              minWidth: '100px',
+              ...this.getSortingProperties(3)
+            }
+          ]}
+          >
+          <MainToolbar/>
+          <Table.Content/>
+        </Table>
+      </Card>
+    );
+  }
+}
+
+const MainToolbar = () => {
+  return (
+    <TableToolbar>
+      <ItemGroup position="start">
+        <Item>
+          <Title>My Table</Title>
+        </Item>
+      </ItemGroup>
+    </TableToolbar>
+  );
+};

--- a/stories/Table/TableSortingExample.js
+++ b/stories/Table/TableSortingExample.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import sortBy from 'lodash/sortBy';
 import {Table} from 'wix-style-react/Table';
 import {
   TableToolbar,
@@ -15,82 +16,58 @@ export class TableSortingExample extends React.Component {
     super(props);
 
     this.state = {
-      sortedColumn: -1,
+      sortingField: '',
       sortingDirection: 'none',
 
       data: [
-        {name: 'Cyan Towls', visible: false, onSale: false, price: '$145.99'},
-        {name: 'Apple Towels', visible: true, onSale: false, price: '$22.99'},
-        {name: 'Red Slippers', visible: false, onSale: false, price: '$1,265.69'},
-        {name: 'Marble Slippers', visible: false, onSale: false, price: '$125,265.00'}
+        {name: 'Cyan Towls', visible: false, onSale: false, price: 145.99},
+        {name: 'Apple Towels', visible: true, onSale: false, price: 22.99},
+        {name: 'Red Slippers', visible: false, onSale: false, price: 1265.69},
+        {name: 'Marble Slippers', visible: false, onSale: false, price: 125.00}
       ]
     };
   }
 
   getNextSortingDirection(dir = 'none') {
-    const nextDirs = {
-      none: 'asc',
-      asc: 'desc',
-      desc: 'none'
-    };
-
-    return nextDirs[dir];
+    const dirs = ['none', 'asc', 'desc'];
+    return dirs.find((d, i) => i === (dirs.indexOf(dir) + 1) % dirs.length);
   }
 
-  getSortingProperties(colNum) {
-    const {sortedColumn, sortingDirection} = this.state;
+  getSortingProperties(field) {
+    const {sortingField, sortingDirection} = this.state;
 
-    const isCurentlySorted = sortedColumn === colNum;
+    const isCurentlySorted = sortingField === field;
 
     return {
       sortable: true,
+      sortingField: field, // This field is not used by `<Table/>`, but can be accessed on `handleSortClick`
       sortIconDirection: isCurentlySorted ? sortingDirection : 'none',
       sortIconDirectionOnHover: isCurentlySorted ? this.getNextSortingDirection(sortingDirection) : this.getNextSortingDirection()
     };
   }
 
-  handleSortClick(colNum) {
-    const {sortedColumn, sortingDirection} = this.state;
+  handleSortClick(field) {
+    const {sortingField, sortingDirection} = this.state;
 
-    const isCurentlySorted = sortedColumn === colNum;
+    const isCurentlySorted = sortingField === field;
 
     this.setState({
-      sortedColumn: colNum,
+      sortingField: field,
       sortingDirection: isCurentlySorted ? this.getNextSortingDirection(sortingDirection) : this.getNextSortingDirection()
     });
   }
 
   getSortedData() {
-    const {sortedColumn, sortingDirection, data} = this.state;
+    const {sortingField, sortingDirection, data} = this.state;
 
     if (sortingDirection === 'none') {
       return data;
     }
 
-    const fields = {
-      0: 'name',
-      3: 'price'
-    };
-
-    const fieldToSortBy = fields[sortedColumn];
     const desc = sortingDirection === 'desc';
+    const sortedData = sortBy(data, sortingField);
 
-    const newData = [...data];
-
-    // Currently comparing strings
-    newData.sort((a, b) => {
-      let res = 0;
-
-      if (a[fieldToSortBy] < b[fieldToSortBy]) {
-        res = -1;
-      } else if (a[fieldToSortBy] > b[fieldToSortBy]) {
-        res = 1;
-      }
-
-      return desc ? res : res * -1;
-    });
-
-    return newData;
+    return desc ? sortedData : sortedData.reverse();
   }
 
   render() {
@@ -100,14 +77,14 @@ export class TableSortingExample extends React.Component {
           dataHook="story-table-column-alignment-example"
           data={this.getSortedData()}
           itemsPerPage={20}
-          onSortClick={(column, colNum) => this.handleSortClick(colNum)}
+          onSortClick={column => this.handleSortClick(column.sortingField)}
           columns={[
             {
               title: 'Name',
               render: row => <span>{row.name}</span>,
               width: '30%',
               minWidth: '150px',
-              ...this.getSortingProperties(0)
+              ...this.getSortingProperties('name')
             },
             {
               title: 'Visibility',
@@ -130,10 +107,10 @@ export class TableSortingExample extends React.Component {
             },
             {
               title: 'Price',
-              render: row => <span>{row.price}</span>,
+              render: row => <span>{`$${row.price}`}</span>,
               width: '20%',
               minWidth: '100px',
-              ...this.getSortingProperties(3)
+              ...this.getSortingProperties('price')
             }
           ]}
           >


### PR DESCRIPTION
This PR is a WIP - DO NOT MERGE YET. The API is not complete yet and is expected to be changed.

---

Man, I love tables.

As per https://github.com/wix/wix-style-react/issues/2369, we've decided to go with the following API:

We'll keep the `<DataTable/>`'s `onSortClick`. We'll deprecate the `sortDescending` property of a single column, and add the following:

| Prop | Type | Description |
| ---- | ---- | ----------- |
| `sortIconDirection` | `'asc' \| 'desc' \| 'none'` | Will set the direction of the sorting icon on the column's `<th>`. When `'none'`, not arrow will be shown. |
| `sortIconDirectionOnHover` | `'asc' \| 'desc' \| 'none' \| undefined` | Will set the direction of the sorting icon on the column's `<th>` **when the user hovers the row**. When `undefined`, the `sortIconDirection` will still be shown on hover. |

The `<DataTable/>` won't be responsible for any sorting - it's up to the consumer to implement this logic. The `<DataTable/>` will only display the arrows accordingly.

Some points to mention:

1. Normally, when the user clicks the row, the consumer will update the sorting state, thus the `sortIconDirectionOnHover` will be changed. Immediately after the click, the user is still hovering the row, and as a result, the arrow icon will be also changed.
As per the UX specs, after the user clicks the row, the last hovered row should be persisted. This involves having the last value of `sortIconDirectionOnHover` stored in the `<DataTable/>` internal state.
https://github.com/wix/wix-style-react/blob/c7beff4991f7becfc037ebad9bb2b85c7a5737cb/src/DataTable/DataTable.js#L309-L316
I'm not a fan of that. If someone got a better idea, please let me know.

2. Take a look at the story example for `<Table/>` regarding the sorting ([here](https://github.com/wix/wix-style-react/blob/c7beff4991/stories/Table/TableSortingExample.js)). It's pretty big. Are we really want that the consumer will have to manage all of that?
Of course, this is just one way to implement the sorting using the proposed API, and there may be a better (and a shorter) way to do that.

3. If we want to hide some of this logic from the consumers, we could have a different API. @lbelinsk suggested that the table would manage the sorting state by itself, and the consumers would simply pass a sorting function to it.
So, the consumer will pass a `compareFunction` to each column to make it "sortable", and using the `initialSortableColumn` (I'm bad in naming I know) prop, the consumer could determine the default column to be sorted by. Also, the consumers could still be aware to the current sorting state (and change it) using the table's `ref`.

	**Pros:**
	- This would dramatically decrease complexity in the consumer side.
	- API will become slimmer.
	- By defining a fixed behaviour, we could make the usage stricter to the UX guidelines.

	**Cons:**
	- The `<DataTable/>` would have to manage an internal state for the sorting behaviour.
	- The `<DataTable/>` would have to store a copy of the data.
	- What would happen when the data is changed, or more items will be added (for example, after a server calling)?
	- ~~Sorting by multiple columns will be difficult to manage.~~

Again, this is a question of "controlled" vs "un-controlled" (or "less-controlled"). Wdyt?

@shlomitc @hepiyellow @argshook 
