### PR TITLE
<Page stretchVertically> (#2810)

### DIFF
--- a/src/Page/Page.js
+++ b/src/Page/Page.js
@@ -233,6 +233,8 @@ class Page extends WixComponent {
       className,
       children,
       minWidth,
+      stretchVertically,
+      bottomPadding,
     } = this.props;
     const { minimized } = this.state;
     const hasBackgroundImage = !!backgroundImageUrl;
@@ -251,18 +253,20 @@ class Page extends WixComponent {
       minimizedFixedContainerHeight,
     } = this._calculateHeaderMeasurements({ PageTail });
 
+    const classNameStretchVertically = stretchVertically ? s.stretchVertically: '';
+
     const contentLayoutProps = {
       className: classNames(s.content, {
         [s.contentFullScreen]: contentFullScreen,
-      }),
+      }, classNameStretchVertically),
       style: contentFullScreen ? null : pageDimensionsStyle,
     };
 
     return (
-      <div className={classNames(s.pageWrapper, className)}>
+      <div className={classNames(s.pageWrapper, className, classNameStretchVertically)}>
         <div
-          className={s.page}
-          style={{ minWidth: minWidth + 2 * PAGE_SIDE_PADDING_PX }}
+          className={classNames(s.page, classNameStretchVertically)}
+          style={{ minWidth: minWidth + 2 * PAGE_SIDE_PADDING_PX, paddingBottom: bottomPadding }}
         >
           <div
             data-hook="page-fixed-container"
@@ -336,7 +340,7 @@ class Page extends WixComponent {
                 style={{ height: gradientHeight }}
               />
             )}
-            <div className={s.contentContainer}>
+            <div className={classNames(s.contentContainer, classNameStretchVertically)}>
               <div {...contentLayoutProps}>
                 {this._safeGetChildren(PageContent)}
               </div>
@@ -377,6 +381,8 @@ Page.propTypes = {
   minWidth: PropTypes.number,
   /** Sets padding of the sides of the page */
   sidePadding: PropTypes.number,
+  /** Sets padding at the bottom of the page */
+  bottomPadding: PropTypes.number,
   /** A css class to be applied to the component's root element */
   className: PropTypes.string,
   /** Header background color class name, allows to add a gradient to the header */
@@ -385,6 +391,8 @@ Page.propTypes = {
   gradientCoverTail: PropTypes.bool,
   /** Is called with the Page's scrollable content ref **/
   scrollableContentRef: PropTypes.func,
+  /** If true, page and page content will cover available height */
+  stretchVertically: PropTypes.bool,
 
   children: PropTypes.arrayOf((children, key) => {
     const childrenObj = getChildrenObject(children);

--- a/src/Page/Page.scss
+++ b/src/Page/Page.scss
@@ -122,3 +122,7 @@ $image-container-offset: 30px;
   padding-left: 0;
   padding-right: 0;
 }
+
+.stretch-vertically {
+  height: 100%;
+}

--- a/src/Page/README.md
+++ b/src/Page/README.md
@@ -10,8 +10,10 @@ The PageHeader component is the header implementation that will be changed when 
 | backgroundImageUrl | string | null | false | Background image url of the header beackground |
 | maxWidth | number | null | false | Sets the max width of the header and the content |
 | sidePadding | number | null | false | Sets padding of the sides of the page |
+| bottomPadding | number | null | false | Sets padding for the bottom of the page content |
 | gradientClassName | string | null | false | Header background color class name, allows to add a gradient to the header |
 | gradientCoverTail | bool | true | false | Should gradient cover Page.Tail |
+| stretchVertically | bool | false | false | If true, the page content will use all of its container's height |
 
 ## Children
 
@@ -20,7 +22,7 @@ The PageHeader component is the header implementation that will be changed when 
 | Page.Header | Page.Header | null | true | The PageHeader object which defines the components within the Header |
 | Page.Tail | Page.Tail | null | false | A placeholder for a component which sticks to the bottom of the header. Page.Tail.children receive `minimized` flag |
 | Page.Content | Page.Content | null | true | A placeholder for the page scrollable body, support `fullScreen` property which spans the content on the available area |
-| Page.FixedContent | Page.FixedContent | null | false | A placeholder for the a component which sticks to the bottom of the Tail (or bottom of Header if there is no Tail). It gets the same layout as the Page.Content. If Page.content `fullScreen` is enabled, then this FixedContent will be also full screen. |
+| Page.FixedContent | Page.FixedContent | null | false | A placeholder for a component which sticks to the bottom of the Tail (or bottom of Header if there is no Tail). It gets the same layout as the Page.Content. If Page.content `fullScreen` is enabled, then this FixedContent will be also full screen. |
 
 
 ## Usage

--- a/stories/Page/FullPageExample.js
+++ b/stories/Page/FullPageExample.js
@@ -37,6 +37,8 @@ class FullPageExample extends React.Component {
     shortContent: bool,
     maxWidth: number,
     sidePadding: number,
+    stretchVertically: bool,
+    bottomPadding: number,
   };
 
   render() {
@@ -50,6 +52,8 @@ class FullPageExample extends React.Component {
           <Page
             maxWidth={this.props.maxWidth}
             sidePadding={this.props.sidePadding}
+            bottomPadding={this.props.bottomPadding}
+            stretchVertically={this.props.stretchVertically}
           >
             {header(Breadcrumbs)}
             {tail}
@@ -89,5 +93,9 @@ if (displayAdditionalStories) {
     .add(
       '2.13 + Page Example with short content sidePadding and maxWidth',
       () => <FullPageExample sidePadding={0} maxWidth={800} shortContent />,
+    )
+    .add(
+      '2.14 + Page Example with short content bottomPadding and stretchVertically',
+      () => <FullPageExample shortContent bottomPadding={120} stretchVertically/>,
     );
 }

--- a/stories/Page/SomeContentComponent.js
+++ b/stories/Page/SomeContentComponent.js
@@ -12,7 +12,7 @@ export default class SomeContentComponent extends React.Component {
 
   render() {
     return (
-      <div style={{ backgroundColor: 'white' }}>
+      <div style={{ backgroundColor: 'white', minHeight: '100%' }}>
         {this.props.showScss && !this.props.shortContent && (
           <pre>
             <code>{stylesRaw}</code>


### PR DESCRIPTION
### 🔦 Summary
Enable the `<Page>` component to stretch vertically and use up all the available height, even if its contents are short. In particular, this enables an inner component to stretch itself vertically inside `<Page.Content>` if it supports it (such as `<Card>`).

### ✅ Checklist
- ✅ 📚 Change is documented
  - ✅ Story
  - ✅ API description
