### PR TITLE
`<Page/>` (Tests) - Rename e2e test to have `Deprecated` suffix

### DIFF
--- a/src/Page/Page.deprecated.e2e.js
+++ b/src/Page/Page.deprecated.e2e.js
@@ -12,9 +12,13 @@ import { storySettings } from '../../stories/Page/storySettings';
 const { category, storyName } = storySettings;
 
 const testStoryUrl = testName =>
-  createTestStoryUrl({ category, storyName, testName });
+  createTestStoryUrl({
+    category,
+    storyName: `${storyName}/Deprecated`,
+    testName,
+  });
 
-describe('Page', () => {
+describe('Page Deprecated', () => {
   const initTest = async ({ storyUrl, dataHook }) => {
     await browser.get(storyUrl);
     const driver = pageTestkitFactory({ dataHook });

--- a/stories/Page/ExamplePageContainer.js
+++ b/stories/Page/ExamplePageContainer.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import s from './ExamplePageContainer.scss';
+
+/* This layout try to immitate the current BusinessManager's layout and styles. */
+
+export const ExamplePageContainer = ({ children }) => (
+  <div className={s.root}>
+    <div className={s.header} />
+    <div className={s.body}>
+      <div className={s.sideBar}>
+        <div className={s.sideBarContent}>SideBar Which is 220px wide</div>
+      </div>
+      <div className={s.rightSide}>
+        <div className={s.mainContentContainer}>
+          <div className={s.mainContent}>
+            <div className={s.withLoadingIndicatorWrapper}>
+              <div className={s.withLoadingIndicatorContainer}>{children}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+);

--- a/stories/Page/ExamplePageContainer.scss
+++ b/stories/Page/ExamplePageContainer.scss
@@ -1,0 +1,79 @@
+/* These styles try to immitate the current BusinessManager's styles.
+   Created by running the business-manager-test-app and copying the relevant DOM structure and styles.
+ */
+
+ $headerHeight: 48px;
+ $sideBarWidth: 220px;
+ 
+ .root {
+   display: flex;
+   flex-direction: column;
+   height: calc(100vh - 16px); // Compensate for browser's default margin
+ }
+ 
+ .header {
+   align-items: center;
+   box-shadow: 0 1px 5px 0 rgba(41,85,115,.21);
+   display: flex;
+   height: $headerHeight;
+   justify-content: space-between;
+   position: relative;
+   background-color: #fff;
+   z-index: 2000
+ }
+ 
+ .body {
+   flex: 1;
+   display: flex;
+   overflow: hidden;
+   height: calc(100% - 48px);
+ }
+ 
+ .sideBar {
+   z-index: 2;
+   display: flex;
+   position: relative;
+   white-space: pre-wrap;
+   height: 100%;
+   width: $sideBarWidth;
+   background-color:rgb(35, 38, 60);
+ 
+   .sideBarContent {
+     color: white;
+     width: 220px;
+   }
+ }
+ 
+ .rightSide {
+   flex: 1 1 0%;
+   display: flex;
+   flex-direction: column;
+   position: relative;
+   direction: ltr;
+   background: #f0f4f7;
+ 
+   .mainContentContainer {
+     flex-grow: 1;
+     height: 100%;
+     position: relative;
+ 
+     .mainContent {
+       position: absolute;
+       left: 0;
+       right: 0;
+       top: 0;
+       bottom: 0;
+ 
+       .withLoadingIndicatorWrapper {
+         display: flex;
+         flex-direction: column;
+         height: 100%;
+         
+         .withLoadingIndicatorContainer {
+           height: 100%;
+         }
+       }
+     }
+   }
+ }
+ 

--- a/stories/Page/PageTestStoriesDeprecated.js
+++ b/stories/Page/PageTestStoriesDeprecated.js
@@ -5,10 +5,11 @@ import { storiesOf } from '@storybook/react';
 import Page from 'wix-style-react/Page';
 import { getTestStoryKind } from '../storiesHierarchy';
 
-import * as s from './PageExample.scss';
+import * as s from './PageTestStoriesDeprecated.scss';
 import { header, tail, fixedContent, content } from './PageChildren';
 import { storySettings } from './storySettings';
 import ExampleEmptyState from './ExampleEmptyState';
+import { ExamplePageContainer } from './ExamplePageContainer';
 
 const PageContainer = props => {
   return (
@@ -21,7 +22,7 @@ PageContainer.propTypes = {
   children: PropTypes.any,
 };
 
-const kind = getTestStoryKind(storySettings);
+const kind = `${getTestStoryKind(storySettings)}/Deprecated`;
 const dataHook = 'story-page';
 
 storiesOf(kind, module).add('Header-Tail-Content: 1. Image', () => (
@@ -145,4 +146,10 @@ storiesOf(kind, module).add('8. Empty State', () => (
   <PageContainer>
     <ExampleEmptyState />
   </PageContainer>
+));
+
+storiesOf(kind, module).add('9. Empty State in BM', () => (
+  <ExamplePageContainer>
+    <ExampleEmptyState />
+  </ExamplePageContainer>
 ));

--- a/stories/Page/PageTestStoriesDeprecated.scss
+++ b/stories/Page/PageTestStoriesDeprecated.scss
@@ -1,0 +1,31 @@
+[data-hook="side-bar"] {
+  width: 200px;
+  height: calc(100% - 16px); // -16px account for chrome default body margin
+  background: red;
+  display: inline-block;
+  position: fixed;
+}
+
+@mixin PageConteiner() {
+  height: calc(100vh - 16px); // -16px account for chrome default body margin
+  display: flex;
+  flex-flow: column;
+  min-height: 0;
+}
+
+.pageContainer {
+  @include PageConteiner;
+}
+
+[data-hook="body-content"] {
+  height: calc(100vh - 16px); // -16px account for chrome default body margin
+  display: flex;
+  flex-flow: column;
+  margin-left: 200px;
+}
+
+[data-hook="top-bar"] {
+  background: green;
+  width: 100%;
+  flex: 0 0 100px;
+}

--- a/stories/index.js
+++ b/stories/index.js
@@ -142,7 +142,7 @@ import './Builders/ContactItemBuilder';
 // Tests
 import './Typography/TypographyTestStories';
 import './Input/InputTestStories';
-import './Page/PageTestStories.js'; // Tests/2. Layout/2.5 + Page/
+import './Page/PageTestStoriesDeprecated.js'; // Tests/2. Layout/2.5 + Page/Deprecated
 import './PageHeader/PageHeaderTestStories.js'; // Tests/2. Layout/2.5 + PageHeader/
 import './Button/testButton'; // Tests/5. Button/5.1 Button
 import './IconButton/testStory'; // Tests/5. Button/5.2 IconButton


### PR DESCRIPTION
Rename e2e tests to have `Deprecated` suffix.
This is preparation for the new Page PR, so that we would have trusted baseline for the deprecated Page. 