### PR TITLE
prefix and suffix icons to modal confirm and cancel buttons

### DIFF
--- a/src/MessageBox/FooterLayout.js
+++ b/src/MessageBox/FooterLayout.js
@@ -9,9 +9,13 @@ const FooterLayout = ({
   children,
   theme,
   cancelText,
+  cancelPrefixIcon,
+  cancelSuffixIcon,
   onCancel,
   onOk,
   confirmText,
+  confirmPrefixIcon,
+  confirmSuffixIcon,
   buttonsHeight,
   enableOk,
   enableCancel,
@@ -28,6 +32,8 @@ const FooterLayout = ({
         <div className={footerButtonsClassNames}>
           {cancelText && (
             <Button
+              prefixIcon={cancelPrefixIcon}
+              suffixIcon={cancelSuffixIcon}
               disabled={!enableCancel}
               height={buttonsHeight}
               theme={'empty' + theme}
@@ -38,6 +44,8 @@ const FooterLayout = ({
           )}
           {confirmText && (
             <Button
+              prefixIcon={confirmPrefixIcon}
+              suffixIcon={confirmSuffixIcon}
               disabled={!enableOk}
               height={buttonsHeight}
               theme={'full' + theme}
@@ -62,7 +70,11 @@ const FooterLayout = ({
 
 FooterLayout.propTypes = {
   confirmText: PropTypes.node,
+  confirmPrefixIcon: PropTypes.element,
+  confirmSuffixIcon: PropTypes.element,
   cancelText: PropTypes.node,
+  cancelPrefixIcon: PropTypes.element,
+  cancelSuffixIcon: PropTypes.element,
   onCancel: PropTypes.func,
   onOk: PropTypes.func,
   enableOk: PropTypes.bool,

--- a/src/MessageBox/MessageBoxFunctionalLayout.driver.js
+++ b/src/MessageBox/MessageBoxFunctionalLayout.driver.js
@@ -13,12 +13,20 @@ const messageBoxFunctionalLayoutDriverFactory = ({ element }) => {
   return {
     exists: () => !!element,
     getConfirmationButtonText: () => confirmationButton().textContent,
+    isConfirmationButtonPrefixIconExists: () =>
+      confirmationButton().innerHTML.indexOf('prefix') !== -1,
+    isConfirmationButtonSuffixIconExists: () =>
+      confirmationButton().innerHTML.indexOf('suffix') !== -1,
     clickOnConfirmationButton: () =>
       ReactTestUtils.Simulate.click(confirmationButton()),
     getConfirmationButton: confirmationButton,
     getCancellationButton: cancellationButton,
     getHeaderCloseButton: headerCloseButton,
     getCancellationButtonText: () => cancellationButton().textContent,
+    isCancellationButtonPrefixIconExists: () =>
+      cancellationButton().innerHTML.indexOf('prefix') !== -1,
+    isCancellationButtonSuffixIconExists: () =>
+      cancellationButton().innerHTML.indexOf('suffix') !== -1,
     clickOnCancellationButton: () =>
       ReactTestUtils.Simulate.click(cancellationButton()),
     clickOnHeaderCloseButton: () =>
@@ -32,7 +40,7 @@ const messageBoxFunctionalLayoutDriverFactory = ({ element }) => {
       cancellationButton().className.indexOf('disabled') === -1,
     isConfirmationEnable: () =>
       confirmationButton().className.indexOf('disabled') === -1,
-    toHaveBodyPadding: () => !body().classList.contains(`${styles.noPadding}`),
+    toHaveBodyPadding: () => !body().classList.contains(`${styles.noPadding}`)
   };
 };
 

--- a/src/MessageBox/MessageBoxFunctionalLayout.js
+++ b/src/MessageBox/MessageBoxFunctionalLayout.js
@@ -57,7 +57,11 @@ class MessageBoxFunctionalLayout extends WixComponent {
       onOk,
       onClose,
       confirmText,
+      confirmPrefixIcon,
+      confirmSuffixIcon,
       cancelText,
+      cancelPrefixIcon,
+      cancelSuffixIcon,
       children,
       buttonsHeight,
       hideFooter,
@@ -135,7 +139,11 @@ class MessageBoxFunctionalLayout extends WixComponent {
             enableOk={!disableConfirmation}
             buttonsHeight={buttonsHeight}
             confirmText={confirmText}
+            confirmPrefixIcon={confirmPrefixIcon}
+            confirmSuffixIcon={confirmSuffixIcon}
             cancelText={cancelText}
+            cancelPrefixIcon={cancelPrefixIcon}
+            cancelSuffixIcon={cancelSuffixIcon}
             onCancel={onCancel}
             onOk={onOk}
             theme={theme}
@@ -150,7 +158,11 @@ class MessageBoxFunctionalLayout extends WixComponent {
 MessageBoxFunctionalLayout.propTypes = {
   hideFooter: PropTypes.bool,
   confirmText: PropTypes.node,
+  confirmPrefixIcon: PropTypes.element,
+  confirmSuffixIcon: PropTypes.element,
   cancelText: PropTypes.node,
+  cancelPrefixIcon: PropTypes.element,
+  cancelSuffixIcon: PropTypes.element,
   theme: PropTypes.string,
   onOk: PropTypes.func,
   onCancel: PropTypes.func,

--- a/src/MessageBox/MessageBoxFunctionalLayout.spec.js
+++ b/src/MessageBox/MessageBoxFunctionalLayout.spec.js
@@ -10,6 +10,7 @@ import {
 import { messageBoxFunctionalLayoutTestkitFactory } from '../../testkit';
 import { messageBoxFunctionalLayoutTestkitFactory as enzymeMessageBoxTestkitFactory } from '../../testkit/enzyme';
 import { mount } from 'enzyme';
+import ChevronDown from 'wix-style-react/new-icons/ChevronDown';
 
 describe('MessageBox', () => {
   const createDriver = createDriverFactory(MessageBoxFunctionalLayoutFactory);
@@ -22,12 +23,52 @@ describe('MessageBox', () => {
       expect(driver.getConfirmationButtonText()).toBe(props.confirmText);
     });
 
+    it('should display the prefix icon on top the confirmation button', () => {
+      const props = {
+        confirmText: 'confirmText',
+        confirmPrefixIcon: <ChevronDown />,
+      };
+      const driver = createDriver(<MessageBoxFunctionalLayout {...props} />);
+      expect(driver.getConfirmationButtonText()).toBe(props.confirmText);
+      expect(driver.isConfirmationButtonPrefixIconExists()).toBeTruthy();
+    });
+
+    it('should display the suffix icon on top the confirmation button', () => {
+      const props = {
+        confirmText: 'confirmText',
+        confirmSuffixIcon: <ChevronDown />,
+      };
+      const driver = createDriver(<MessageBoxFunctionalLayout {...props} />);
+      expect(driver.getConfirmationButtonText()).toBe(props.confirmText);
+      expect(driver.isConfirmationButtonSuffixIconExists()).toBeTruthy();
+    });
+
     it('should display the cancellation text on top the cancellation button', () => {
       const props = {
         cancelText: 'cancelText',
       };
       const driver = createDriver(<MessageBoxFunctionalLayout {...props} />);
       expect(driver.getCancellationButtonText()).toBe(props.cancelText);
+    });
+
+    it('should display the prefix icon on top the cancellation button', () => {
+      const props = {
+        cancelText: 'cancelText',
+        cancelPrefixIcon: <ChevronDown />,
+      };
+      const driver = createDriver(<MessageBoxFunctionalLayout {...props} />);
+      expect(driver.getCancellationButtonText()).toBe(props.cancelText);
+      expect(driver.isCancellationButtonPrefixIconExists()).toBeTruthy();
+    });
+
+    it('should display the suffix icon on top the cancellation button', () => {
+      const props = {
+        cancelText: 'cancelText',
+        cancelSuffixIcon: <ChevronDown />,
+      };
+      const driver = createDriver(<MessageBoxFunctionalLayout {...props} />);
+      expect(driver.getCancellationButtonText()).toBe(props.cancelText);
+      expect(driver.isCancellationButtonSuffixIconExists()).toBeTruthy();
     });
 
     it('should disable cancel button if disabled', () => {

--- a/src/MessageBox/README.md
+++ b/src/MessageBox/README.md
@@ -23,7 +23,11 @@
 | hideFooter | bool | - | - | Hide or show footer |
 | footerBottomChildren | node | - | - | Content to appear at the footer (below the footer's buttons) |
 | confirmText | string | - | - | Confirm button Label |
+| confirmPrefixIcon | element | - | - | Element based icon (svg, image etc.) |
+| confirmSuffixIcon | element | - | - | Element based icon (svg, image etc.) |
 | cancelText | string | - | - | Cancel button Label |
+| cancelPrefixIcon | element | - | - | Element based icon (svg, image etc.) |
+| cancelSuffixIcon | element | - | - | Element based icon (svg, image etc.) |
 | theme | string | - | - | theme of the message box, (green, blue , red) |
 | onOk | func | - | - | Ok callback |
 | onCancel | func | - | - | Cancel callback |


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!---
- Be as descriptive as possible when explaining what was changed.
- Link to an issue if one exists
-->
### 🔦 Summary
Added option to pass prefix and suffix icons to the modal confirm and cancel buttons.

<!--- Please mark all checkbox. If one is not relevant - delete it -->
### ✅ Checklist
- [ ] 👨‍💻 API change is approved by the UI Infra Developers <!--- Please tag the relevant team member -->
- [ ] 👨‍🎨 UX change is approved by the Design System UX <!--- Please tag the relevant team member -->
- 📚 Change is documented
  - [x] Story
  - [ ] API description
  - [ ] Other (explain)
- 🔬 Change is tested
  - [x] Component
  - [ ] Visual test
