### PR TITLE
fix: add button type to tag close button

### DIFF
--- a/src/CloseButton/CloseButton.js
+++ b/src/CloseButton/CloseButton.js
@@ -26,6 +26,8 @@ class CloseButton extends Component {
     disabled: bool,
     /** string based data hook for testing */
     dataHook: string,
+    /** Button type */
+    type: oneOf(['button', 'submit', 'reset']),
   };
 
   static defaultProps = {

--- a/src/Tag/Tag.js
+++ b/src/Tag/Tag.js
@@ -46,6 +46,7 @@ class Tag extends WixComponent {
     if (removable && !disabled) {
       return (
         <CloseButton
+          type="button"
           size={size === 'large' ? 'medium' : 'small'}
           skin="dark"
           dataHook={dataHooks.removeButton}


### PR DESCRIPTION
https://github.com/wix/wix-style-react/issues/2657

<!---
- Be as descriptive as possible when explaining what was changed.
- Link to an issue if one exists
-->
### 🔦 Summary
Add `button` type to close button in Tag component

The reason is: when Multiselect was wrapped with html element `form` after push Enter the button is submitted.
So I should change the button type to `button`

probably the better solution is to change the default button type to `button` in core ui lib