### PR TITLE
add name prop to inputarea component

### DIFF
--- a/src/InputArea/InputArea.driver.js
+++ b/src/InputArea/InputArea.driver.js
@@ -12,6 +12,7 @@ const inputAreaDriverFactory = ({element, wrapper, component}) => {
     focus: () => textArea.focus(),
     enterText: text => ReactTestUtils.Simulate.change(textArea, {target: {value: text}}),
     getValue: () => textArea.value,
+    getName: () => textArea.name,
     getPlaceholder: () => textArea.placeholder,
     getDefaultValue: () => textArea.defaultValue,
     getRowsCount: () => textArea.rows,

--- a/src/InputArea/InputArea.js
+++ b/src/InputArea/InputArea.js
@@ -39,6 +39,7 @@ class InputArea extends WixComponent {
       forceFocus,
       forceHover,
       id,
+      name,
       onKeyUp,
       placeholder,
       readOnly,
@@ -88,6 +89,7 @@ class InputArea extends WixComponent {
             ref={ref => this.textArea = ref}
             className={styles.inputArea}
             id={id}
+            name={name}
             style={inlineStyle}
             defaultValue={defaultValue}
             value={value}
@@ -190,6 +192,9 @@ InputArea.propTypes = {
   /** When true a letters counter will appear */
   hasCounter: PropTypes.bool,
   id: PropTypes.string,
+
+  /** Name Attribute */
+  name: PropTypes.string,
 
   /** i.e. '12px' */
   maxHeight: PropTypes.string,

--- a/src/InputArea/InputArea.spec.js
+++ b/src/InputArea/InputArea.spec.js
@@ -105,6 +105,15 @@ describe('InputArea', () => {
     });
   });
 
+  describe('name attribute', () => {
+    it('should pass down to the wrapped input', () => {
+      const name = 'someName';
+
+      const driver = createDriver(<InputAreaForTesting name={name}/>);
+      expect(driver.getName()).toEqual(name);
+    });
+  });
+
   describe('readOnly attribute', () => {
     it('should pass down to the wrapped input', () => {
       const driver = createDriver(<InputAreaForTesting readOnly/>);


### PR DESCRIPTION
### What changed
Added `name` prop to `InputArea` component
fixes #2448 

### Why it changed
`name` prop was missing

---

- [ v ] Change is tested
- [ v ] Change is documented
- [ ? ] Build is green
- [ ? ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

