### PR TITLE
<BadgeSelect/> - add a z-index to the dropdown container

### DIFF
--- a/src/BadgeSelect/BadgeSelect.scss
+++ b/src/BadgeSelect/BadgeSelect.scss
@@ -9,6 +9,7 @@
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
+  z-index: 1;
 
   width: intrinsic;           /* Safari/WebKit uses a non-standard name */
   width: -moz-max-content;    /* Firefox/Gecko */


### PR DESCRIPTION
### What changed

Add a z-index to the dropdown container so it will be visible over other elements.

### Why it changed

https://github.com/wix/wix-style-react/issues/2474

---

- [ ] Change is tested
- [ ] Change is documented
- [ ] Build is green
- [ ] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
