### PR TITLE
Testkit - smoke-test : Assert all components support `dataHook` prop

### DIFF
--- a/testkit/testkit-smoke.test.js
+++ b/testkit/testkit-smoke.test.js
@@ -28,6 +28,8 @@ const attachHooks = (beforeAllHook, afterAllHook) => {
   afterAll(async () => await afterAllHook());
 };
 
+const DATA_HOOK_PROP_NAME = 'dataHook';
+
 const DRIVER_ASSERTS = {
   enzyme: ({ name, component, props, beforeAllHook, afterAllHook }) => {
     describe('Enzyme testkits', () => {
@@ -39,6 +41,7 @@ const DRIVER_ASSERTS = {
             React.createElement(component, props),
             enzymeTestkitFactories[`${lowerFirst(name)}TestkitFactory`],
             mount,
+            { dataHookPropName: DATA_HOOK_PROP_NAME },
           ),
         ).toBe(true));
     });
@@ -52,6 +55,7 @@ const DRIVER_ASSERTS = {
           isTestkitExists(
             React.createElement(component, props),
             reactTestUtilsTestkitFactories[`${lowerFirst(name)}TestkitFactory`],
+            { dataHookPropName: DATA_HOOK_PROP_NAME },
           ),
         ).toBe(true));
     });

--- a/testkit/testkit-smoke.test.js
+++ b/testkit/testkit-smoke.test.js
@@ -93,6 +93,7 @@ const UNIDRIVER_ASSERTS = {
             React.createElement(component, props),
             enzymeTestkitFactories[`${lowerFirst(name)}TestkitFactory`],
             mount,
+            { dataHookPropName: DATA_HOOK_PROP_NAME },
           ),
         ).resolves.toBe(true));
     });
@@ -106,6 +107,7 @@ const UNIDRIVER_ASSERTS = {
           isUniTestkitExists(
             React.createElement(component, props),
             reactTestUtilsTestkitFactories[`${lowerFirst(name)}TestkitFactory`],
+            { dataHookPropName: DATA_HOOK_PROP_NAME },
           ),
         ).resolves.toBe(true));
     });


### PR DESCRIPTION
Previously, the `isTestkitXXX` would render the component with both `dataHook` and `data-hook`.
Now it will render only with `dataHook`.

> This is due to a bug with FLoatingHelper which didn't support `dataHook` (only `data-hook`).
