### PR TITLE
<ColorPicker/> - add methods onMouseDownConfirm and onMouseDownCancel

### DIFF
--- a/src/ColorPicker/ColorPicker.driver.js
+++ b/src/ColorPicker/ColorPicker.driver.js
@@ -7,8 +7,16 @@ export const colorPickerDriverFactory = ({ element }) => {
       ReactTestUtils.Simulate.click(
         element.querySelector('[data-hook="color-picker-confirm-button"]'),
       ),
+    mouseDownConfirm: () =>
+      ReactTestUtils.Simulate.mouseDown(
+        element.querySelector('[data-hook="color-picker-confirm-button"]'),
+      ),
     cancel: () =>
       ReactTestUtils.Simulate.click(
+        element.querySelector('[data-hook="color-picker-cancel-button"]'),
+      ),
+    mouseDownCancel: () =>
+      ReactTestUtils.Simulate.mouseDown(
         element.querySelector('[data-hook="color-picker-cancel-button"]'),
       ),
     clickOnPreviousColor: () =>

--- a/src/ColorPicker/ColorPicker.js
+++ b/src/ColorPicker/ColorPicker.js
@@ -37,13 +37,20 @@ export default class ColorPicker extends WixComponent {
     showInput: bool,
 
     /** Handle color change event. */
-    onChange: func.isRequired,
+    onChange: func,
 
     /** Handle cancel button click */
-    onCancel: func.isRequired,
+    onCancel: func,
+
+    /** Handle cancel button onMouseDown event */
+    onMouseDownCancel: func,
 
     /** Handle confirm button click */
-    onConfirm: func.isRequired,
+    onConfirm: func,
+
+    /** Handle confirm button onMouseDown event */
+    onMouseDownConfirm: func,
+
     /** Children would be rendered above action buttons */
     children: node,
   };
@@ -60,6 +67,8 @@ export default class ColorPicker extends WixComponent {
     this.change = this.change.bind(this);
     this.confirm = this.confirm.bind(this);
     this.cancel = this.cancel.bind(this);
+    this.onMouseDownConfirm = this.onMouseDownConfirm.bind(this);
+    this.onMouseDownCancel = this.onMouseDownCancel.bind(this);
 
     const _color = safeColor(props.value) || FALLBACK_COLOR;
     this.state = { current: _color, previous: _color };
@@ -88,7 +97,12 @@ export default class ColorPicker extends WixComponent {
           onEnter={this.confirm}
         />
         {children && <div className={css.children}>{children}</div>}
-        <ColorPickerActions onConfirm={this.confirm} onCancel={this.cancel} />
+        <ColorPickerActions
+          onMouseDownConfirm={this.onMouseDownConfirm}
+          onMouseDownCancel={this.onMouseDownCancel}
+          onConfirm={this.confirm}
+          onCancel={this.cancel}
+        />
       </div>
     );
   }
@@ -104,6 +118,15 @@ export default class ColorPicker extends WixComponent {
     this.setState({ current: _color }, () => {
       this.props.onChange(_color);
     });
+  }
+
+  onMouseDownConfirm() {
+    this.setState({ previous: this.state.current });
+    this.props.onMouseDownConfirm(this.state.current);
+  }
+
+  onMouseDownCancel() {
+    this.props.onMouseDownCancel(this.state.previous);
   }
 
   confirm() {

--- a/src/ColorPicker/ColorPicker.spec.js
+++ b/src/ColorPicker/ColorPicker.spec.js
@@ -133,5 +133,44 @@ describe('ColorPicker', () => {
       driver.cancel();
       expect(onChange).toHaveBeenCalledTimes(1);
     });
+
+    it('`onMouseDownConfirm` should be called on confirm button', () => {
+      const onChange = jest.fn();
+      const onCancel = jest.fn();
+      const onMouseDownConfirm = jest.fn();
+      const value = '#00FF00';
+      createComponent({
+        value,
+        onChange,
+        onCancel,
+        onMouseDownConfirm,
+        showHistory: true,
+      });
+      driver.selectBlackColor();
+      expect(color(driver.historyCurrentColor()).hex()).toBe('#000000');
+      expect(color(driver.historyPreviousColor()).hex()).toBe(value);
+      driver.mouseDownConfirm();
+      expect(onMouseDownConfirm).toHaveBeenCalledTimes(1);
+      expect(color(driver.historyPreviousColor()).hex()).toBe('#000000');
+    });
+    it('`onMouseDownCancel` should be called on cancel button', () => {
+      const onChange = jest.fn();
+      const onConfirm = jest.fn();
+      const onMouseDownCancel = jest.fn();
+      const value = '#00FF00';
+      createComponent({
+        value,
+        onChange,
+        onConfirm,
+        onMouseDownCancel,
+        showHistory: true,
+      });
+      driver.selectBlackColor();
+      expect(color(driver.historyCurrentColor()).hex()).toBe('#000000');
+      expect(color(driver.historyPreviousColor()).hex()).toBe(value);
+      driver.mouseDownCancel();
+      expect(onMouseDownCancel).toHaveBeenCalledTimes(1);
+      expect(color(driver.historyPreviousColor()).hex()).toBe('#00FF00');
+    });
   });
 });

