### PR TITLE
test storybook 4.1.0-alpha.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,8 +72,8 @@
   "homepage": "https://github.com/wix/wix-style-react#readme",
   "devDependencies": {
     "@storybook/addon-links": "^3.4.10",
-    "@storybook/addon-options": "4.0.0-alpha.14",
-    "@storybook/react": "4.0.0-alpha.14",
+    "@storybook/addon-options": "4.1.0-alpha.8",
+    "@storybook/react": "4.1.0-alpha.8",
     "@stylable/dom-test-kit": "^0.1.0",
     "@types/react": "^15.5.4",
     "autosuggest-highlight": "^3.1.0",


### PR DESCRIPTION
### What changed

Update storybook version that should support react 15.

### Why it changed

After storybook version was pinned in wsr to - https://github.com/wix/yoshi/commit/0338873c49b3cb2ef2f53460307cbe9bc02e2039

They've released a new version that will attempt to support all versions of react. We're opening this PR to see whether it will work for us.

### context
https://github.com/storybooks/storybook/issues/4191#issuecomment-441388216

---

- [ ] Build is green
