### PR TITLE
Make Dropdown controlled again

### DIFF
--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import isUndefined from 'lodash/isUndefined';
 import InputWithOptions from '../InputWithOptions/InputWithOptions';
 import styles from './Dropdown.scss';
-import { PropTypes } from 'react';
+import PropTypes from 'prop-types';
 
 class Dropdown extends InputWithOptions {
   constructor(props) {

--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -79,7 +79,12 @@ class Dropdown extends InputWithOptions {
   }
 }
 
-Dropdown.propTypes = {...InputWithOptions.propTypes, controlled: PropTypes.bool};
+Dropdown.propTypes = {
+  ...InputWithOptions.propTypes,
+  /** When true, changing `selectedId` prop will determine the selected option and its' parsed value */
+  controlled: PropTypes.bool
+};
+
 Dropdown.defaultProps = InputWithOptions.defaultProps;
 Dropdown.displayName = 'Dropdown';
 

--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 import isUndefined from 'lodash/isUndefined';
 import InputWithOptions from '../InputWithOptions/InputWithOptions';
 import styles from './Dropdown.scss';
+import { PropTypes } from 'react';
 
 class Dropdown extends InputWithOptions {
   constructor(props) {
@@ -68,15 +69,17 @@ class Dropdown extends InputWithOptions {
   }
 
   _onSelect(option) {
-    this.setState({
-      value: this.props.valueParser(option),
-      selectedId: option.id,
-    });
+    if (!this.props.controlled) {
+      this.setState({
+        value: this.props.valueParser(option),
+        selectedId: option.id,
+      });
+    }
     super._onSelect(option);
   }
 }
 
-Dropdown.propTypes = InputWithOptions.propTypes;
+Dropdown.propTypes = {...InputWithOptions.propTypes, controlled: PropTypes.bool};
 Dropdown.defaultProps = InputWithOptions.defaultProps;
 Dropdown.displayName = 'Dropdown';
 

--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -82,7 +82,7 @@ class Dropdown extends InputWithOptions {
 Dropdown.propTypes = {
   ...InputWithOptions.propTypes,
   /** When true, changing `selectedId` prop will determine the selected option and its' parsed value */
-  controlled: PropTypes.bool
+  controlled: PropTypes.bool,
 };
 
 Dropdown.defaultProps = InputWithOptions.defaultProps;

--- a/src/Dropdown/Dropdown.spec.js
+++ b/src/Dropdown/Dropdown.spec.js
@@ -91,7 +91,7 @@ describe('Dropdown', () => {
 
   it('should be controlled', () => {
     const { driver, dropdownLayoutDriver, inputDriver } = createDriver(
-      <Dropdown options={getOptions()} selectedId={0} controlled />
+      <Dropdown options={getOptions()} selectedId={0} controlled />,
     );
 
     driver.focus();

--- a/src/Dropdown/Dropdown.spec.js
+++ b/src/Dropdown/Dropdown.spec.js
@@ -89,6 +89,17 @@ describe('Dropdown', () => {
     expect(driver.isReadOnly()).toBeTruthy();
   });
 
+  it('should be controlled', () => {
+    const { driver, dropdownLayoutDriver } = createDriver(
+      <Dropdown options={getOptions()} selectedId={0} controlled />
+    );
+
+    driver.focus();
+    dropdownLayoutDriver.clickAtOption(1);
+
+    expect(dropdownLayoutDriver.isOptionSelected(0)).toBeTruthy();
+  });
+
   describe('testkit', () => {
     it('should exist', () => {
       const div = document.createElement('div');

--- a/src/Dropdown/Dropdown.spec.js
+++ b/src/Dropdown/Dropdown.spec.js
@@ -89,16 +89,33 @@ describe('Dropdown', () => {
     expect(driver.isReadOnly()).toBeTruthy();
   });
 
-  it('should be controlled', () => {
-    const { driver, dropdownLayoutDriver, inputDriver } = createDriver(
-      <Dropdown options={getOptions()} selectedId={0} controlled />,
-    );
+  describe('Controlled mode', () => {
+    it('should keep current selection and value when option clicked', () => {
+      const { driver, dropdownLayoutDriver, inputDriver } = createDriver(
+        <Dropdown options={getOptions()} selectedId={0} controlled />,
+      );
 
-    driver.focus();
-    dropdownLayoutDriver.clickAtOption(1);
+      driver.focus();
+      dropdownLayoutDriver.clickAtOption(1);
 
-    expect(dropdownLayoutDriver.isOptionSelected(0)).toBeTruthy();
-    expect(inputDriver.getValue()).toBe('Option 1');
+      expect(dropdownLayoutDriver.isOptionSelected(0)).toBeTruthy();
+      expect(inputDriver.getValue()).toBe('Option 1');
+    });
+
+    it('should update selection and value when props change', () => {
+      const { driver: _driver, rerender } = render(
+        <Dropdown options={getOptions()} selectedId={0} controlled />,
+      );
+      const { dropdownLayoutDriver, inputDriver } = _driver;
+
+      expect(dropdownLayoutDriver.isOptionSelected(0)).toBeTruthy();
+      expect(inputDriver.getValue()).toBe('Option 1');
+
+      rerender(<Dropdown options={getOptions()} selectedId={1} controlled />);
+
+      expect(dropdownLayoutDriver.isOptionSelected(1)).toBeTruthy();
+      expect(inputDriver.getValue()).toBe('Option 2');
+    });
   });
 
   describe('testkit', () => {

--- a/src/Dropdown/Dropdown.spec.js
+++ b/src/Dropdown/Dropdown.spec.js
@@ -90,7 +90,7 @@ describe('Dropdown', () => {
   });
 
   it('should be controlled', () => {
-    const { driver, dropdownLayoutDriver } = createDriver(
+    const { driver, dropdownLayoutDriver, inputDriver } = createDriver(
       <Dropdown options={getOptions()} selectedId={0} controlled />
     );
 
@@ -98,6 +98,7 @@ describe('Dropdown', () => {
     dropdownLayoutDriver.clickAtOption(1);
 
     expect(dropdownLayoutDriver.isOptionSelected(0)).toBeTruthy();
+    expect(inputDriver.getValue()).toBe('Option 1');
   });
 
   describe('testkit', () => {

--- a/stories/components/Dropdown/ExampleControlled.js
+++ b/stories/components/Dropdown/ExampleControlled.js
@@ -7,7 +7,7 @@ const style = {
   padding: '0 5px 0',
   width: '200px',
   lineHeight: '22px',
-  marginBottom: '160px',
+  marginBottom: '160px'
 };
 
 const options = [
@@ -15,17 +15,22 @@ const options = [
   { id: 2, value: 'Option 2' },
   { id: 3, value: 'Option 3' },
   { id: 4, value: 'Option 4', disabled: true },
-  { id: 5, value: 'Option 5' },
+  { id: 5, value: 'Option 5' }
 ];
 
 class ControlledDropdown extends React.Component {
   constructor(props) {
     super(props);
     this.onSelect = this.onSelect.bind(this);
+    this.state = {
+      selectedId: 1
+    };
   }
 
   onSelect(option) {
-    console.log(`Option ${JSON.stringify(option)} selected`);
+    if (confirm(`Confirm selection of ${option.value}`)) {
+      this.setState({ selectedId: option.id });
+    }
   }
 
   render() {
@@ -35,6 +40,8 @@ class ControlledDropdown extends React.Component {
         options={options}
         onSelect={this.onSelect}
         placeholder={'Choose an option'}
+        selectedId={this.state.selectedId}
+        controlled
       />
     );
   }

--- a/stories/components/Dropdown/ExampleControlled.js
+++ b/stories/components/Dropdown/ExampleControlled.js
@@ -7,7 +7,7 @@ const style = {
   padding: '0 5px 0',
   width: '200px',
   lineHeight: '22px',
-  marginBottom: '160px'
+  marginBottom: '160px',
 };
 
 const options = [
@@ -15,7 +15,7 @@ const options = [
   { id: 2, value: 'Option 2' },
   { id: 3, value: 'Option 3' },
   { id: 4, value: 'Option 4', disabled: true },
-  { id: 5, value: 'Option 5' }
+  { id: 5, value: 'Option 5' },
 ];
 
 class ControlledDropdown extends React.Component {
@@ -23,7 +23,7 @@ class ControlledDropdown extends React.Component {
     super(props);
     this.onSelect = this.onSelect.bind(this);
     this.state = {
-      selectedId: 1
+      selectedId: 1,
     };
   }
 


### PR DESCRIPTION
### What changed

Added a `controlled` prop to <Dropdown/> to make it "really controlled"

### Why it changed

Before, <Dropdown/> was not really controlled, and for example, when `onSelect` does not change the `selectedId` prop (which is mapped to the component's state) the local state of the <Dropdown/> is still altered to the "selected" option.

---

- [x] Change is tested
- [x] Change is documented
- [ ] Build is green
- [x] Change of UX is approved by [wuwa](https://github.com/wuwa) or [milkyfruit](https://github.com/milkyfruit)

### Thanks for contributing :)
