### PR TITLE
infra: add babel-plugin-transform-runtime to build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@stylable/dom-test-kit": "^0.1.6",
     "@types/react": "^15.6.20",
     "babel-plugin-transform-decorators-legacy": "^1.3.5",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-polyfill": "^6.23.0",
     "babel-preset-es2015": "^6.14.0",
     "babel-preset-react": "*",
@@ -129,6 +130,7 @@
     "logLevel": "verbose"
   },
   "dependencies": {
+    "babel-runtime": "^6.26.0",
     "bootstrap-sass": "^3.3.7",
     "classnames": "^2.2.5",
     "color": "^2.0.0",
@@ -193,7 +195,8 @@
       "stage-2"
     ],
     "plugins": [
-      "transform-decorators-legacy"
+      "transform-decorators-legacy",
+      "babel-plugin-transform-runtime"
     ],
     "ignore": [
       "./scripts/component-generator/templates/"


### PR DESCRIPTION
Lately, users complained about receiving `ReferenceError: regeneratorRuntime is not defined` while running their tests.

I reproduced in the following combination:
1. Typescript project
2. E2E testing (protractor)
3. Using the `TextButton` driver (which uses `async-await` behind the scenes).

This happens because babel transpilation is not enough, as it assumes `babel-polyfill`/`babel-runtime` exists in the consuming project.

This PR adds `babel-plugin-transform-runtime` to the build step.