### PR TITLE
Upgrade Storybook to 4.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,9 +72,9 @@
   },
   "homepage": "https://github.com/wix/wix-style-react#readme",
   "devDependencies": {
-    "@storybook/addon-links": "^3.4.10",
-    "@storybook/addon-options": "4.0.0-alpha.14",
-    "@storybook/react": "4.0.0-alpha.14",
+    "@storybook/addon-links": "4.1.6",
+    "@storybook/addon-options": "4.1.6",
+    "@storybook/react": "4.1.6",
     "@stylable/dom-test-kit": "^0.1.6",
     "@types/react": "^15.6.20",
     "babel-plugin-transform-decorators-legacy": "^1.3.5",


### PR DESCRIPTION
I just released `@storybook/react@4.1.6` that fixes the react 15.x backwards compatibility issue raised in https://github.com/storybooks/storybook/issues/4191 and https://github.com/wix/wix-style-react/pull/2494

Please give it a try here. Dev server and static build are both working on my dev machine.

@shlomitc @ranyitz Thanks for your bug report and patience!!