### PR TITLE
Test/testkit sanity migration

### DIFF
--- a/src/Breadcrumbs/Breadcrumbs.spec.js
+++ b/src/Breadcrumbs/Breadcrumbs.spec.js
@@ -1,20 +1,13 @@
 import React from 'react';
-import ReactTestUtils from 'react-dom/test-utils';
-import {mount} from 'enzyme';
 
 import {createDriverFactory} from 'wix-ui-test-utils/driver-factory';
-import {breadcrumbsTestkitFactory} from '../../testkit';
-import {breadcrumbsTestkitFactory as enzymeBreadcrumbsTestkitFactory} from '../../testkit/enzyme';
 import breadcrumbsDriverFactory from './Breadcrumbs.driver';
 
 import Breadcrumbs from './Breadcrumbs';
 
 describe('Breadcrumbs', () => {
   const createDriver = createDriverFactory(breadcrumbsDriverFactory);
-  const items = [
-    {id: 0, value: 'Option 1'},
-    {id: 1, value: 'Option 2'}
-  ];
+  const items = [{id: 0, value: 'Option 1'}, {id: 1, value: 'Option 2'}];
   let onClick;
   let driver;
 
@@ -38,7 +31,10 @@ describe('Breadcrumbs', () => {
     const itemIndex = 1;
 
     driver.clickBreadcrumbAt(itemIndex);
-    expect(onClick).toBeCalledWith({id: items[itemIndex].id, value: 'Option 2'});
+    expect(onClick).toBeCalledWith({
+      id: items[itemIndex].id,
+      value: 'Option 2'
+    });
   });
 
   it('should get correct size from props', () => {
@@ -101,12 +97,25 @@ describe('Breadcrumbs', () => {
 
   describe('customElement attribute', () => {
     const customItems = [
-      {id: 0, value: 'Option 1', customElement: <a href="//www.wix.com">Option 1</a>},
-      {id: 1, value: 'Option 2', customElement: <a href="//www.facebook.com">Option 2</a>}
+      {
+        id: 0,
+        value: 'Option 1',
+        customElement: <a href="//www.wix.com">Option 1</a>
+      },
+      {
+        id: 1,
+        value: 'Option 2',
+        customElement: <a href="//www.facebook.com">Option 2</a>
+      }
     ];
 
     const customItemsWithLinks = [
-      {id: 0, value: 'value', customElement: <a href="//www.wix.com">Custom value</a>, link: 'www.bla.com'}
+      {
+        id: 0,
+        value: 'value',
+        customElement: <a href="//www.wix.com">Custom value</a>,
+        link: 'www.bla.com'
+      }
     ];
 
     it('should render the customElement when given', () => {
@@ -118,7 +127,6 @@ describe('Breadcrumbs', () => {
     });
 
     it('should render the customElement even if link attribute is given', () => {
-
       createComponent({items: customItemsWithLinks});
 
       expect(driver.breadcrumbsLength()).toBe(customItemsWithLinks.length);
@@ -129,25 +137,6 @@ describe('Breadcrumbs', () => {
       createComponent({items: customItemsWithLinks, activeId: 0});
 
       expect(driver.breadcrumbContentAt(0)).toBe(customItemsWithLinks[0].value);
-    });
-  });
-
-  describe('testkit', () => {
-    it('should exist', () => {
-      const div = document.createElement('div');
-      const dataHook = 'myDataHook';
-      const wrapper = div.appendChild(ReactTestUtils.renderIntoDocument(<div><Breadcrumbs onClick={onClick} items={items} dataHook={dataHook}/></div>));
-      const breadcrumbsTestkit = breadcrumbsTestkitFactory({wrapper, dataHook});
-      expect(breadcrumbsTestkit.exists()).toBeTruthy();
-    });
-  });
-
-  describe('enzyme testkit', () => {
-    it('should exist', () => {
-      const dataHook = 'myDataHook';
-      const wrapper = mount(<Breadcrumbs onClick={onClick} items={items} dataHook={dataHook}/>);
-      const breadcrumbsTestkit = enzymeBreadcrumbsTestkitFactory({wrapper, dataHook});
-      expect(breadcrumbsTestkit.exists()).toBeTruthy();
     });
   });
 });

--- a/src/Selector/Selector.spec.js
+++ b/src/Selector/Selector.spec.js
@@ -1,11 +1,7 @@
 import React from 'react';
-import ReactTestUtils from 'react-dom/test-utils';
 import selectorDriverFactory from './Selector.driver';
 import {createDriverFactory} from 'wix-ui-test-utils/driver-factory';
-import {selectorTestkitFactory} from '../../testkit';
 import Selector from './Selector';
-import {selectorTestkitFactory as enzymeSelectorTestkitFactory} from '../../testkit/enzyme';
-import {mount} from 'enzyme';
 
 describe('Selector', () => {
   const createDriver = createDriverFactory(selectorDriverFactory);
@@ -54,7 +50,9 @@ describe('Selector', () => {
   });
 
   it('should render the image', () => {
-    const driver = createDriver(<Selector {...defaultProps} image={<img src="img.png"/>}/>);
+    const driver = createDriver(
+      <Selector {...defaultProps} image={<img src="img.png"/>}/>
+    );
     expect(driver.hasImage()).toBe(true);
     expect(driver.getImage()).toBeInstanceOf(HTMLImageElement);
     expect(driver.getImage().src).toBe('img.png');
@@ -72,7 +70,6 @@ describe('Selector', () => {
     expect(driver.toggleType()).toBe(toggleType);
   });
 
-
   it('should render a radio toggle', () => {
     const toggleType = 'radio';
     const props = {...defaultProps, ...{toggleType}};
@@ -84,7 +81,9 @@ describe('Selector', () => {
     const onToggle = jest.fn();
     const toggleType = 'radio';
     const props = {...defaultProps, ...{toggleType}};
-    const driver = createDriver(<Selector onToggle={onToggle} {...props} isDisabled/>);
+    const driver = createDriver(
+      <Selector onToggle={onToggle} {...props} isDisabled/>
+    );
 
     driver.toggle();
 
@@ -114,25 +113,6 @@ describe('Selector', () => {
 
         expect(driver[method](size)).toBe(true);
       });
-    });
-  });
-
-  describe('testkit', () => {
-    it('should exist', () => {
-      const div = document.createElement('div');
-      const dataHook = 'myDataHook';
-      const wrapper = div.appendChild(ReactTestUtils.renderIntoDocument(<div><Selector {...defaultProps} dataHook={dataHook}/></div>));
-      const selectorTestkit = selectorTestkitFactory({wrapper, dataHook});
-      expect(selectorTestkit.exists()).toBeTruthy();
-    });
-  });
-
-  describe('enzyme testkit', () => {
-    it('should exist', () => {
-      const dataHook = 'myDataHook';
-      const wrapper = mount(<Selector {...defaultProps} dataHook={dataHook}/>);
-      const selectorTestkit = enzymeSelectorTestkitFactory({wrapper, dataHook});
-      expect(selectorTestkit.exists()).toBeTruthy();
     });
   });
 });

--- a/src/Slider/Slider.spec.js
+++ b/src/Slider/Slider.spec.js
@@ -2,13 +2,8 @@ import React from 'react';
 import Slider from './Slider';
 import {createDriverFactory} from 'wix-ui-test-utils/driver-factory';
 import sliderDriverFactory from './Slider.driver';
-import {sliderTestkitFactory} from '../../testkit';
-import {sliderTestkitFactory as enzymeSliderTestkitFactory} from '../../testkit/enzyme';
-import {isTestkitExists, isEnzymeTestkitExists} from '../../test/utils/testkit-sanity';
-import {mount} from 'enzyme';
 
 describe('Slider', () => {
-
   const createDriver = createDriverFactory(sliderDriverFactory);
   let driver;
 
@@ -64,17 +59,5 @@ describe('Slider', () => {
     expect(driver.getToolTipValue()).toBeFalsy();
 
     driver.unHoverHandle({handleIndex: 0});
-  });
-});
-
-describe('testkit', () => {
-  it('should exist', () => {
-    expect(isTestkitExists(<Slider onChange={() => {}}/>, sliderTestkitFactory)).toBe(true);
-  });
-});
-
-describe('enzyme testkit', () => {
-  it('should exist', () => {
-    expect(isEnzymeTestkitExists(<Slider onChange={() => {}}/>, enzymeSliderTestkitFactory, mount)).toBe(true);
   });
 });

--- a/src/StatsWidget/StatsWidget.spec.js
+++ b/src/StatsWidget/StatsWidget.spec.js
@@ -3,55 +3,55 @@ import {createDriverFactory} from 'wix-ui-test-utils/driver-factory';
 import statsWidgetDriverFactory from './StatsWidget.driver';
 import StatsWidget from './StatsWidget';
 import ButtonWithOptions from '../../src/ButtonWithOptions';
-import {isEnzymeTestkitExists, isTestkitExists} from '../../test/utils/testkit-sanity';
-import {statsWidgetTestkitFactory} from '../../testkit';
-import {statsWidgetTestkitFactory as enzymeStatsWidgetTestkitFactory} from '../../testkit/enzyme';
-import {mount} from 'enzyme';
 
 describe('StatsWidget', () => {
   const createDriver = createDriverFactory(statsWidgetDriverFactory);
 
   const title = 'Stats Widget title';
-  const statistics = [{
-    title: '10$',
-    subtitle: 'Revenue'
-  },
-  {
-    title: '2',
-    subtitle: 'Products'
-  },
-  {
-    title: '1',
-    subtitle: 'Transactions'
-  },
-  {
-    title: '5',
-    subtitle: 'Profit'
-  },
-  {
-    title: '15',
-    subtitle: 'Music'
-  }];
+  const statistics = [
+    {
+      title: '10$',
+      subtitle: 'Revenue'
+    },
+    {
+      title: '2',
+      subtitle: 'Products'
+    },
+    {
+      title: '1',
+      subtitle: 'Transactions'
+    },
+    {
+      title: '5',
+      subtitle: 'Profit'
+    },
+    {
+      title: '15',
+      subtitle: 'Music'
+    }
+  ];
 
-  const statisticsWithPercents = [{
-    title: '10$',
-    subtitle: 'Revenue',
-    percent: 15
-  },
-  {
-    title: '2',
-    subtitle: 'Products',
-    percent: -15
-  },
-  {
-    title: '1',
-    subtitle: 'Transactions',
-    percent: 0
-  }];
+  const statisticsWithPercents = [
+    {
+      title: '10$',
+      subtitle: 'Revenue',
+      percent: 15
+    },
+    {
+      title: '2',
+      subtitle: 'Products',
+      percent: -15
+    },
+    {
+      title: '1',
+      subtitle: 'Transactions',
+      percent: 0
+    }
+  ];
 
   let driver;
 
-  const stub = console.error = jest.fn();
+  const stub = (console.error = jest.fn());
 
   function createComponent(props) {
     driver = createDriver(<StatsWidget {...props}/>);
@@ -88,8 +88,12 @@ describe('StatsWidget', () => {
 
   it('should show abs of percentage', () => {
     createComponent({title, statistics: statisticsWithPercents});
-    expect(driver.getStatisticPercentValue(0)).toBe(Math.abs(statisticsWithPercents[0].percent) + '%');
-    expect(driver.getStatisticPercentValue(1)).toBe(Math.abs(statisticsWithPercents[1].percent) + '%');
+    expect(driver.getStatisticPercentValue(0)).toBe(
+      Math.abs(statisticsWithPercents[0].percent) + '%'
+    );
+    expect(driver.getStatisticPercentValue(1)).toBe(
+      Math.abs(statisticsWithPercents[1].percent) + '%'
+    );
   });
 
   it('should put proper classes to percentage according to value', () => {
@@ -103,66 +107,94 @@ describe('StatsWidget', () => {
   });
 
   it('should show filter with ButtonWithOptions inside', () => {
-    const children = (<StatsWidget.Filter selectedId={1} dataHook="stats-widget-filter" onSelect={stub}><ButtonWithOptions.Button/>{[<ButtonWithOptions.Option key={1}>value</ButtonWithOptions.Option>]}</StatsWidget.Filter>);
+    const children = (
+      <StatsWidget.Filter
+        selectedId={1}
+        dataHook="stats-widget-filter"
+        onSelect={stub}
+        >
+        <ButtonWithOptions.Button/>
+        {[<ButtonWithOptions.Option key={1}>value</ButtonWithOptions.Option>]}
+      </StatsWidget.Filter>
+    );
     createComponent({title, statistics, children});
-    expect(driver.getFilterDriver('stats-widget-filter').dropdownLayoutDriver.exists()).toBe(true);
+    expect(
+      driver
+        .getFilterDriver('stats-widget-filter')
+        .dropdownLayoutDriver.exists()
+    ).toBe(true);
   });
 
   it('filters should have selectable options', () => {
     const stub = jest.fn();
-    const children = (<StatsWidget.Filter selectedId={1} dataHook="stats-widget-filter" onSelect={stub}><ButtonWithOptions.Button/>{[<ButtonWithOptions.Option key={1}>value</ButtonWithOptions.Option>]}</StatsWidget.Filter>);
+    const children = (
+      <StatsWidget.Filter
+        selectedId={1}
+        dataHook="stats-widget-filter"
+        onSelect={stub}
+        >
+        <ButtonWithOptions.Button/>
+        {[<ButtonWithOptions.Option key={1}>value</ButtonWithOptions.Option>]}
+      </StatsWidget.Filter>
+    );
     createComponent({title, statistics, children});
-    driver.getFilterDriver('stats-widget-filter').dropdownLayoutDriver.clickAtOption(0);
+    driver
+      .getFilterDriver('stats-widget-filter')
+      .dropdownLayoutDriver.clickAtOption(0);
     expect(stub).toHaveBeenCalled();
   });
 
   it('should show filters with option value specified', () => {
     const value = 'Last Week';
-    const children = (<StatsWidget.Filter selectedId={1} dataHook="stats-widget-filter" onSelect={stub}><ButtonWithOptions.Button/>{[<ButtonWithOptions.Option key={1}>{value}</ButtonWithOptions.Option>]}</StatsWidget.Filter>);
+    const children = (
+      <StatsWidget.Filter
+        selectedId={1}
+        dataHook="stats-widget-filter"
+        onSelect={stub}
+        >
+        <ButtonWithOptions.Button/>
+        {[<ButtonWithOptions.Option key={1}>{value}</ButtonWithOptions.Option>]}
+      </StatsWidget.Filter>
+    );
     createComponent({title, statistics, children});
-    expect(driver.getFilterDriver('stats-widget-filter').dropdownLayoutDriver.optionsContent()).toContain(value);
+    expect(
+      driver
+        .getFilterDriver('stats-widget-filter')
+        .dropdownLayoutDriver.optionsContent()
+    ).toContain(value);
   });
 
   it('should not initialize component with 1 bad child', () => {
-    const PageRequiredChildrenArrayError = 'Warning: Failed prop type: Invalid prop `children` of type `object` supplied to `StatsWidget`, expected an array.\n    in StatsWidget';
+    const PageRequiredChildrenArrayError =
+      'Warning: Failed prop type: Invalid prop `children` of type `object` supplied to `StatsWidget`, expected an array.\n    in StatsWidget';
     createComponent({title, statistics, children: <div/>});
 
     expect(stub).toHaveBeenCalledWith(PageRequiredChildrenArrayError);
   });
 
   it('should not initialize component with percent which are not a numbers', () => {
+    const wrongStatistics = [
+      {
+        title: '10$',
+        subtitle: 'Revenue',
+        percent: '15%'
+      },
+      {
+        title: '2',
+        subtitle: 'Products',
+        percent: '-15%'
+      },
+      {
+        title: '1',
+        subtitle: 'Transactions',
+        percent: '0'
+      }
+    ];
 
-    const wrongStatistics = [{
-      title: '10$',
-      subtitle: 'Revenue',
-      percent: '15%'
-    },
-    {
-      title: '2',
-      subtitle: 'Products',
-      percent: '-15%'
-    },
-    {
-      title: '1',
-      subtitle: 'Transactions',
-      percent: '0'
-    }];
-
-    const PageRequiredChildrenArrayError = 'Warning: Failed prop type: Invalid prop `statistics[0].percent` of type `string` supplied to `StatsWidget`, expected `number`.\n    in StatsWidget';
+    const PageRequiredChildrenArrayError =
+      'Warning: Failed prop type: Invalid prop `statistics[0].percent` of type `string` supplied to `StatsWidget`, expected `number`.\n    in StatsWidget';
     createComponent({title, statistics: wrongStatistics});
 
     expect(stub).toHaveBeenCalledWith(PageRequiredChildrenArrayError);
-  });
-
-  describe('testkit', () => {
-    it('should exist', () => {
-      expect(isTestkitExists(<StatsWidget title="test title" statistics={statistics}/>, statsWidgetTestkitFactory)).toBeTruthy();
-    });
-  });
-
-  describe('enzyme testkit', () => {
-    it('should exist', () => {
-      expect(isEnzymeTestkitExists(<StatsWidget title="test title" statistics={statistics}/>, enzymeStatsWidgetTestkitFactory, mount)).toBeTruthy();
-    });
   });
 });

--- a/testkit/testkit-smoke.test.js
+++ b/testkit/testkit-smoke.test.js
@@ -23,11 +23,10 @@ const FAILING_COMPONENTS = [
   'BadgeSelectItemBuilder',
   'ButtonLayout',
   'ButtonWithOptions',
-  'Calendar',
   'CalendarPanel',
   'Card',
   'CloseButton',
-  'ColorPicker',
+  'ColorPicker', // missing testkit for enzyme
   'Composite',
   'DataTable',
   'DatePicker',
@@ -39,8 +38,8 @@ const FAILING_COMPONENTS = [
   'FullTextView',
   'GoogleAddressInput',
   'GoogleAddressInputWithLabel',
-  'Grid',
-  'HBox',
+  'Grid', // Component has no testkit
+  'HBox', // Component has no testkit
   'IconWithOptions',
   'Layout',
   'MessageBox',
@@ -66,7 +65,7 @@ const FAILING_COMPONENTS = [
   'TextArea',
   'TextField',
   'Tooltip',
-  'VBox'
+  'VBox' // Component has no testkit
 ];
 
 /**
@@ -92,6 +91,9 @@ const REQUIRED_PROPS = {
   },
   Breadcrumbs: {
     items: [{id: 0, value: 'Option 1'}, {id: 1, value: 'Option 2'}]
+  },
+  Calendar: {
+    onChange: () => {}
   }
 };
 

--- a/testkit/testkit-smoke.test.js
+++ b/testkit/testkit-smoke.test.js
@@ -57,7 +57,6 @@ const FAILING_COMPONENTS = [
   'RichTextAreaComposite',
   'Selector',
   'SideMenuDrill',
-  'Slider',
   'StatsWidget',
   'Table',
   'TableToolbar',
@@ -93,6 +92,10 @@ const REQUIRED_PROPS = {
     items: [{id: 0, value: 'Option 1'}, {id: 1, value: 'Option 2'}]
   },
   Calendar: {
+    onChange: () => {}
+  },
+
+  Slider: {
     onChange: () => {}
   }
 };

--- a/testkit/testkit-smoke.test.js
+++ b/testkit/testkit-smoke.test.js
@@ -56,7 +56,6 @@ const FAILING_COMPONENTS = [
   'RichTextArea',
   'RichTextAreaComposite',
   'SideMenuDrill',
-  'StatsWidget',
   'Table',
   'TableToolbar',
   'Tabs',
@@ -100,6 +99,9 @@ const REQUIRED_PROPS = {
   Selector: {
     id: 1,
     title: 'title'
+  },
+  StatsWidget: {
+    title: 'test title'
   }
 };
 

--- a/testkit/testkit-smoke.test.js
+++ b/testkit/testkit-smoke.test.js
@@ -55,7 +55,6 @@ const FAILING_COMPONENTS = [
   'Range',
   'RichTextArea',
   'RichTextAreaComposite',
-  'Selector',
   'SideMenuDrill',
   'StatsWidget',
   'Table',
@@ -97,6 +96,10 @@ const REQUIRED_PROPS = {
 
   Slider: {
     onChange: () => {}
+  },
+  Selector: {
+    id: 1,
+    title: 'title'
   }
 };
 

--- a/testkit/testkit-smoke.test.js
+++ b/testkit/testkit-smoke.test.js
@@ -21,7 +21,6 @@ import * as enzymeTestkitFactories from './enzyme';
 const FAILING_COMPONENTS = [
   'AutoCompleteComposite',
   'BadgeSelectItemBuilder',
-  'Breadcrumbs',
   'ButtonLayout',
   'ButtonWithOptions',
   'Calendar',
@@ -90,6 +89,9 @@ const REQUIRED_PROPS = {
   BadgeSelect: {
     options: [{id: '0', skin: 'general', text: 'general'}],
     selectedId: '0'
+  },
+  Breadcrumbs: {
+    items: [{id: 0, value: 'Option 1'}, {id: 1, value: 'Option 2'}]
   }
 };
 


### PR DESCRIPTION
after #2446 was merged, i took just a few components as example case to
see how migration can be done.

prettier makes it look like i didn't remove much, but reality is that
sanity tests were cleaned from Breadcrumbs, Calendar, Slider, Selector &
StatsWidget. these components are still covered by tests, but in
automated way.

continuing with reducing `FAILING_COMPONENTS` list can be part of our infra day or a
well defined guildweek task for a day or two

@shlomitc this took me 14 minutes, im not wasting time here :)