--- a/src/ColorPicker/ColorPickerActions.js
+++ b/src/ColorPicker/ColorPickerActions.js
@@ -7,13 +7,19 @@ import Check from '../new-icons/Check';
 
 import css from './ColorPickerActions.scss';
 
-const ColorPickerActions = ({ onCancel, onConfirm }) => (
+const ColorPickerActions = ({
+  onCancel,
+  onConfirm,
+  onMouseDownCancel,
+  onMouseDownConfirm,
+}) => (
   <div className={css.root}>
     <IconButton
       dataHook="color-picker-cancel-button"
       size="small"
       priority="secondary"
       onClick={onCancel}
+      onMouseDown={onMouseDownCancel}
     >
       <X />
     </IconButton>
@@ -21,6 +27,7 @@ const ColorPickerActions = ({ onCancel, onConfirm }) => (
       dataHook="color-picker-confirm-button"
       size="small"
       onClick={onConfirm}
+      onMouseDown={onMouseDownConfirm}
     >
       <Check />
     </IconButton>
@@ -30,6 +37,8 @@ const ColorPickerActions = ({ onCancel, onConfirm }) => (
 ColorPickerActions.propTypes = {
   onCancel: func.isRequired,
   onConfirm: func.isRequired,
+  onMouseDownCancel: func,
+  onMouseDownConfirm: func,
 };
 
 export default ColorPickerActions;

--- a/stories/ColorPicker/index.story.js
+++ b/stories/ColorPicker/index.story.js
@@ -17,5 +17,7 @@ export default {
     onChange: ev => ev.hex(),
     onCancel: () => 'Cancelled',
     onConfirm: () => 'Confirmed',
+    onMouseDownCancel: () => 'Cancelled',
+    onMouseDownConfirm: () => 'Confirmed',
   },
 };


### PR DESCRIPTION
### 🔦 Summary

Added additional mouse handlers for `Confirm` and `Cancel` buttons. The reason for this is to enable `onMouseDown` functionality for popover based `ColorPickers`.

Usually when ColorPicker is used inside Popover - very often onClickOutside functionality is used .For example in `Input` used together with ColorPicker. 

I.e. if `Input` is depending on `onBlur` or `onClickOutside` events then users will not able to click on `ColorPickers` confirm or cancel buttons. The point is the onBlur is triggering a re-render which seems to lead the browser to do not follow up with the onClick. 

Additionally I have removed `onCancel` and `onConfirm` proptypes required rule. In this case if two kind of mouse event handlers can be used - user needs to choose which one to use. And also I don't think that `oCancel` and `onConfirm` is seriously needed to be passed to render the component. It would be strange that user would not handle those by default. 

### Solution

Add onMouseDown event handlers which will not trigger popover childs `onBlur`  or `onClickOutside`methods.

### ✅ Checklist
- [ ] 👨‍💻 API change is approved by the UI Infra Developers  @hepiyellow @argshook @shlomitc  
- 📚 Change is documented
  - [x] Story
  - [x] API description
- 🔬 Change is tested
  - [x] Component