### PR TITLE
<Dropdown/>: Controlled when selectedId and onSelect are passed

### DIFF
--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -67,11 +67,20 @@ class Dropdown extends InputWithOptions {
     return { readOnly: true, value: this.state.value };
   }
 
+  _isControlled() {
+    return (
+      typeof this.props.selectedId !== 'undefined' &&
+      typeof this.props.onSelect !== 'undefined'
+    );
+  }
+
   _onSelect(option) {
-    this.setState({
-      value: this.props.valueParser(option),
-      selectedId: option.id,
-    });
+    if (!this._isControlled()) {
+      this.setState({
+        value: this.props.valueParser(option),
+        selectedId: option.id,
+      });
+    }
     super._onSelect(option);
   }
 }

--- a/src/Dropdown/Dropdown.spec.js
+++ b/src/Dropdown/Dropdown.spec.js
@@ -32,6 +32,20 @@ describe('Dropdown', () => {
     expect(inputDriver.getValue()).toBe('Option 1');
   });
 
+  it('should not set item value when controlled', () => {
+    const onSelect = jest.fn();
+    const { driver, inputDriver, dropdownLayoutDriver } = createDriver(
+      <Dropdown options={getOptions()} selectedId={0} onSelect={onSelect} />
+    );
+
+    driver.focus();
+    dropdownLayoutDriver.clickAtOption(1);
+
+    expect(onSelect).toBeCalledWith(getOptions()[1]);
+    expect(dropdownLayoutDriver.isOptionSelected(1)).toBeFalsy();
+    expect(inputDriver.getValue()).not.toBe('Option 2');
+  });
+
   it('should select an item when clicked', () => {
     const { driver, dropdownLayoutDriver } = createDriver(
       <Dropdown options={getOptions()} />,

--- a/src/Dropdown/README.md
+++ b/src/Dropdown/README.md
@@ -7,6 +7,8 @@
 > See API tab.
 > API tab may not be complete. Props should include all props of `InputWithOptions`, which includes all props of `Input` and `DropdownLayout`.
 
+> Similar to `DropdownLayout` When both `selectedId` and `onSelect` are passed, `Dropdown` will be Controlled 
+
 ## Option (an item in the `options` prop)
 
 | propName | propType | defaultValue | isRequired | description |

--- a/stories/components/Dropdown/ExampleControlled.js
+++ b/stories/components/Dropdown/ExampleControlled.js
@@ -22,10 +22,15 @@ class ControlledDropdown extends React.Component {
   constructor(props) {
     super(props);
     this.onSelect = this.onSelect.bind(this);
+    this.state = {
+      selectedId: 1
+    };
   }
 
   onSelect(option) {
-    console.log(`Option ${JSON.stringify(option)} selected`);
+    if (confirm(`Do you want to select ${option.value}`)) {
+      this.setState({ selectedId: option.id });
+    }
   }
 
   render() {
@@ -35,6 +40,7 @@ class ControlledDropdown extends React.Component {
         options={options}
         onSelect={this.onSelect}
         placeholder={'Choose an option'}
+        selectedId={this.state.selectedId}
       />
     );
   }


### PR DESCRIPTION
### What changed

- Updated <Dropdown/> controlled example
- Changed <Dropdown/> not to change local state when is controlled
- Updated <Dropdown/> readme to include this information
- Added a relevant test for <Dropdown/>

### Why it changed

- It is a requirement in Price Quotes Web, to prompt user before changing the dropdown value

---

- [x] Change is tested
- [x] Change is documented
- [ ] Build is green
- [x] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
