### PR TITLE
<DataTable/> - updated sorting behaviour

### DIFF
--- a/src/DataTable/DataTable.driver.js
+++ b/src/DataTable/DataTable.driver.js
@@ -27,6 +27,10 @@ const dataTableDriverFactory = ({element, wrapper, component}) => {
   const getTitleInfoIcon = index => element.querySelector(`th [data-hook="${index}_info_tooltip"]`);
   const getSortableTitleArrowDesc = index => element.querySelector(`th [data-hook="${index}_title"]  [data-hook="active_arrow_desc"]`);
 
+  const getSortingIconsDataHooks = index =>
+    Array.from(element.querySelectorAll(`th [data-hook="${index}_title"] svg`))
+      .map(el => el.getAttribute('data-hook') || '');
+
   return {
     getRow,
     getRowsCount,
@@ -71,7 +75,23 @@ const dataTableDriverFactory = ({element, wrapper, component}) => {
       return !!sortableTitle && sortableTitle.classList.contains('sortArrowAsc');
     },
     clickSort: (index, eventData) => ReactTestUtils.Simulate.click(getHeaderCell(index), eventData),
-    getRowDetails: index => getRowDetails(index)
+    getRowDetails: index => getRowDetails(index),
+
+    // New sorting arrows
+    getActiveSortingArrowDirection: index => {
+      const hooks = getSortingIconsDataHooks(index);
+      const activeIconDataHook = hooks.find(h => h.includes('active'));
+
+      return activeIconDataHook && /active_arrow_(.+)$/.exec(activeIconDataHook)[1];
+    },
+    getHiddenSortingArrowDirection: index => {
+      const hooks = getSortingIconsDataHooks(index);
+      const activeIconDataHook = hooks.find(h => h.includes('hidden'));
+
+      return activeIconDataHook && /hidden_arrow_(.+)$/.exec(activeIconDataHook)[1];
+    },
+    mouseEnterHeaderCell: (index, eventData) => ReactTestUtils.Simulate.mouseEnter(getHeaderCell(index), eventData),
+    mouseLeaveHeaderCell: (index, eventData) => ReactTestUtils.Simulate.mouseLeave(getHeaderCell(index), eventData)
   };
 };
 

