### PR TITLE
docs(Notification): WIP example with wix-storybook-utils sections

### DIFF
--- a/.storybook/common/stories.js
+++ b/.storybook/common/stories.js
@@ -81,6 +81,7 @@ import '../../stories/Tooltip/Composite/CompositeStory';
 // 8. Notification Bars
 // 8.1 Standard, 8.2 Error, 8.3 Success, 8.4 Warning, 8.5 Premium
 import '../../stories/Notification';
+import '../../stories/Notification/index.story.js';
 import '../../stories/FloatingHelper/FloatingHelper.story.js'; // 8.6 FloatingHelper
 import '../../stories/FloatingHelperContent/FloatingHelperContent.story.js'; // 8.6 + FloatingHelper.Content
 import '../../stories/SectionHelper/SectionHelper.story.js'; // 8.7 SectionHelper

--- a/stories/Notification/index.story.js
+++ b/stories/Notification/index.story.js
@@ -1,0 +1,46 @@
+import {
+  importExample,
+  description,
+  code
+} from 'wix-storybook-utils/dist/src/Sections/builders';
+
+import Notification from 'wix-style-react/Notification';
+
+const sourceForThemes = theme => `
+<Notification theme="${theme}" show>
+  <Notification.TextLabel>${theme}</Notification.TextLabel>
+  <Notification.CloseButton/>
+</Notification>
+`;
+
+const wrapWithDiv = string =>
+  `<div>
+  ${string}
+</div>`;
+
+export default {
+  category: 'Notification',
+  storyName: 'Notification new',
+  componentPath: '../../src/Notification',
+
+  sections: [
+    importExample({
+      source: 'import Notification from \'wix-style-react/Notification\';'
+    }),
+
+    description({
+      text:
+        'A sticky toast bar that appears on top of the screen notifying about system changes.'
+    }),
+
+    code({
+      source: wrapWithDiv(
+        ['standard', 'error', 'success', 'warning', 'premium'].reduce(
+          (a, theme) => a.concat(sourceForThemes(theme).trim() + '\n'),
+          ''
+        )
+      ),
+      components: {Notification}
+    })
+  ]
+};


### PR DESCRIPTION
Please don't merge, this is WIP and is just for showcase.

This is part of our storybook design update effort.
Idea is to have more flexibility in wix-storybook-utils which allows controlling what parts should be displayed in docs.

depends on https://github.com/wix/wix-ui/pull/900