### PR TITLE
Add `.npmignore` with original dirs and dev configs.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -17,5 +17,3 @@ CHANGELOG.md
 protractor.conf.js
 babel.config.js
 depmonkey.ignore
-
-

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,21 @@
+# original dirs
+new-icons
+scripts
+src
+testkit
+stories
+
+# markdowns
+README.md
+CONTRIBUTING.md
+CHANGELOG.md
+
+# configs
+.travis.yml
+.editorconfig
+.ci_config
+protractor.conf.js
+babel.config.js
+depmonkey.ignore
+
+


### PR DESCRIPTION
It should reduce `npm install wix-style-react` time. We don't need to publish original directories, .md files, development configs, etc.