### PR TITLE
Try upgrading storybook - To Fix addon-links

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,9 +74,9 @@
   },
   "homepage": "https://github.com/wix/wix-style-react#readme",
   "devDependencies": {
-    "@storybook/addon-links": "^3.4.10",
-    "@storybook/addon-options": "4.0.0-alpha.14",
-    "@storybook/react": "4.0.0-alpha.14",
+    "@storybook/addon-links": "^4.1.6",
+    "@storybook/addon-options": "^4.1.6",
+    "@storybook/react": "^4.1.6",
     "@stylable/dom-test-kit": "^0.1.6",
     "@types/react": "^15.6.20",
     "babel-plugin-transform-decorators-legacy": "^1.3.5",
@@ -164,7 +164,7 @@
     "wix-ui-test-utils": "^1.0.115"
   },
   "lint-staged": {
-    "*.{js,scss}": "yoshi lint"
+    "*.{js,scss},.eslintignore": "yoshi lint"
   },
   "jest": {
     "setupFiles": [


### PR DESCRIPTION
Story Links were not working. (e.g. TextFiled story has a link to the FormField component)
We were using an old version of `@storybook/addon-links`.

Before trying to debug it, I am trying to upgrade storybook from `4.0.0.alpha-14` to the official `4.1.6`.

Locally it seems to solve the links issue.