--- a/src/DataTable/DataTable.driver.js
+++ b/src/DataTable/DataTable.driver.js
@@ -25,7 +25,7 @@ const dataTableDriverFactory = ({element, wrapper, component}) => {
   const getHeaderCell = index => getHeader().querySelectorAll('th')[index];
   const getSortableTitle = index => element.querySelector(`th [data-hook="${index}_title"]`);
   const getTitleInfoIcon = index => element.querySelector(`th [data-hook="${index}_info_tooltip"]`);
-  const getSortableTitleArrowDesc = index => element.querySelector(`th [data-hook="${index}_title"]  [data-hook="sort_arrow_dec"]`);
+  const getSortableTitleArrowDesc = index => element.querySelector(`th [data-hook="${index}_title"]  [data-hook="active_arrow_desc"]`);
 
   return {
     getRow,

--- a/src/DataTable/DataTable.driver.js
+++ b/src/DataTable/DataTable.driver.js
@@ -27,10 +27,6 @@ const dataTableDriverFactory = ({element, wrapper, component}) => {
   const getTitleInfoIcon = index => element.querySelector(`th [data-hook="${index}_info_tooltip"]`);
   const getSortableTitleArrowDesc = index => element.querySelector(`th [data-hook="${index}_title"]  [data-hook="active_arrow_desc"]`);
 
-  const getSortingIconsDataHooks = index =>
-    Array.from(element.querySelectorAll(`th [data-hook="${index}_title"] svg`))
-      .map(el => el.getAttribute('data-hook') || '');
-
   return {
     getRow,
     getRowsCount,
@@ -78,17 +74,19 @@ const dataTableDriverFactory = ({element, wrapper, component}) => {
     getRowDetails: index => getRowDetails(index),
 
     // New sorting arrows
-    getActiveSortingArrowDirection: index => {
-      const hooks = getSortingIconsDataHooks(index);
-      const activeIconDataHook = hooks.find(h => h.includes('active'));
+    getActiveSortingArrowDirection: columnIndex => {
+      const activeIconDataHook = getSortableTitle(columnIndex)
+        .querySelector('[data-hook*="active_arrow_"]')
+        .getAttribute('data-hook');
 
       return activeIconDataHook && /active_arrow_(.+)$/.exec(activeIconDataHook)[1];
     },
-    getHiddenSortingArrowDirection: index => {
-      const hooks = getSortingIconsDataHooks(index);
-      const activeIconDataHook = hooks.find(h => h.includes('hidden'));
+    getHiddenSortingArrowDirection: columnIndex => {
+      const hiddenIconDataHook = getSortableTitle(columnIndex)
+        .querySelector('[data-hook*="hidden_arrow_"]')
+        .getAttribute('data-hook');
 
-      return activeIconDataHook && /hidden_arrow_(.+)$/.exec(activeIconDataHook)[1];
+      return hiddenIconDataHook && /hidden_arrow_(.+)$/.exec(hiddenIconDataHook)[1];
     },
     mouseEnterHeaderCell: (index, eventData) => ReactTestUtils.Simulate.mouseEnter(getHeaderCell(index), eventData),
     mouseLeaveHeaderCell: (index, eventData) => ReactTestUtils.Simulate.mouseLeave(getHeaderCell(index), eventData)

--- a/src/DataTable/DataTable.js
+++ b/src/DataTable/DataTable.js
@@ -308,7 +308,7 @@ class TableHeader extends Component {
 
     // When the cell is active, we want to preserve the *previous* state after
     // the click
-    const isCurrentCellActive = this.state.activeHeaderCell === colNum;
+    const isCurrentCellActive = sortIconDirectionOnHover && this.state.activeHeaderCell === colNum;
 
     const activeDirection = sortIconDirection;
     const hiddenDirection = isCurrentCellActive ?
@@ -413,7 +413,7 @@ class TableHeader extends Component {
       );
 
       // "Disable" the hover effect when using the legacy `sortDescending` property
-      sortIconDirectionOnHover = sortIconDirection;
+      sortIconDirectionOnHover = undefined;
 
       deprecationLog(
         'Property `sortDescending` of Table\'s `columns` prop is deprecated; use `sortIconDirection` instead.'

--- a/src/DataTable/DataTable.js
+++ b/src/DataTable/DataTable.js
@@ -268,8 +268,21 @@ class TableHeader extends Component {
     newDesign: PropTypes.bool
   };
 
+  state = {
+    // This state property indicates what header cell is currently active. A
+    // cell becomes "active" when it is clicked, and stops being active when
+    // the mouse leaves it.
+    activeHeaderCell: -1
+  }
+
   get style() {
     return styles;
+  }
+
+  setActiveHeaderCell = colNum => {
+    this.setState({
+      activeHeaderCell: colNum
+    });
   }
 
   renderSortingArrow = (column, colNum) => {
@@ -301,6 +314,10 @@ class TableHeader extends Component {
       return null;
     }
 
+    // When the cell is active, we want to preserve the *previous* state after
+    // the click
+    const isCurrentCellActive = this.state.activeHeaderCell === colNum;
+
     return (
       <span
         data-hook={`${colNum}_title`}
@@ -308,6 +325,9 @@ class TableHeader extends Component {
         >
         {ActiveSortingArrow && (
           <ActiveSortingArrow
+            style={{
+              display: isCurrentCellActive ? 'inherit' : undefined
+            }}
             height={12}
             className={this.style.activeSortingArrow}
             data-hook={`active_arrow_${sortingIconDirection}`}
@@ -315,6 +335,9 @@ class TableHeader extends Component {
         )}
         {HiddenSortingArrow && (
           <HiddenSortingArrow
+            style={{
+              display: isCurrentCellActive ? 'none' : undefined
+            }}
             height={12}
             className={this.style.hiddenSortingArrow}
             data-hook={`active_arrow_${sortingIconDirection}`}
@@ -378,10 +401,17 @@ class TableHeader extends Component {
       [this.style.thText]: this.props.newDesign
     });
 
-    const optionalHeaderCellProps = {};
+    let optionalHeaderCellProps = {};
 
     if (column.sortable) {
-      optionalHeaderCellProps.onClick = () => this.props.onSortClick && this.props.onSortClick(column, colNum);
+      optionalHeaderCellProps = {
+        ...optionalHeaderCellProps,
+        onClick: () => {
+          this.setActiveHeaderCell(colNum);
+          this.props.onSortClick && this.props.onSortClick(column, colNum);
+        },
+        onMouseLeave: () => this.setActiveHeaderCell(-1)
+      };
     }
 
     let sortingIconDirection = column.sortingIconDirection;

--- a/src/DataTable/DataTable.js
+++ b/src/DataTable/DataTable.js
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import InfiniteScroll from './InfiniteScroll';
 import SortByArrowUp from '../new-icons/system/SortByArrowUp';
 import SortByArrowDown from '../new-icons/system/SortByArrowDown';
+import CloseLarge from '../new-icons/system/CloseLarge';
 import {Animator} from 'wix-animations';
 import InfoCircle from 'wix-ui-icons-common/InfoCircle';
 import Tooltip from '../Tooltip/Tooltip';
@@ -320,7 +321,11 @@ class TableHeader extends Component {
       sortIconDirectionOnHover || sortIconDirection;
 
     const ActiveSortingArrow = this.getSortingArrow(activeDirection);
-    const HiddenSortingArrow = this.getSortingArrow(hiddenDirection);
+    const HiddenSortingArrow = this.getSortingArrow(hiddenDirection) || (
+      // Show the close icon when we don't have an icon to show (sorting
+      // direction is `none`), but only if the cell is not active
+      isCurrentCellActive ? null : CloseLarge
+    );
 
     if (!ActiveSortingArrow && !HiddenSortingArrow) {
       return null;

--- a/src/DataTable/DataTable.js
+++ b/src/DataTable/DataTable.js
@@ -300,6 +300,10 @@ class TableHeader extends Component {
   renderSortingArrow = (column, colNum) => {
     const {sortIconDirection, sortIconDirectionOnHover} = column;
 
+    if (!sortIconDirection && !sortIconDirectionOnHover) {
+      return;
+    }
+
     // Support old design
     if (!this.props.newDesign) {
       const sortDirectionClassName = sortIconDirection === 'desc' ? this.style.sortArrowAsc : this.style.sortArrowDesc;

--- a/src/DataTable/DataTable.protractor.driver.js
+++ b/src/DataTable/DataTable.protractor.driver.js
@@ -11,7 +11,8 @@ const dataTableDriverFactory = component => ({
   clickRowByIndex: index => rowByIdx(component, index).click(),
   getRowTextByIndex: index => rowByIdx(component, index).getText(),
   scrollToRowByIdx: index => scrollIntoView(rowByIdx(component, index)),
-  element: () => component
+  element: () => component,
+  getHeaderCell: index => component.$$('thead th').get(index)
 });
 
 export default dataTableDriverFactory;

--- a/src/DataTable/DataTable.scss
+++ b/src/DataTable/DataTable.scss
@@ -64,6 +64,17 @@ $rowShadow: inset 0 1px 0 0 $D70;
   &.th-text {
     @include Text($weight: normal, $size: small);
   }
+
+  // Sorting arrows
+  .activeSortingArrow,
+  &:hover .hiddenSortingArrow{
+    display: inherit;
+  }
+
+  &:hover .activeSortingArrow,
+  .hiddenSortingArrow{
+    display: none;
+  }
 }
 
 

--- a/src/DataTable/DataTable.scss
+++ b/src/DataTable/DataTable.scss
@@ -67,16 +67,15 @@ $rowShadow: inset 0 1px 0 0 $D70;
 
   // Sorting arrows
   .activeSortingArrow,
-  &:hover .hiddenSortingArrow{
+  &:hover .hiddenSortingArrow {
     display: inherit;
   }
 
   &:hover .activeSortingArrow,
-  .hiddenSortingArrow{
+  .hiddenSortingArrow {
     display: none;
   }
 }
-
 
 .table td {
   @include Text($weight: thin, $size: small, $secondary: true);

--- a/src/DataTable/README.TESTKIT.md
+++ b/src/DataTable/README.TESTKIT.md
@@ -28,8 +28,8 @@
 | hasSortDescending | (index) | bool | true if column title has sort descending style |
 | clickSort | (index, eventData) | - | click with <eventData> the column index <number> |
 | getRowDetails | string | element | returns row details by row index |
-| getActiveSortingArrowDirection | (index: number) | string | returns the direction of the active (current) sorting arrow |
-| getHiddenSortingArrowDirection | (index: number) | string | returns the direction of the hidden (next) sorting arrow |
+| getActiveSortingArrowDirection | (columnIndex: number) | string | returns the direction of the active (current) sorting arrow |
+| getHiddenSortingArrowDirection | (columnIndex: number) | string | returns the direction of the hidden (next) sorting arrow |
 | mouseEnterHeaderCell | (index: number) | - | mouse enter on a header cell |
 | mouseLeaveHeaderCell | (index: number) | - | mouse leave on a header cell |
 

--- a/src/DataTable/README.TESTKIT.md
+++ b/src/DataTable/README.TESTKIT.md
@@ -28,6 +28,10 @@
 | hasSortDescending | (index) | bool | true if column title has sort descending style |
 | clickSort | (index, eventData) | - | click with <eventData> the column index <number> |
 | getRowDetails | string | element | returns row details by row index |
+| getActiveSortingArrowDirection | (index: number) | string | returns the direction of the active (current) sorting arrow |
+| getHiddenSortingArrowDirection | (index: number) | string | returns the direction of the hidden (next) sorting arrow |
+| mouseEnterHeaderCell | (index: number) | - | mouse enter on a header cell |
+| mouseLeaveHeaderCell | (index: number) | - | mouse leave on a header cell |
 
 ## Protractor TestKit API
 
@@ -36,6 +40,7 @@
 | clickRowByIndex | number | - | click row index <number> |
 | getRowTextByIndex | number | string | get row index <number> text |
 | element | - | element | get the actual element |
+| getHeaderCell | (index: number) | element | get a header cell element |
 
 ## Usage Example
 

--- a/src/DataTable/README.md
+++ b/src/DataTable/README.md
@@ -35,7 +35,7 @@
 | thLetterSpacing | string | '1.5px' | - | Table headers letter spacing |
 | rowDetails | func | - | - | Function that returns React component that will be rendered in row details section. Example: `rowDetails={(row, rowNum) => <MyRowDetailsComponent {...row} />}` |
 | allowMultiDetailsExpansion | boolean | false | - | Allows to open multiple row details |
-| onSortClick | func | - | - | A callback function called on each column title click. Signature `onSortClick(colData, colNum)` |
+| onSortClick | func | - | - | A callback function called on each column title click. Signature `onSortClick(colData, colNum, nextSortingDirection)`. The `nextSortingDirection` is the desired sorting direction to be set after the user has changed the sorting direction. |
 | newDesign | boolean | false | - | A flag specifying weather to apply the new layout/design update. Default will change to true in the next major release (version 5.0.0)|
 
 ### Column object props

--- a/src/Table/README.TESTKIT.md
+++ b/src/Table/README.TESTKIT.md
@@ -29,12 +29,16 @@
 | clickSort | (index, eventData) | - | click with <eventData> the column index <number> |
 | getRowDetails | string | element | returns row details by row index |
 |    getRowCheckboxDriver | index: number | CheckboxDriver | Get driver of row selection checbox by row index |
-|getBulkSelectionCheckboxDriver | - | CheckboxDriver | Get driver of row bulk-selection checbox |
-|clickRowChecbox | index | - | Click the row selection checkbox |
-|clickBulkSelectionCheckbox| - | - | Click the bulk-selection checkbox|
-|isRowSelected | index : number | boolean | Is row selected by index |
-|getBulkSelectionState | - | string | Get bulk seleciton state. Possible value 'ALL', 'SOME', 'NONE. |
-|getTitlebar | - | element | Get title-bar (column titles) |
+| getBulkSelectionCheckboxDriver | - | CheckboxDriver | Get driver of row bulk-selection checbox |
+| clickRowChecbox | index | - | Click the row selection checkbox |
+| clickBulkSelectionCheckbox| - | - | Click the bulk-selection checkbox|
+| isRowSelected | index : number | boolean | Is row selected by index |
+| getBulkSelectionState | - | string | Get bulk seleciton state. Possible value 'ALL', 'SOME', 'NONE. |
+| getTitlebar | - | element | Get title-bar (column titles) |
+| getActiveSortingArrowDirection | (index: number) | string | returns the direction of the active (current) sorting arrow |
+| getHiddenSortingArrowDirection | (index: number) | string | returns the direction of the hidden (next) sorting arrow |
+| mouseEnterHeaderCell | (index: number) | - | mouse enter on a header cell |
+| mouseLeaveHeaderCell | (index: number) | - | mouse leave on a header cell |
 
 ## Protractor TestKit API
 
@@ -44,6 +48,7 @@
 | getRowTextByIndex | number | string | get row index <number> text |
 | element | - | element | get the actual element |
 | hoverRow | (index) | element | Hover a specific row with the mouse |
+| getHeaderCell | (index: number) | element | get a header cell element |
 
 ### Puppeteer
 

--- a/src/Table/README.TESTKIT.md
+++ b/src/Table/README.TESTKIT.md
@@ -35,8 +35,8 @@
 | isRowSelected | index : number | boolean | Is row selected by index |
 | getBulkSelectionState | - | string | Get bulk seleciton state. Possible value 'ALL', 'SOME', 'NONE. |
 | getTitlebar | - | element | Get title-bar (column titles) |
-| getActiveSortingArrowDirection | (index: number) | string | returns the direction of the active (current) sorting arrow |
-| getHiddenSortingArrowDirection | (index: number) | string | returns the direction of the hidden (next) sorting arrow |
+| getActiveSortingArrowDirection | (columnIndex: number) | string | returns the direction of the active (current) sorting arrow |
+| getHiddenSortingArrowDirection | (columnIndex: number) | string | returns the direction of the hidden (next) sorting arrow |
 | mouseEnterHeaderCell | (index: number) | - | mouse enter on a header cell |
 | mouseLeaveHeaderCell | (index: number) | - | mouse leave on a header cell |
 

--- a/src/Table/README.md
+++ b/src/Table/README.md
@@ -14,8 +14,8 @@
 | render | function | - | true | A function to render column cells. The function will be called with each row's data and should return a jsx element. Signature: `render(rowData, rowNum)` |
 | width | string | - | - | The width to apply to the column. No value means column will try to contain its children, if possible.  |
 | important | bool | false | - | Whether font color should be stronger, more dominant |
-| sortable | bool | false | - | Enables sorting by column |
-| sortDescending | bool | - | - | Pass false - for ascending sort, true - for descending|
+| sortable | bool | false | - | Set this to `true` to enable sorting for the column. This means that when the `onSortClick` prop will be called when the user presses the header cell. Check out the relevant example in the bottom for more info. |
+| sortIconDirection | oneOf([`asc`, `desc`, `none`]) | - | - | This property defines the current direction of the sorting icon. Pass `asc` to indicate that the data is sorted in an ascending order, `desc` for descending, and `none` if the data is not sorted by the column. |
 | infoTooltipProps | object | - | - | Props object for [tooltip](https://wix-wix-style-react.surge.sh/?selectedKind=7.%20Tooltips&selectedStory=7.1.%20Tooltip&full=0&addons=0&stories=1&panelRight=0). Note: dataHook, moveBy and children will not be passed to tooltip. |
 | align | oneOf(`start`, `center`, `end`) | - | - | The alignment of the column |
 

--- a/src/Table/Table.e2e.js
+++ b/src/Table/Table.e2e.js
@@ -1,7 +1,7 @@
 import eyes from 'eyes.it';
 
 import {tableTestkitFactory, tableActionCellTestkitFactory} from '../../testkit/protractor';
-import {waitForVisibilityOf, scrollToElement} from 'wix-ui-test-utils/protractor';
+import {waitForVisibilityOf, scrollToElement, mouseEnter, mouseLeave} from 'wix-ui-test-utils/protractor';
 import {createStoryUrl} from '../../test/utils/storybook-helpers';
 import {flattenInternalDriver} from '../../test/utils/private-drivers';
 import {storySettings} from '../../stories/Table/storySettings';
@@ -78,6 +78,37 @@ describe('Table', () => {
 
         tableDriver.hoverRow(1);
       });
+    });
+  });
+
+  describe('sorting example', () => {
+    const checkSortingArrow = async (headerCellElement, currentSortingState) => {
+      await mouseEnter(headerCellElement);
+      eyes.checkWindow(`'${currentSortingState}' sorting state hover`);
+
+      headerCellElement.click();
+      eyes.checkWindow(`'${currentSortingState}' sorting state click`);
+
+      await mouseLeave(headerCellElement);
+      eyes.checkWindow(`'${currentSortingState}' sorting state exit`);
+    };
+
+    it('should render correctly', async () => {
+      await init('story-table-sorting-example');
+    });
+
+    it('should cycle through sorting direction', async () => {
+      const driver = await init('story-table-sorting-example');
+      const headerCellElement = driver.getHeaderCell(0);
+
+      // From the initial state (none) to asc
+      await checkSortingArrow(headerCellElement, 'none');
+
+      // From asc to desc
+      await checkSortingArrow(headerCellElement, 'asc');
+
+      // From desc to none
+      await checkSortingArrow(headerCellElement, 'desc');
     });
   });
 });

--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -154,9 +154,11 @@ Table.propTypes = {
     ]).isRequired,
     render: PropTypes.func.isRequired,
     sortable: PropTypes.bool,
+    sortIconDirection: PropTypes.oneOf(['asc', 'desc', 'none']),
     infoTooltipProps: PropTypes.shape(Tooltip.propTypes),
-    sortDescending: PropTypes.bool,
-    align: PropTypes.oneOf(['start', 'center', 'end'])
+    align: PropTypes.oneOf(['start', 'center', 'end']),
+    /** @deprecated */
+    sortDescending: PropTypes.bool
   })).isRequired,
   /** A func that gets row data and returns a class(es) to apply to that specific row */
   dynamicRowClass: PropTypes.func,
@@ -202,6 +204,9 @@ Table.propTypes = {
 
   /** Should the table show the header when data is empty */
   showHeaderWhenEmpty: PropTypes.bool,
+
+  /** A callback function called on each column title click, whose signature is `onSortClick(colData, colNum, nextSortingDirection)`. The `nextSortingDirection` is the desired sorting direction to be set after the user has changed the sorting direction, and its value can be one of the `sortIconDirection` values. */
+  onSortClick: PropTypes.func,
 
   // Table props
 

--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -205,7 +205,7 @@ Table.propTypes = {
   /** Should the table show the header when data is empty */
   showHeaderWhenEmpty: PropTypes.bool,
 
-  /** A callback function called on each column title click, whose signature is `onSortClick(colData, colNum, nextSortingDirection)`. The `nextSortingDirection` is the desired sorting direction to be set after the user has changed the sorting direction, and its value can be one of the `sortIconDirection` values. */
+  /** A callback function called on each sortable column title click, whose signature is `onSortClick(colData, colNum, nextSortingDirection)`. The `nextSortingDirection` is the desired sorting direction to be set after the user has changed the sorting direction, and its value can be one of the `sortIconDirection` values. */
   onSortClick: PropTypes.func,
 
   // Table props

--- a/stories/Table/Table.story.js
+++ b/stories/Table/Table.story.js
@@ -26,6 +26,9 @@ import TableEmptyStateExampleRaw from '!raw-loader!./TableEmptyStateExample';
 import {TableColumnAlignmentExample} from './TableColumnAlignmentExample';
 import TableColumnAlignmentExampleRaw from '!raw-loader!./TableColumnAlignmentExample';
 
+import {TableSortingExample} from './TableSortingExample';
+import TableSortingExampleRaw from '!raw-loader!./TableSortingExample';
+
 const data = [
   {firstName: 'Meghan', lastName: 'Bishop'},
   {firstName: 'Sara', lastName: 'Porter'},
@@ -108,6 +111,11 @@ export default {
         <div className={s.example}>
           <CodeExample title="Table with column alignments" code={TableColumnAlignmentExampleRaw}>
             <TableColumnAlignmentExample/>
+          </CodeExample>
+        </div>
+        <div className={s.example}>
+          <CodeExample title="Table with sorting" code={TableSortingExampleRaw}>
+            <TableSortingExample/>
           </CodeExample>
         </div>
       </div>

--- a/stories/Table/TableSortingExample.js
+++ b/stories/Table/TableSortingExample.js
@@ -1,0 +1,158 @@
+import React from 'react';
+import {Table} from 'wix-style-react/Table';
+import {
+  TableToolbar,
+  ItemGroup,
+  Item,
+  Title
+} from 'wix-style-react/TableToolbar';
+
+import Card from 'wix-style-react/Card';
+
+export class TableSortingExample extends React.Component {
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      sortedColumn: -1,
+      sortingDirection: 'none',
+
+      data: [
+        {name: 'Cyan Towls', visible: false, onSale: false, price: '$145.99'},
+        {name: 'Apple Towels', visible: true, onSale: false, price: '$22.99'},
+        {name: 'Red Slippers', visible: false, onSale: false, price: '$1,265.69'},
+        {name: 'Marble Slippers', visible: false, onSale: false, price: '$125,265.00'}
+      ]
+    };
+  }
+
+  getNextSortingDirection(dir = 'none') {
+    const nextDirs = {
+      none: 'asc',
+      asc: 'desc',
+      desc: 'none'
+    };
+
+    return nextDirs[dir];
+  }
+
+  getSortingProperties(colNum) {
+    const {sortedColumn, sortingDirection} = this.state;
+
+    const isCurentlySorted = sortedColumn === colNum;
+
+    return {
+      sortable: true,
+      sortIconDirection: isCurentlySorted ? sortingDirection : 'none',
+      sortIconDirectionOnHover: isCurentlySorted ? this.getNextSortingDirection(sortingDirection) : this.getNextSortingDirection()
+    };
+  }
+
+  handleSortClick(colNum) {
+    const {sortedColumn, sortingDirection} = this.state;
+
+    const isCurentlySorted = sortedColumn === colNum;
+
+    this.setState({
+      sortedColumn: colNum,
+      sortingDirection: isCurentlySorted ? this.getNextSortingDirection(sortingDirection) : this.getNextSortingDirection()
+    });
+  }
+
+  getSortedData() {
+    const {sortedColumn, sortingDirection, data} = this.state;
+
+    if (sortingDirection === 'none') {
+      return data;
+    }
+
+    const fields = {
+      0: 'name',
+      3: 'price'
+    };
+
+    const fieldToSortBy = fields[sortedColumn];
+    const desc = sortingDirection === 'desc';
+
+    const newData = [...data];
+
+    // Currently comparing strings
+    newData.sort((a, b) => {
+      let res = 0;
+
+      if (a[fieldToSortBy] < b[fieldToSortBy]) {
+        res = -1;
+      } else if (a[fieldToSortBy] > b[fieldToSortBy]) {
+        res = 1;
+      }
+
+      return desc ? res : res * -1;
+    });
+
+    return newData;
+  }
+
+  render() {
+    return (
+      <Card>
+        <Table
+          dataHook="story-table-column-alignment-example"
+          data={this.getSortedData()}
+          itemsPerPage={20}
+          onSortClick={(column, colNum) => this.handleSortClick(colNum)}
+          columns={[
+            {
+              title: 'Name',
+              render: row => <span>{row.name}</span>,
+              width: '30%',
+              minWidth: '150px',
+              ...this.getSortingProperties(0)
+            },
+            {
+              title: 'Visibility',
+              render: row => (
+                <span>{row.visible ? 'Visible' : 'Hidden'}</span>
+              ),
+              width: '20%',
+              minWidth: '100px'
+            },
+            {
+              title: 'On Sale',
+              render: row => (
+                <span>{row.onSale ? 'On sale' : 'Not on sale'}</span>
+              ),
+              width: '20%',
+              minWidth: '100px',
+              infoTooltipProps: {
+                content: 'I am a Tooltip!'
+              }
+            },
+            {
+              title: 'Price',
+              render: row => <span>{row.price}</span>,
+              width: '20%',
+              minWidth: '100px',
+              ...this.getSortingProperties(3)
+            }
+          ]}
+          >
+          <MainToolbar/>
+          <Table.Content/>
+        </Table>
+      </Card>
+    );
+  }
+}
+
+const MainToolbar = () => {
+  return (
+    <TableToolbar>
+      <ItemGroup position="start">
+        <Item>
+          <Title>My Table</Title>
+        </Item>
+      </ItemGroup>
+    </TableToolbar>
+  );
+};

--- a/stories/Table/TableSortingExample.js
+++ b/stories/Table/TableSortingExample.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import sortBy from 'lodash/sortBy';
 import {Table} from 'wix-style-react/Table';
 import {
   TableToolbar,
@@ -15,82 +16,58 @@ export class TableSortingExample extends React.Component {
     super(props);
 
     this.state = {
-      sortedColumn: -1,
+      sortingField: '',
       sortingDirection: 'none',
 
       data: [
-        {name: 'Cyan Towls', visible: false, onSale: false, price: '$145.99'},
-        {name: 'Apple Towels', visible: true, onSale: false, price: '$22.99'},
-        {name: 'Red Slippers', visible: false, onSale: false, price: '$1,265.69'},
-        {name: 'Marble Slippers', visible: false, onSale: false, price: '$125,265.00'}
+        {name: 'Cyan Towls', visible: false, onSale: false, price: 145.99},
+        {name: 'Apple Towels', visible: true, onSale: false, price: 22.99},
+        {name: 'Red Slippers', visible: false, onSale: false, price: 1265.69},
+        {name: 'Marble Slippers', visible: false, onSale: false, price: 125.00}
       ]
     };
   }
 
   getNextSortingDirection(dir = 'none') {
-    const nextDirs = {
-      none: 'asc',
-      asc: 'desc',
-      desc: 'none'
-    };
-
-    return nextDirs[dir];
+    const dirs = ['none', 'asc', 'desc'];
+    return dirs.find((d, i) => i === (dirs.indexOf(dir) + 1) % dirs.length);
   }
 
-  getSortingProperties(colNum) {
-    const {sortedColumn, sortingDirection} = this.state;
+  getSortingProperties(field) {
+    const {sortingField, sortingDirection} = this.state;
 
-    const isCurentlySorted = sortedColumn === colNum;
+    const isCurentlySorted = sortingField === field;
 
     return {
       sortable: true,
+      sortingField: field, // This field is not used by `<Table/>`, but can be accessed on `handleSortClick`
       sortIconDirection: isCurentlySorted ? sortingDirection : 'none',
       sortIconDirectionOnHover: isCurentlySorted ? this.getNextSortingDirection(sortingDirection) : this.getNextSortingDirection()
     };
   }
 
-  handleSortClick(colNum) {
-    const {sortedColumn, sortingDirection} = this.state;
+  handleSortClick(field) {
+    const {sortingField, sortingDirection} = this.state;
 
-    const isCurentlySorted = sortedColumn === colNum;
+    const isCurentlySorted = sortingField === field;
 
     this.setState({
-      sortedColumn: colNum,
+      sortingField: field,
       sortingDirection: isCurentlySorted ? this.getNextSortingDirection(sortingDirection) : this.getNextSortingDirection()
     });
   }
 
   getSortedData() {
-    const {sortedColumn, sortingDirection, data} = this.state;
+    const {sortingField, sortingDirection, data} = this.state;
 
     if (sortingDirection === 'none') {
       return data;
     }
 
-    const fields = {
-      0: 'name',
-      3: 'price'
-    };
-
-    const fieldToSortBy = fields[sortedColumn];
     const desc = sortingDirection === 'desc';
+    const sortedData = sortBy(data, sortingField);
 
-    const newData = [...data];
-
-    // Currently comparing strings
-    newData.sort((a, b) => {
-      let res = 0;
-
-      if (a[fieldToSortBy] < b[fieldToSortBy]) {
-        res = -1;
-      } else if (a[fieldToSortBy] > b[fieldToSortBy]) {
-        res = 1;
-      }
-
-      return desc ? res : res * -1;
-    });
-
-    return newData;
+    return desc ? sortedData : sortedData.reverse();
   }
 
   render() {
@@ -100,14 +77,14 @@ export class TableSortingExample extends React.Component {
           dataHook="story-table-column-alignment-example"
           data={this.getSortedData()}
           itemsPerPage={20}
-          onSortClick={(column, colNum) => this.handleSortClick(colNum)}
+          onSortClick={column => this.handleSortClick(column.sortingField)}
           columns={[
             {
               title: 'Name',
               render: row => <span>{row.name}</span>,
               width: '30%',
               minWidth: '150px',
-              ...this.getSortingProperties(0)
+              ...this.getSortingProperties('name')
             },
             {
               title: 'Visibility',
@@ -130,10 +107,10 @@ export class TableSortingExample extends React.Component {
             },
             {
               title: 'Price',
-              render: row => <span>{row.price}</span>,
+              render: row => <span>{`$${row.price}`}</span>,
               width: '20%',
               minWidth: '100px',
-              ...this.getSortingProperties(3)
+              ...this.getSortingProperties('price')
             }
           ]}
           >

--- a/stories/Table/TableSortingExample.js
+++ b/stories/Table/TableSortingExample.js
@@ -11,61 +11,46 @@ import {
 import Card from 'wix-style-react/Card';
 
 export class TableSortingExample extends React.Component {
+  state = {
+    sortingColumnKey: '',
+    sortingDirection: 'none',
 
-  constructor(props) {
-    super(props);
+    data: [
+      {name: 'Cyan Towls', visible: false, onSale: false, price: 145.99},
+      {name: 'Apple Towels', visible: true, onSale: false, price: 22.99},
+      {name: 'Red Slippers', visible: false, onSale: false, price: 1265.69},
+      {name: 'Marble Slippers', visible: false, onSale: false, price: 125.00}
+    ]
+  };
 
-    this.state = {
-      sortingField: '',
-      sortingDirection: 'none',
+  getSortingProperties = key => {
+    const {sortingColumnKey, sortingDirection} = this.state;
 
-      data: [
-        {name: 'Cyan Towls', visible: false, onSale: false, price: 145.99},
-        {name: 'Apple Towels', visible: true, onSale: false, price: 22.99},
-        {name: 'Red Slippers', visible: false, onSale: false, price: 1265.69},
-        {name: 'Marble Slippers', visible: false, onSale: false, price: 125.00}
-      ]
-    };
-  }
-
-  getNextSortingDirection(dir = 'none') {
-    const dirs = ['none', 'asc', 'desc'];
-    return dirs.find((d, i) => i === (dirs.indexOf(dir) + 1) % dirs.length);
-  }
-
-  getSortingProperties(field) {
-    const {sortingField, sortingDirection} = this.state;
-
-    const isCurentlySorted = sortingField === field;
+    const isCurentlySorted = sortingColumnKey === key;
 
     return {
+      key, // This field is not used by `<Table/>`, but can be accessed on `handleSortClick`
       sortable: true,
-      sortingField: field, // This field is not used by `<Table/>`, but can be accessed on `handleSortClick`
-      sortIconDirection: isCurentlySorted ? sortingDirection : 'none',
-      sortIconDirectionOnHover: isCurentlySorted ? this.getNextSortingDirection(sortingDirection) : this.getNextSortingDirection()
+      sortIconDirection: isCurentlySorted ? sortingDirection : 'none'
     };
   }
 
-  handleSortClick(field) {
-    const {sortingField, sortingDirection} = this.state;
-
-    const isCurentlySorted = sortingField === field;
-
+  handleSortChange = (column, colNum, nextSortingDirection) => {
     this.setState({
-      sortingField: field,
-      sortingDirection: isCurentlySorted ? this.getNextSortingDirection(sortingDirection) : this.getNextSortingDirection()
+      sortingColumnKey: column.key,
+      sortingDirection: nextSortingDirection
     });
   }
 
-  getSortedData() {
-    const {sortingField, sortingDirection, data} = this.state;
+  getSortedData = () => {
+    const {sortingColumnKey, sortingDirection, data} = this.state;
 
     if (sortingDirection === 'none') {
       return data;
     }
 
     const desc = sortingDirection === 'desc';
-    const sortedData = sortBy(data, sortingField);
+    const sortedData = sortBy(data, sortingColumnKey);
 
     return desc ? sortedData : sortedData.reverse();
   }
@@ -74,10 +59,10 @@ export class TableSortingExample extends React.Component {
     return (
       <Card>
         <Table
-          dataHook="story-table-column-alignment-example"
+          dataHook="story-table-sorting-example"
           data={this.getSortedData()}
           itemsPerPage={20}
-          onSortClick={column => this.handleSortClick(column.sortingField)}
+          onSortClick={this.handleSortChange}
           columns={[
             {
               title: 'Name',


### PR DESCRIPTION
Continued from https://github.com/wix/wix-style-react/pull/2433.

### What changed

This PR continues from the changes made in https://github.com/wix/wix-style-react/pull/2433.

* Removed the the `sortIconDirectionOnHover` prop. From now on, the `<DataTable/>` will determine the next direction itself.
* The next suggested sorting direction will be passed in the `onSortClick ` callback.
* Streamlined the sorting example in the `<Table/>` story.

### Todos

- [ ] Add e2e tests (mainly for the hover behaviour)
- [ ] Document Document Document!
