### PR TITLE
FIX. Google maps places method  getPlacePredictions() api has changed for countryCode

### DIFF
--- a/src/GoogleAddressInput/GoogleAddressInput.js
+++ b/src/GoogleAddressInput/GoogleAddressInput.js
@@ -257,7 +257,7 @@ class GoogleAddressInput extends React.Component {
 
         const request = {
           types,
-          components: 'country:' + countryCode,
+          componentRestrictions: { country: countryCode },
           input: valuePrefix + value,
         };
 

--- a/src/GoogleAddressInput/GoogleAddressInput.spec.js
+++ b/src/GoogleAddressInput/GoogleAddressInput.spec.js
@@ -230,7 +230,6 @@ describe('GoogleAddressInput', () => {
 
       await eventually(() => {
         component.update();
-        console.warn(component.find('InputWithOptions').props().options);
         expect(component.find('InputWithOptions').props().options).toEqual([
           {
             id: 0,

--- a/src/GoogleAddressInput/GoogleAddressInput.spec.js
+++ b/src/GoogleAddressInput/GoogleAddressInput.spec.js
@@ -230,14 +230,17 @@ describe('GoogleAddressInput', () => {
 
       await eventually(() => {
         component.update();
+        console.warn(component.find('InputWithOptions').props().options);
         expect(component.find('InputWithOptions').props().options).toEqual([
           {
             id: 0,
-            value: '{"components":"country:XX","input":"Hatomer 49"} - 1',
+            value:
+              '{"componentRestrictions":{"country":"XX"},"input":"Hatomer 49"} - 1',
           },
           {
             id: 1,
-            value: '{"components":"country:XX","input":"Hatomer 49"} - 2',
+            value:
+              '{"componentRestrictions":{"country":"XX"},"input":"Hatomer 49"} - 2',
           },
         ]);
       });


### PR DESCRIPTION
This PR fixes prop 'countryCode'. Which should restrict by countryCode autocomplete output. Looks like google maps api has changed in a way how this should be passed.