### PR TITLE
`<MultiSelect/>` (New API) - `onSelect` receives original option excluding `valur` prop

### DIFF
--- a/src/MultiSelect/MultiSelect.js
+++ b/src/MultiSelect/MultiSelect.js
@@ -5,6 +5,8 @@ import InputWithTags from './InputWithTags';
 import last from 'lodash/last';
 import difference from 'difference';
 import uniqueId from 'lodash/uniqueId';
+import { validatorWithSideEffect } from '../utils/propTypes';
+import deprecationLog from '../utils/deprecationLog';
 
 class MultiSelect extends InputWithOptions {
   constructor(props) {
@@ -180,8 +182,11 @@ class MultiSelect extends InputWithOptions {
       return;
     }
 
-    if (this.props.onManuallyInput) {
-      this.props.onManuallyInput(
+    const { onManuallyInput, onTagsAdded } = this.props;
+    if (onTagsAdded) {
+      onTagsAdded([inputValue]);
+    } else if (onManuallyInput) {
+      onManuallyInput(
         inputValue,
         this.optionToTag({ id: uniqueId('customOption_'), value: inputValue }),
       );
@@ -208,6 +213,16 @@ MultiSelect.propTypes = {
   error: PropTypes.bool,
   errorMessage: PropTypes.string,
   onReorder: PropTypes.func,
+  /** A callback which is called when the user performs a Submit action.
+   * Submit action triggers are: "Enter", "Tab", [typing any defined delimiters], Paste action.
+   * The callback receives one argument which is an array of strings, which are the result of splitting the input value by the given delimiters */
+  onTagsAdded: validatorWithSideEffect(PropTypes.func, (props, propName) => {
+    if (props[propName] && props['onManuallyInput']) {
+      deprecationLog(
+        `When 'onTagsAdded' is passed then 'isManuallyInput' will not be called. Please remove the 'isManuallyInput' prop.`,
+      );
+    }
+  }),
 };
 
 MultiSelect.defaultProps = {

--- a/src/MultiSelect/MultiSelect.js
+++ b/src/MultiSelect/MultiSelect.js
@@ -131,7 +131,7 @@ class MultiSelect extends InputWithOptions {
         this.hideOptions();
       }
 
-      this.onManuallyInput(inputValue);
+      this.submitValue(inputValue);
     }
     this.clearInput();
   }
@@ -176,7 +176,7 @@ class MultiSelect extends InputWithOptions {
     this.input.focus();
   }
 
-  onManuallyInput(inputValue) {
+  submitValue(inputValue) {
     if (!inputValue) {
       this.input.blur();
       return;

--- a/src/MultiSelect/MultiSelect.js
+++ b/src/MultiSelect/MultiSelect.js
@@ -27,8 +27,10 @@ class MultiSelect extends InputWithOptions {
 
   onClickOutside() {
     const { value, options, onSelect } = this.props;
-    if (!options.length && value) {
-      onSelect([{ id: value.trim(), label: value.trim() }]);
+    if (!this._isNewCallbackApi()) {
+      if (!options.length && value) {
+        onSelect([{ id: value.trim(), label: value.trim() }]);
+      }
     }
     if (this.state.showOptions) {
       this.hideOptions();

--- a/src/MultiSelect/MultiSelect.js
+++ b/src/MultiSelect/MultiSelect.js
@@ -121,8 +121,12 @@ class MultiSelect extends InputWithOptions {
   }
 
   _onManuallyInput(inputValue) {
-    const { value, options } = this.props;
+    if (this._isNewCallbackApi()) {
+      this._onManuallyInputNewApi(inputValue);
+      return;
+    }
 
+    const { value, options } = this.props;
     if (value && value.trim()) {
       if (options.length) {
         const unselectedOptions = this.getUnselectedOptions();
@@ -146,6 +150,17 @@ class MultiSelect extends InputWithOptions {
       this.submitValue(inputValue);
     }
     this.clearInput();
+  }
+
+  _onManuallyInputNewApi(inputValue) {
+    const { value } = this.props;
+    const _value = (value && value.trim()) || (inputValue && inputValue.trim());
+
+    this.submitValue(_value);
+
+    if (this.closeOnSelect()) {
+      this.hideOptions();
+    }
   }
 
   getManualSubmitKeys() {
@@ -196,7 +211,8 @@ class MultiSelect extends InputWithOptions {
 
     const { onManuallyInput, onTagsAdded } = this.props;
     if (this._isNewCallbackApi()) {
-      onTagsAdded && onTagsAdded(this._splitValues(inputValue));
+      const values = this._splitValues(inputValue);
+      onTagsAdded && values.length && onTagsAdded(values);
     } else if (onManuallyInput) {
       onManuallyInput(
         inputValue,

--- a/src/MultiSelect/MultiSelect.js
+++ b/src/MultiSelect/MultiSelect.js
@@ -194,12 +194,23 @@ class MultiSelect extends InputWithOptions {
     return tag ? { id, ...tag } : { id, label: value, theme };
   }
 
-  onSelect(options) {
+  onSelect(_options) {
     this.clearInput();
 
-    if (this.props.onSelect) {
-      options = options.map(this.optionToTag);
-      this.props.onSelect(options);
+    const { onSelect } = this.props;
+
+    if (onSelect) {
+      if (this._isNewCallbackApi()) {
+        onSelect(
+          _options.map(op => {
+            const { value: _ignore, ...rest } = op;
+            return rest;
+          }),
+        );
+      } else {
+        const tags = _options.map(this.optionToTag);
+        onSelect(tags);
+      }
     }
 
     this.input.focus();

--- a/src/MultiSelect/MultiSelect.js
+++ b/src/MultiSelect/MultiSelect.js
@@ -196,7 +196,7 @@ class MultiSelect extends InputWithOptions {
 
     const { onManuallyInput, onTagsAdded } = this.props;
     if (this._isNewCallbackApi()) {
-      onTagsAdded && onTagsAdded([inputValue]);
+      onTagsAdded && onTagsAdded(this._splitValues(inputValue));
     } else if (onManuallyInput) {
       onManuallyInput(
         inputValue,

--- a/src/MultiSelect/MultiSelect.js
+++ b/src/MultiSelect/MultiSelect.js
@@ -72,10 +72,7 @@ class MultiSelect extends InputWithOptions {
   }
 
   _onChange(event) {
-    if (!this.state.pasteDetected) {
-      this.setState({ inputValue: event.target.value });
-      this.props.onChange && this.props.onChange(event);
-    } else {
+    if (this.state.pasteDetected) {
       const delimitersRegexp = new RegExp(this.props.delimiters.join('|'), 'g');
       const value = event.target.value.replace(delimitersRegexp, ',');
       const tags = value
@@ -97,6 +94,9 @@ class MultiSelect extends InputWithOptions {
       });
 
       this.onSelect(suggestedOptions);
+    } else {
+      this.setState({ inputValue: event.target.value });
+      this.props.onChange && this.props.onChange(event);
     }
     // If the input value is not empty, should show the options
     if (event.target.value.trim()) {

--- a/src/MultiSelect/MultiSelect.spec.js
+++ b/src/MultiSelect/MultiSelect.spec.js
@@ -8,6 +8,8 @@ import { mount } from 'enzyme';
 import { createRendererWithDriver, cleanup } from '../../test/utils/unit';
 import { depLogger } from '../utils/deprecationLog';
 
+const noop = () => {};
+
 describe('MultiSelect', () => {
   const render = createRendererWithDriver(multiSelectDriverFactory);
   const createDriver = jsx => render(jsx).driver;
@@ -348,7 +350,7 @@ describe('MultiSelect', () => {
     });
   });
 
-  describe('onTagsAdded', () => {
+  describe('new API', () => {
     class ControlledMultiSelect extends React.Component {
       state = { inputValue: '' };
 
@@ -364,166 +366,217 @@ describe('MultiSelect', () => {
         );
       }
     }
-    it('should have deprecationLog when onManuallyInput is also passed', () => {
-      const depLogSpy = jest.spyOn(depLogger, 'log');
-      render(
-        <MultiSelect
-          options={options}
-          onManuallyInput={() => {}}
-          onTagsAdded={() => {}}
-        />,
-      );
-      expect(depLogSpy).toBeCalledWith(
-        `When 'onTagsAdded' is passed then 'isManuallyInput' will not be called. Please remove the 'isManuallyInput' prop.`,
-      );
-      depLogSpy.mockRestore();
-    });
 
-    describe('type&submit', () => {
-      describe('input is empty', () => {
-        it('should not be called when Enter is pressed', () => {
-          const onManuallyInput = jest.fn();
-          const onTagsAdded = jest.fn();
-          const { driver } = createDriver(
-            <ControlledMultiSelect
-              options={options}
-              onManuallyInput={onManuallyInput}
-              onTagsAdded={onTagsAdded}
-            />,
-          );
+    describe('onTagsAdded', () => {
+      it('should have deprecationLog when onManuallyInput is also passed', () => {
+        const depLogSpy = jest.spyOn(depLogger, 'log');
+        render(
+          <MultiSelect
+            options={options}
+            onManuallyInput={() => {}}
+            onTagsAdded={() => {}}
+          />,
+        );
+        expect(depLogSpy).toBeCalledWith(
+          `When 'onTagsAdded' is passed then 'isManuallyInput' will not be called. Please remove the 'isManuallyInput' prop.`,
+        );
+        depLogSpy.mockRestore();
+      });
 
-          driver.focus();
-          driver.pressKey('Enter');
+      describe('type&submit', () => {
+        describe('input is empty', () => {
+          it('should not be called when Enter is pressed', () => {
+            const onManuallyInput = jest.fn();
+            const onTagsAdded = jest.fn();
+            const { driver } = createDriver(
+              <ControlledMultiSelect
+                options={options}
+                onManuallyInput={onManuallyInput}
+                onTagsAdded={onTagsAdded}
+              />,
+            );
 
-          expect(onManuallyInput).toHaveBeenCalledTimes(0);
-          expect(onTagsAdded).toHaveBeenCalledTimes(0);
+            driver.focus();
+            driver.pressKey('Enter');
+
+            expect(onManuallyInput).toHaveBeenCalledTimes(0);
+            expect(onTagsAdded).toHaveBeenCalledTimes(0);
+          });
+        });
+
+        describe('input is not empty', () => {
+          function testCase({
+            props,
+            keyPressed,
+            enteredText = 'custom value',
+            Component = MultiSelect,
+            expectOnTagsAddedToBeCalled = true,
+          }) {
+            const onManuallyInput = jest.fn();
+            const onSelect = jest.fn();
+            const onTagsAdded = jest.fn();
+            const { driver, inputDriver } = createDriver(
+              <Component
+                onManuallyInput={onManuallyInput}
+                onTagsAdded={onTagsAdded}
+                onSelect={onSelect}
+                {...props}
+              />,
+            );
+
+            driver.focus();
+            inputDriver.enterText(enteredText);
+            driver.pressKey(keyPressed);
+
+            expect(onManuallyInput).toHaveBeenCalledTimes(0);
+            expect(onSelect).toHaveBeenCalledTimes(0);
+            expect(onTagsAdded).toHaveBeenCalledTimes(
+              expectOnTagsAddedToBeCalled ? 1 : 0,
+            );
+            expectOnTagsAddedToBeCalled &&
+              expect(onTagsAdded).toBeCalledWith([enteredText]);
+          }
+
+          it('should be called when Enter is pressed', () => {
+            testCase({ props: { options }, keyPressed: 'Enter' });
+          });
+
+          it('should be called when Enter is pressed given ControlledMultiSelect', () => {
+            testCase({
+              props: { options },
+              keyPressed: 'Enter',
+              Component: ControlledMultiSelect,
+            });
+          });
+
+          it('should be called when delimiter is pressed', () => {
+            testCase({ props: { options }, keyPressed: ',' });
+          });
+
+          it('should be called when delimiter is pressed given no options', () => {
+            testCase({ props: {}, keyPressed: ',' });
+          });
+
+          it('should NOT be called when Enter pressed given enteredText is spaces only', () => {
+            testCase({
+              props: { options },
+              enteredText: '   ',
+              keyPressed: 'Enter',
+              expectOnTagsAddedToBeCalled: false,
+            });
+          });
+
+          it('should NOT be called when Enter pressed given enteredText is delimited spaces only', () => {
+            testCase({
+              props: { options },
+              enteredText: ' ,  ',
+              keyPressed: 'Enter',
+              expectOnTagsAddedToBeCalled: false,
+            });
+          });
         });
       });
 
-      describe('input is not empty', () => {
-        function testCase({
-          props,
-          keyPressed,
-          enteredText = 'custom value',
-          Component = MultiSelect,
-          expectOnTagsAddedToBeCalled = true,
-        }) {
+      describe('Paste', () => {
+        function testCase({ props, pasteValue, expectedOnTagsAddedArg }) {
           const onManuallyInput = jest.fn();
           const onSelect = jest.fn();
           const onTagsAdded = jest.fn();
           const { driver, inputDriver } = createDriver(
-            <Component
-              onManuallyInput={onManuallyInput}
-              onTagsAdded={onTagsAdded}
+            <MultiSelect
+              options={options}
               onSelect={onSelect}
+              onTagsAdded={onTagsAdded}
+              onManuallyInput={onManuallyInput}
               {...props}
             />,
           );
-
           driver.focus();
-          inputDriver.enterText(enteredText);
-          driver.pressKey(keyPressed);
+          inputDriver.trigger('paste');
+          inputDriver.enterText(pasteValue);
 
           expect(onManuallyInput).toHaveBeenCalledTimes(0);
           expect(onSelect).toHaveBeenCalledTimes(0);
-          expect(onTagsAdded).toHaveBeenCalledTimes(
-            expectOnTagsAddedToBeCalled ? 1 : 0,
-          );
-          expectOnTagsAddedToBeCalled &&
-            expect(onTagsAdded).toBeCalledWith([enteredText]);
+          expect(onTagsAdded).toHaveBeenCalledTimes(1);
+          expect(onTagsAdded).toBeCalledWith(expectedOnTagsAddedArg);
         }
 
-        it('should be called when Enter is pressed', () => {
-          testCase({ props: { options }, keyPressed: 'Enter' });
-        });
-
-        it('should be called when Enter is pressed given ControlledMultiSelect', () => {
+        it('should be called with single value when pasting a single custom value', () => {
           testCase({
-            props: { options },
-            keyPressed: 'Enter',
-            Component: ControlledMultiSelect,
+            pasteValue: 'custom value',
+            expectedOnTagsAddedArg: ['custom value'],
           });
         });
 
-        it('should be called when delimiter is pressed', () => {
-          testCase({ props: { options }, keyPressed: ',' });
-        });
-
-        it('should be called when delimiter is pressed given no options', () => {
-          testCase({ props: {}, keyPressed: ',' });
-        });
-
-        it('should NOT be called when Enter pressed given enteredText is spaces only', () => {
+        it('should be called with multiple values with pasting comma-delimited value (default delimiter)', () => {
           testCase({
-            props: { options },
-            enteredText: '   ',
-            keyPressed: 'Enter',
-            expectOnTagsAddedToBeCalled: false,
+            pasteValue: 'value1,value2',
+            expectedOnTagsAddedArg: ['value1', 'value2'],
           });
         });
 
-        it('should NOT be called when Enter pressed given enteredText is delimited spaces only', () => {
+        it('should be called with multiple values with pasting colun-delimited value (custom delimiter)', () => {
           testCase({
-            props: { options },
-            enteredText: ' ,  ',
-            keyPressed: 'Enter',
-            expectOnTagsAddedToBeCalled: false,
+            props: { delimiters: [':'] },
+            pasteValue: 'value1:value2',
+            expectedOnTagsAddedArg: ['value1', 'value2'],
+          });
+        });
+
+        it('should be called with trimmed values', () => {
+          testCase({
+            pasteValue: ' value1 , value2 ',
+            expectedOnTagsAddedArg: ['value1', 'value2'],
           });
         });
       });
     });
 
-    describe('Paste', () => {
-      function testCase({ props, pasteValue, expectedOnTagsAddedArg }) {
-        const onManuallyInput = jest.fn();
+    describe('onSelect', () => {
+      it('should be called when option clicked', () => {
         const onSelect = jest.fn();
-        const onTagsAdded = jest.fn();
-        const { driver, inputDriver } = createDriver(
+
+        const { driver, dropdownLayoutDriver } = createDriver(
           <MultiSelect
             options={options}
             onSelect={onSelect}
-            onTagsAdded={onTagsAdded}
-            onManuallyInput={onManuallyInput}
-            {...props}
+            onTagsAdded={noop}
           />,
         );
-        driver.focus();
-        inputDriver.trigger('paste');
-        inputDriver.enterText(pasteValue);
+        driver.pressKey('ArrowDown');
+        dropdownLayoutDriver.clickAtOption(0);
 
-        expect(onManuallyInput).toHaveBeenCalledTimes(0);
+        expect(onSelect).toHaveBeenCalledTimes(1);
+        // TODO: add expect(onSelect).toBeCalledWith(...)
+      });
+
+      it('should be called when option is selected by keyboard', () => {
+        const onSelect = jest.fn();
+
+        const { driver } = createDriver(
+          <MultiSelect
+            options={options}
+            onSelect={onSelect}
+            onTagsAdded={noop}
+          />,
+        );
+        driver.pressKey('ArrowDown');
+        driver.pressKey('ArrowDown');
+        driver.pressKey('Enter');
+
+        expect(onSelect).toHaveBeenCalledTimes(1);
+        // TODO: add expect(onSelect).toBeCalledWith(...)
+      });
+
+      it('should NOT be called when clicked-out-side', () => {
+        const onSelect = jest.fn();
+
+        const { driver, inputDriver } = createDriver(
+          <ControlledMultiSelect onSelect={onSelect} onTagsAdded={noop} />,
+        );
+        inputDriver.enterText('foo');
+        driver.outsideClick();
         expect(onSelect).toHaveBeenCalledTimes(0);
-        expect(onTagsAdded).toHaveBeenCalledTimes(1);
-        expect(onTagsAdded).toBeCalledWith(expectedOnTagsAddedArg);
-      }
-
-      it('should be called with single value when pasting a single custom value', () => {
-        testCase({
-          pasteValue: 'custom value',
-          expectedOnTagsAddedArg: ['custom value'],
-        });
-      });
-
-      it('should be called with multiple values with pasting comma-delimited value (default delimiter)', () => {
-        testCase({
-          pasteValue: 'value1,value2',
-          expectedOnTagsAddedArg: ['value1', 'value2'],
-        });
-      });
-
-      it('should be called with multiple values with pasting colun-delimited value (custom delimiter)', () => {
-        testCase({
-          props: { delimiters: [':'] },
-          pasteValue: 'value1:value2',
-          expectedOnTagsAddedArg: ['value1', 'value2'],
-        });
-      });
-
-      it('should be called with trimmed values', () => {
-        testCase({
-          pasteValue: ' value1 , value2 ',
-          expectedOnTagsAddedArg: ['value1', 'value2'],
-        });
       });
     });
   });

--- a/src/MultiSelect/MultiSelect.spec.js
+++ b/src/MultiSelect/MultiSelect.spec.js
@@ -424,7 +424,7 @@ describe('MultiSelect', () => {
     });
 
     describe('Paste', () => {
-      it('should support pasting single custom value', () => {
+      function testCase({ props, pasteValue, expectedOnTagsAddedArg }) {
         const onManuallyInput = jest.fn();
         const onSelect = jest.fn();
         const onTagsAdded = jest.fn();
@@ -434,16 +434,46 @@ describe('MultiSelect', () => {
             onSelect={onSelect}
             onTagsAdded={onTagsAdded}
             onManuallyInput={onManuallyInput}
+            {...props}
           />,
         );
         driver.focus();
         inputDriver.trigger('paste');
-        inputDriver.enterText('custom value');
+        inputDriver.enterText(pasteValue);
 
         expect(onManuallyInput).toHaveBeenCalledTimes(0);
         expect(onSelect).toHaveBeenCalledTimes(0);
         expect(onTagsAdded).toHaveBeenCalledTimes(1);
-        expect(onTagsAdded).toBeCalledWith(['custom value']);
+        expect(onTagsAdded).toBeCalledWith(expectedOnTagsAddedArg);
+      }
+
+      it('should be called with single value when pasting a single custom value', () => {
+        testCase({
+          pasteValue: 'custom value',
+          expectedOnTagsAddedArg: ['custom value'],
+        });
+      });
+
+      it('should be called with multiple values with pasting comma-delimited value (default delimiter)', () => {
+        testCase({
+          pasteValue: 'value1,value2',
+          expectedOnTagsAddedArg: ['value1', 'value2'],
+        });
+      });
+
+      it('should be called with multiple values with pasting colun-delimited value (custom delimiter)', () => {
+        testCase({
+          props: { delimiters: [':'] },
+          pasteValue: 'value1:value2',
+          expectedOnTagsAddedArg: ['value1', 'value2'],
+        });
+      });
+
+      it('should be called with trimmed values', () => {
+        testCase({
+          pasteValue: ' value1 , value2 ',
+          expectedOnTagsAddedArg: ['value1', 'value2'],
+        });
       });
     });
   });

--- a/src/MultiSelect/MultiSelect.spec.js
+++ b/src/MultiSelect/MultiSelect.spec.js
@@ -364,60 +364,86 @@ describe('MultiSelect', () => {
       depLogSpy.mockRestore();
     });
 
-    describe('input is empty', () => {
-      it('should not be called when Enter is pressed', () => {
-        const onManuallyInput = jest.fn();
-        const onTagsAdded = jest.fn();
-        const { driver } = createDriver(
-          <MultiSelect
-            options={options}
-            onManuallyInput={onManuallyInput}
-            onTagsAdded={onTagsAdded}
-          />,
-        );
+    describe('type&submit', () => {
+      describe('input is empty', () => {
+        it('should not be called when Enter is pressed', () => {
+          const onManuallyInput = jest.fn();
+          const onTagsAdded = jest.fn();
+          const { driver } = createDriver(
+            <MultiSelect
+              options={options}
+              onManuallyInput={onManuallyInput}
+              onTagsAdded={onTagsAdded}
+            />,
+          );
 
-        driver.focus();
-        driver.pressKey('Enter');
+          driver.focus();
+          driver.pressKey('Enter');
 
-        expect(onManuallyInput).toHaveBeenCalledTimes(0);
-        expect(onTagsAdded).toHaveBeenCalledTimes(0);
+          expect(onManuallyInput).toHaveBeenCalledTimes(0);
+          expect(onTagsAdded).toHaveBeenCalledTimes(0);
+        });
+      });
+
+      describe('input is not empty', () => {
+        function testCase({ props, keyPressed }) {
+          const onManuallyInput = jest.fn();
+          const onSelect = jest.fn();
+          const onTagsAdded = jest.fn();
+          const { driver, inputDriver } = createDriver(
+            <MultiSelect
+              onManuallyInput={onManuallyInput}
+              onTagsAdded={onTagsAdded}
+              onSelect={onSelect}
+              {...props}
+            />,
+          );
+
+          driver.focus();
+          inputDriver.enterText('custom value');
+          driver.pressKey(keyPressed);
+
+          expect(onManuallyInput).toHaveBeenCalledTimes(0);
+          expect(onSelect).toHaveBeenCalledTimes(0);
+          expect(onTagsAdded).toHaveBeenCalledTimes(1);
+          expect(onTagsAdded).toBeCalledWith(['custom value']);
+        }
+
+        it('should be called when Enter is pressed', () => {
+          testCase({ props: { options }, keyPressed: 'Enter' });
+        });
+
+        it('should be called when delimiter is pressed', () => {
+          testCase({ props: { options }, keyPressed: ',' });
+        });
+
+        it('should be called when delimiter is pressed given no options', () => {
+          testCase({ props: {}, keyPressed: ',' });
+        });
       });
     });
 
-    describe('input is not empty', () => {
-      function testCase({ props, keyPressed }) {
+    describe('Paste', () => {
+      it('should support pasting single custom value', () => {
         const onManuallyInput = jest.fn();
         const onSelect = jest.fn();
         const onTagsAdded = jest.fn();
         const { driver, inputDriver } = createDriver(
           <MultiSelect
-            onManuallyInput={onManuallyInput}
-            onTagsAdded={onTagsAdded}
+            options={options}
             onSelect={onSelect}
-            {...props}
+            onTagsAdded={onTagsAdded}
+            onManuallyInput={onManuallyInput}
           />,
         );
-
         driver.focus();
+        inputDriver.trigger('paste');
         inputDriver.enterText('custom value');
-        driver.pressKey(keyPressed);
 
         expect(onManuallyInput).toHaveBeenCalledTimes(0);
         expect(onSelect).toHaveBeenCalledTimes(0);
         expect(onTagsAdded).toHaveBeenCalledTimes(1);
         expect(onTagsAdded).toBeCalledWith(['custom value']);
-      }
-
-      it('should be called when Enter is pressed', () => {
-        testCase({ props: { options }, keyPressed: 'Enter' });
-      });
-
-      it('should be called when delimiter is pressed', () => {
-        testCase({ props: { options }, keyPressed: ',' });
-      });
-
-      it('should be called when delimiter is pressed given no options', () => {
-        testCase({ props: {}, keyPressed: ',' });
       });
     });
   });

--- a/src/MultiSelect/MultiSelect.spec.js
+++ b/src/MultiSelect/MultiSelect.spec.js
@@ -349,6 +349,21 @@ describe('MultiSelect', () => {
   });
 
   describe('onTagsAdded', () => {
+    class ControlledMultiSelect extends React.Component {
+      state = { inputValue: '' };
+
+      render() {
+        return (
+          <MultiSelect
+            {...this.props}
+            onChange={e => {
+              this.setState({ inputValue: e.target.value });
+            }}
+            value={this.state.inputValue}
+          />
+        );
+      }
+    }
     it('should have deprecationLog when onManuallyInput is also passed', () => {
       const depLogSpy = jest.spyOn(depLogger, 'log');
       render(
@@ -370,7 +385,7 @@ describe('MultiSelect', () => {
           const onManuallyInput = jest.fn();
           const onTagsAdded = jest.fn();
           const { driver } = createDriver(
-            <MultiSelect
+            <ControlledMultiSelect
               options={options}
               onManuallyInput={onManuallyInput}
               onTagsAdded={onTagsAdded}
@@ -386,12 +401,18 @@ describe('MultiSelect', () => {
       });
 
       describe('input is not empty', () => {
-        function testCase({ props, keyPressed }) {
+        function testCase({
+          props,
+          keyPressed,
+          enteredText = 'custom value',
+          Component = MultiSelect,
+          expectOnTagsAddedToBeCalled = true,
+        }) {
           const onManuallyInput = jest.fn();
           const onSelect = jest.fn();
           const onTagsAdded = jest.fn();
           const { driver, inputDriver } = createDriver(
-            <MultiSelect
+            <Component
               onManuallyInput={onManuallyInput}
               onTagsAdded={onTagsAdded}
               onSelect={onSelect}
@@ -400,17 +421,28 @@ describe('MultiSelect', () => {
           );
 
           driver.focus();
-          inputDriver.enterText('custom value');
+          inputDriver.enterText(enteredText);
           driver.pressKey(keyPressed);
 
           expect(onManuallyInput).toHaveBeenCalledTimes(0);
           expect(onSelect).toHaveBeenCalledTimes(0);
-          expect(onTagsAdded).toHaveBeenCalledTimes(1);
-          expect(onTagsAdded).toBeCalledWith(['custom value']);
+          expect(onTagsAdded).toHaveBeenCalledTimes(
+            expectOnTagsAddedToBeCalled ? 1 : 0,
+          );
+          expectOnTagsAddedToBeCalled &&
+            expect(onTagsAdded).toBeCalledWith([enteredText]);
         }
 
         it('should be called when Enter is pressed', () => {
           testCase({ props: { options }, keyPressed: 'Enter' });
+        });
+
+        it('should be called when Enter is pressed given ControlledMultiSelect', () => {
+          testCase({
+            props: { options },
+            keyPressed: 'Enter',
+            Component: ControlledMultiSelect,
+          });
         });
 
         it('should be called when delimiter is pressed', () => {
@@ -419,6 +451,24 @@ describe('MultiSelect', () => {
 
         it('should be called when delimiter is pressed given no options', () => {
           testCase({ props: {}, keyPressed: ',' });
+        });
+
+        it('should NOT be called when Enter pressed given enteredText is spaces only', () => {
+          testCase({
+            props: { options },
+            enteredText: '   ',
+            keyPressed: 'Enter',
+            expectOnTagsAddedToBeCalled: false,
+          });
+        });
+
+        it('should NOT be called when Enter pressed given enteredText is delimited spaces only', () => {
+          testCase({
+            props: { options },
+            enteredText: ' ,  ',
+            keyPressed: 'Enter',
+            expectOnTagsAddedToBeCalled: false,
+          });
         });
       });
     });

--- a/src/MultiSelect/MultiSelect.spec.js
+++ b/src/MultiSelect/MultiSelect.spec.js
@@ -6,6 +6,7 @@ import { multiSelectTestkitFactory } from '../../testkit';
 import { multiSelectTestkitFactory as enzymeMultiSelectTestkitFactory } from '../../testkit/enzyme';
 import { mount } from 'enzyme';
 import { createRendererWithDriver, cleanup } from '../../test/utils/unit';
+import { depLogger } from '../utils/deprecationLog';
 
 describe('MultiSelect', () => {
   const render = createRendererWithDriver(multiSelectDriverFactory);
@@ -344,6 +345,80 @@ describe('MultiSelect', () => {
 
       expect(onManuallyInput.mock.calls).toHaveLength(1);
       expect(onManuallyInput.mock.calls[0][0]).toBe('custom value');
+    });
+  });
+
+  describe('onTagsAdded', () => {
+    it('should have deprecationLog when onManuallyInput is also passed', () => {
+      const depLogSpy = jest.spyOn(depLogger, 'log');
+      render(
+        <MultiSelect
+          options={options}
+          onManuallyInput={() => {}}
+          onTagsAdded={() => {}}
+        />,
+      );
+      expect(depLogSpy).toBeCalledWith(
+        `When 'onTagsAdded' is passed then 'isManuallyInput' will not be called. Please remove the 'isManuallyInput' prop.`,
+      );
+      depLogSpy.mockRestore();
+    });
+
+    describe('input is empty', () => {
+      it('should not be called when Enter is pressed', () => {
+        const onManuallyInput = jest.fn();
+        const onTagsAdded = jest.fn();
+        const { driver } = createDriver(
+          <MultiSelect
+            options={options}
+            onManuallyInput={onManuallyInput}
+            onTagsAdded={onTagsAdded}
+          />,
+        );
+
+        driver.focus();
+        driver.pressKey('Enter');
+
+        expect(onManuallyInput).toHaveBeenCalledTimes(0);
+        expect(onTagsAdded).toHaveBeenCalledTimes(0);
+      });
+    });
+
+    describe('input is not empty', () => {
+      function testCase({ props, keyPressed }) {
+        const onManuallyInput = jest.fn();
+        const onSelect = jest.fn();
+        const onTagsAdded = jest.fn();
+        const { driver, inputDriver } = createDriver(
+          <MultiSelect
+            onManuallyInput={onManuallyInput}
+            onTagsAdded={onTagsAdded}
+            onSelect={onSelect}
+            {...props}
+          />,
+        );
+
+        driver.focus();
+        inputDriver.enterText('custom value');
+        driver.pressKey(keyPressed);
+
+        expect(onManuallyInput).toHaveBeenCalledTimes(0);
+        expect(onSelect).toHaveBeenCalledTimes(0);
+        expect(onTagsAdded).toHaveBeenCalledTimes(1);
+        expect(onTagsAdded).toBeCalledWith(['custom value']);
+      }
+
+      it('should be called when Enter is pressed', () => {
+        testCase({ props: { options }, keyPressed: 'Enter' });
+      });
+
+      it('should be called when delimiter is pressed', () => {
+        testCase({ props: { options }, keyPressed: ',' });
+      });
+
+      it('should be called when delimiter is pressed given no options', () => {
+        testCase({ props: {}, keyPressed: ',' });
+      });
     });
   });
 

--- a/src/MultiSelect/MultiSelect.spec.js
+++ b/src/MultiSelect/MultiSelect.spec.js
@@ -535,6 +535,8 @@ describe('MultiSelect', () => {
     describe('onSelect', () => {
       it('should be called when option clicked', () => {
         const onSelect = jest.fn();
+        const onManuallyInput = jest.fn();
+        const onTagsAdded = jest.fn();
 
         const { driver, dropdownLayoutDriver } = createDriver(
           <MultiSelect
@@ -546,8 +548,30 @@ describe('MultiSelect', () => {
         driver.pressKey('ArrowDown');
         dropdownLayoutDriver.clickAtOption(0);
 
+        expect(onManuallyInput).toHaveBeenCalledTimes(0);
+        expect(onTagsAdded).toHaveBeenCalledTimes(0);
         expect(onSelect).toHaveBeenCalledTimes(1);
-        // TODO: add expect(onSelect).toBeCalledWith(...)
+      });
+
+      it('should be called with proper argument', () => {
+        const onSelect = jest.fn();
+
+        const { driver, dropdownLayoutDriver } = createDriver(
+          <MultiSelect
+            options={[
+              { id: '1', value: 'alabama', arbitraryPropName: { code: 'ALB' } },
+            ]}
+            onSelect={onSelect}
+            onTagsAdded={noop}
+          />,
+        );
+        driver.pressKey('ArrowDown');
+        dropdownLayoutDriver.clickAtOption(0);
+
+        expect(onSelect).toHaveBeenCalledTimes(1);
+        expect(onSelect).toBeCalledWith([
+          { id: '1', arbitraryPropName: { code: 'ALB' } },
+        ]);
       });
 
       it('should be called when option is selected by keyboard', () => {


### PR DESCRIPTION
According [to spec](https://github.com/wix/wix-style-react/blob/c732d5b8d598c6a1d9d8a02a414ce37bb4f6cc75/src/MultiSelect/README.DESIGN-SPEC.md#the-new-onselect-behavior)