### PR TITLE
Fix bug where chrome autofill brakes input borders

### DIFF
--- a/src/Input/Input.scss
+++ b/src/Input/Input.scss
@@ -536,6 +536,10 @@ $material-gap: 8px;
   padding: 0 $double-gap;
 }
 
+.themedWrapper {
+	overflow-y: hidden;
+}
+
 .materialTitle {
   text-overflow: ellipsis;
   overflow: hidden;

--- a/src/Input/ThemedInput.js
+++ b/src/Input/ThemedInput.js
@@ -57,6 +57,7 @@ class ThemedInput extends Input {
         className={classNames(
           classes,
           styles.root,
+          styles.themedWrapper,
           styles[`theme-${theme}`],
           styles[`size-${size}${withSelection ? '-with-selection' : ''}`],
           className,


### PR DESCRIPTION
### 🔦 Summary
Chrome autofill for form is breaking the input layout

more on : https://jira.wixpress.com/browse/EE-17186

