### PR TITLE
BugFix: isOpen always returns true

### DIFF
--- a/src/Modal/Modal.driver.js
+++ b/src/Modal/Modal.driver.js
@@ -11,7 +11,7 @@ const modalDriverFactory = ({element, wrapper, component}) => {
   return {
     exists: () => !!(getPortal()),
     element: () => element,
-    isOpen: () => !!(getContent()),
+    isOpen: () => !!getContent() && !!(getContent().textContent),
     isThemeExist: theme => !!getPortal().querySelector(`.${theme}`),
     getChildBySelector: selector => getPortal().querySelector(selector),
     isScrollable: () => !getPortal().classList.contains('portalNonScrollable'),


### PR DESCRIPTION
### What changed

`isOpen` function in modal driver

### Why it changed
Because of the way the modal is being rendered on the DOM `body`, which the wrapper is rendered empty when the modal is closed and not shown. `!!getContent()` always returned true since it looks for the wrapper DOM node which always exists.
Instead, there should be a deeper check up to see wether there is a content inside it or not
fix a bug where the `isOpen` always returns `true`

