### PR TITLE
`<Page/>` (Fix): Prevent Page FixedContainer form blocking `<Notification type="sticky"/>

### DIFF
--- a/src/Page/Page.e2e.js
+++ b/src/Page/Page.e2e.js
@@ -156,11 +156,21 @@ describe('Page', () => {
   });
 
   eyes.it('should have sidePadding=0', async () => {
-    await browser.get(testStoryUrl('11. Page Example with sidePadding=0'));
+    await browser.get(testStoryUrl('10. Page Example with sidePadding=0'));
   });
 
-  eyes.it('should have short content stretched vertically', async () => {
-    await browser.get(testStoryUrl('12. Page Example with stretchVertically'));
+  eyes.it('should have sticky notification', async () => {
+    const ENOUGH_SCROLL_TO_MINIMIZE = 200;
+    const dataHook = storySettings.dataHook;
+    const privateDriver = protractorTestkitFactoryCreator(
+      pagePrivateDriverFactory,
+    )({ dataHook });
+
+    await browser.get(testStoryUrl('11. With Notification'));
+    await eyes.checkWindow('With shown notification');
+    await privateDriver.scrollVertically(ENOUGH_SCROLL_TO_MINIMIZE);
+    await eyes.checkWindow('With shown notification over a mini-header');
+    // TODO: click to close notification, scroll down to trigger mini-header (notification should not reappear. It happens , I don't know why!)
   });
 
   describe('Vertical Scroll', () => {

--- a/src/Page/Page.js
+++ b/src/Page/Page.js
@@ -279,16 +279,12 @@ class Page extends WixComponent {
     };
   }
 
-  _renderHeader({ minimized, visible }) {
+  _renderHeader({ minimized }) {
     const { children } = this.props;
     const childrenObject = getChildrenObject(children);
     const { PageTail, PageHeader: PageHeaderChild } = childrenObject;
     const pageDimensionsStyle = this._getPageDimensionsStyle();
-    const invisibleStyle = {
-      visibility: 'hidden',
-      position: 'absolute',
-      top: '-5000px', // arbitrary out of screen so it doesn't block click events
-    };
+
     return (
       <div
         className={classNames(s.pageHeaderContainer, {
@@ -301,7 +297,6 @@ class Page extends WixComponent {
             this.headerContainerRef = ref;
           }
         }}
-        style={visible ? {} : invisibleStyle}
       >
         {PageHeaderChild && (
           <div className={s.pageHeader} style={pageDimensionsStyle}>
@@ -328,11 +323,19 @@ class Page extends WixComponent {
 
   _renderFixedContainer() {
     const { scrollBarWidth, displayMiniHeader } = this.state;
+    const invisibleStyle = displayMiniHeader
+      ? {}
+      : {
+          visibility: 'hidden',
+          position: 'absolute',
+          top: '-5000px', // arbitrary out of screen so it doesn't block click events
+        };
     return (
       <div
         data-hook="page-fixed-container"
         style={{
           width: scrollBarWidth ? `calc(100% - ${scrollBarWidth}px` : undefined,
+          ...invisibleStyle,
         }}
         className={classNames(s.fixedContainer)}
         onWheel={event => {
@@ -341,10 +344,7 @@ class Page extends WixComponent {
         }}
       >
         {// We render but with visibility none, in order to measure the height
-        this._renderHeader({
-          minimized: true,
-          visible: displayMiniHeader,
-        })}
+        this._renderHeader({ minimized: true })}
       </div>
     );
   }
@@ -359,10 +359,7 @@ class Page extends WixComponent {
         onScroll={this._handleScroll}
       >
         {this._renderScrollableBackground()}
-        {this._renderHeader({
-          minimized: false,
-          visible: true,
-        })}
+        {this._renderHeader({ minimized: false })}
         {this._renderContentWrapper()}
       </div>
     );

--- a/stories/components/Page/PageTestStories.js
+++ b/stories/components/Page/PageTestStories.js
@@ -2,14 +2,18 @@ import React from 'react';
 import * as PropTypes from 'prop-types';
 import { storiesOf } from '@storybook/react';
 
-import Page from 'wix-style-react/Page';
 import { getTestStoryKind } from '../../storiesHierarchy';
+
+import Page from 'wix-style-react/Page';
+import Notification from '../../src/Notification';
+import Card from '../../src/Card';
 
 import * as s from './PageTestStories.scss';
 import { header, tail, fixedContent, content } from './PageChildren';
 import { storySettings } from './storySettings';
 import ExampleEmptyState from './ExampleEmptyState';
 import { ExamplePageContainer } from './ExamplePageContainer';
+import { LongTextContent } from './SomeContentComponent';
 
 const PageContainer = props => {
   return (
@@ -117,6 +121,26 @@ PageTestStories.add('10. Page Example with sidePadding=0', () => (
   </PageContainer>
 ));
 
+PageTestStories.add('11. With Notification', () => (
+  <PageContainer>
+    <Page {...defaultPageProps}>
+      {header()}
+      <Page.Content>
+        <Card>
+          <Card.Header title="Hello" />
+          <Card.Content>
+            <LongTextContent />
+          </Card.Content>
+        </Card>
+      </Page.Content>
+    </Page>
+    <Notification type="sticky" show>
+      <Notification.TextLabel>Hello Notification</Notification.TextLabel>
+      <Notification.CloseButton />
+    </Notification>
+  </PageContainer>
+));
+
 /*
  *  Vertical Test Stories
  */
@@ -206,7 +230,7 @@ class PageWithScroll extends React.Component {
     // Small scroll - lower than the threshold that triggers minimization
     <PageWithScroll
       {...defaultProps}
-      extraScroll={PageWithScroll.Constants.scrollTrigger - 1}
+      extraScroll={PageWithScroll.Constants.maxScrollNoTrigger}
     />
   ));
 

--- a/stories/components/Page/PageTestStories.js
+++ b/stories/components/Page/PageTestStories.js
@@ -5,8 +5,8 @@ import { storiesOf } from '@storybook/react';
 import { getTestStoryKind } from '../../storiesHierarchy';
 
 import Page from 'wix-style-react/Page';
-import Notification from '../../src/Notification';
-import Card from '../../src/Card';
+import Card from 'wix-style-react/Card';
+import Notification from 'wix-style-react/Notification';
 
 import * as s from './PageTestStories.scss';
 import { header, tail, fixedContent, content } from './PageChildren';

--- a/stories/components/Page/PageTestStoriesDeprecated.js
+++ b/stories/components/Page/PageTestStoriesDeprecated.js
@@ -11,8 +11,8 @@ import { storySettings } from './storySettings';
 import ExampleEmptyState from './ExampleEmptyState';
 import { ExamplePageContainer } from './ExamplePageContainer';
 import { LongTextContent } from './SomeContentComponent';
-import Card from '../../src/Card';
-import Notification from '../../src/Notification';
+import Card from 'wix-style-react/Card';
+import Notification from 'wix-style-react/Notification';
 
 const PageContainer = props => {
   return (

--- a/stories/components/Page/PageTestStoriesDeprecated.js
+++ b/stories/components/Page/PageTestStoriesDeprecated.js
@@ -10,6 +10,9 @@ import { header, tail, fixedContent, content } from './PageChildren';
 import { storySettings } from './storySettings';
 import ExampleEmptyState from './ExampleEmptyState';
 import { ExamplePageContainer } from './ExamplePageContainer';
+import { LongTextContent } from './SomeContentComponent';
+import Card from '../../src/Card';
+import Notification from '../../src/Notification';
 
 const PageContainer = props => {
   return (
@@ -152,4 +155,24 @@ storiesOf(kind, module).add('9. Empty State in BM', () => (
   <ExamplePageContainer>
     <ExampleEmptyState />
   </ExamplePageContainer>
+));
+
+storiesOf(kind, module).add('11. With Notification', () => (
+  <PageContainer>
+    <Page gradientClassName="background-gradient">
+      {header()}
+      <Page.Content>
+        <Card>
+          <Card.Header title="Hello" />
+          <Card.Content>
+            <LongTextContent />
+          </Card.Content>
+        </Card>
+      </Page.Content>
+    </Page>
+    <Notification type="sticky" show>
+      <Notification.TextLabel>Hello Notification</Notification.TextLabel>
+      <Notification.CloseButton />
+    </Notification>
+  </PageContainer>
 ));

--- a/stories/components/Page/storySettings.js
+++ b/stories/components/Page/storySettings.js
@@ -1,14 +1,19 @@
 import { Category } from '../../storiesHierarchy';
 
 const PageWithScrollConstants = (function() {
+  const SAFETY = 5;
   const pageHeight = 500;
   const pageBottomPadding = 48;
   const headerContainerHeight = 156;
   const minimizedHeaderContainerHeight = 67;
-  const scrollTrigger = headerContainerHeight - minimizedHeaderContainerHeight;
+  const scrollTrigger =
+    headerContainerHeight - minimizedHeaderContainerHeight + SAFETY;
+  const maxScrollNoTrigger =
+    headerContainerHeight - minimizedHeaderContainerHeight - SAFETY;
 
   return {
     scrollTrigger,
+    maxScrollNoTrigger,
     minimizedHeaderContainerHeight,
     headerContainerHeight,
     pageBottomPadding,


### PR DESCRIPTION
Make FixedContainer invisible instead of headerContainer.

By making it invisible we also translate it out of the viewport's area, so it can't block anything (since it has a very high z-index.


The minimized-header still is blocking the notification, we will handle that in a separate PR that makes ORDER in z-indexes across WSR.