### PR TITLE
AutoDocs: `generate_autodocs_registry`: Use `getCompName()` to get comp id

### DIFF
--- a/stories/autodocsRegistry.js
+++ b/stories/autodocsRegistry.js
@@ -1,15 +1,8 @@
 import reg from '../autodocs-registry/autodocs-registry.json';
-
-function getKeyFromComp(comp) {
-  // TODO: reuse logic from ui-autotools/packages/registry, or have registry include the 'key' in every metadata object.
-
-  // Should return displayName first, as if it's set, it means that it was set explicitly
-  // (we get "name" by default)
-  return comp.displayName || comp.name || '';
-}
+import { getCompName } from '@ui-autotools/registry';
 
 export function getParsedSource(comp) {
-  const key = getKeyFromComp(comp);
+  const key = getCompName(comp);
 
   return reg[key];
 }


### PR DESCRIPTION
Small refactor to use ui-autotools's `getCompName` to get the component ID for the registry.