### PR TITLE
add minRows prop - works with autoGrow + test it

### DIFF
--- a/src/InputArea/InputArea.e2e.js
+++ b/src/InputArea/InputArea.e2e.js
@@ -109,10 +109,16 @@ describe('input area page', () => {
     },
   );
 
-  eyes.it('should begin with miminum ammount of rows', async () => {
+  eyes.it('should begin with minimum amount of rows', async () => {
     await autoExampleDriver.setProps({ autoGrow: true });
     const rowCount = await inputAreaTestkit.getRowCount();
     expect(rowCount).toBe(InputArea.MIN_ROWS);
+  });
+
+  eyes.it('should begin with minRow amount of rows', async () => {
+    await autoExampleDriver.setProps({ autoGrow: true, minRows: 1 });
+    const rowCount = await inputAreaTestkit.getRowCount();
+    expect(rowCount).toBe(1);
   });
 
   eyes.it('it does not shrink below allowed minimum rows', async () => {

--- a/src/InputArea/InputArea.e2e.js
+++ b/src/InputArea/InputArea.e2e.js
@@ -109,14 +109,14 @@ describe('input area page', () => {
     },
   );
 
-  eyes.it('should begin with minimum amount of rows', async () => {
+  eyes.it('should begin with miminum ammount of rows', async () => {
     await autoExampleDriver.setProps({ autoGrow: true });
     const rowCount = await inputAreaTestkit.getRowCount();
     expect(rowCount).toBe(InputArea.MIN_ROWS);
   });
 
   eyes.it('should begin with minRow amount of rows', async () => {
-    await autoExampleDriver.setProps({ autoGrow: true, minRows: 1 });
+    await autoExampleDriver.setProps({ autoGrow: true, minRowsAutoGrow: 1 });
     const rowCount = await inputAreaTestkit.getRowCount();
     expect(rowCount).toBe(1);
   });

--- a/src/InputArea/InputArea.js
+++ b/src/InputArea/InputArea.js
@@ -28,7 +28,7 @@ class InputArea extends WixComponent {
   state = {
     focus: false,
     counter: (this.props.value || this.props.defaultValue || '').length,
-    computedRows: this.props.minRows,
+    computedRows: this.props.minRowsAutoGrow,
   };
 
   // For autoGrow prop min rows is 2 so the textarea doesn't look like an input
@@ -40,7 +40,10 @@ class InputArea extends WixComponent {
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.autoGrow && prevProps.minRows !== this.props.minRows) {
+    if (
+      this.props.autoGrow &&
+      prevProps.minRowsAutoGrow !== this.props.minRowsAutoGrow
+    ) {
       this._calculateComputedRows();
     }
   }
@@ -208,7 +211,7 @@ class InputArea extends WixComponent {
   _calculateComputedRows() {
     this.setState({ computedRows: 1 }, () => {
       const rowsCount = this._getRowsCount();
-      const computedRows = Math.max(this.props.minRows, rowsCount);
+      const computedRows = Math.max(this.props.minRowsAutoGrow, rowsCount);
       this.setState({
         computedRows,
       });
@@ -269,7 +272,7 @@ InputArea.displayName = 'InputArea';
 
 InputArea.defaultProps = {
   theme: 'normal',
-  minRows: InputArea.MIN_ROWS,
+  minRowsAutoGrow: InputArea.MIN_ROWS,
 };
 
 InputArea.propTypes = {
@@ -346,7 +349,7 @@ InputArea.propTypes = {
   autoGrow: PropTypes.bool,
 
   /** Sets the minimum amount of rows the component can have when in autoGrow mode */
-  minRows: PropTypes.number,
+  minRowsAutoGrow: PropTypes.number,
 
   style: PropTypes.oneOf(['normal', 'paneltitle', 'material', 'amaterial']),
   tabIndex: PropTypes.number,

--- a/src/InputArea/InputArea.js
+++ b/src/InputArea/InputArea.js
@@ -28,7 +28,7 @@ class InputArea extends WixComponent {
   state = {
     focus: false,
     counter: (this.props.value || this.props.defaultValue || '').length,
-    computedRows: InputArea.MIN_ROWS,
+    computedRows: this.props.minRows,
   };
 
   // For autoGrow prop min rows is 2 so the textarea doesn't look like an input
@@ -37,6 +37,12 @@ class InputArea extends WixComponent {
   componentDidMount() {
     super.componentDidMount();
     this.props.autoFocus && this._onFocus();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.autoGrow && prevProps.minRows !== this.props.minRows) {
+      this._calculateComputedRows();
+    }
   }
 
   render() {
@@ -196,9 +202,13 @@ class InputArea extends WixComponent {
   }
 
   _onInput() {
+    this._calculateComputedRows();
+  }
+
+  _calculateComputedRows() {
     this.setState({ computedRows: 1 }, () => {
       const rowsCount = this._getRowsCount();
-      const computedRows = Math.max(InputArea.MIN_ROWS, rowsCount);
+      const computedRows = Math.max(this.props.minRows, rowsCount);
       this.setState({
         computedRows,
       });
@@ -259,6 +269,7 @@ InputArea.displayName = 'InputArea';
 
 InputArea.defaultProps = {
   theme: 'normal',
+  minRows: InputArea.MIN_ROWS,
 };
 
 InputArea.propTypes = {
@@ -333,6 +344,9 @@ InputArea.propTypes = {
 
   /** Will cause the Input Area to grow and shrink according to user input */
   autoGrow: PropTypes.bool,
+
+  /** Sets the minimum amount of rows the component can have when in autoGrow mode */
+  minRows: PropTypes.number,
 
   style: PropTypes.oneOf(['normal', 'paneltitle', 'material', 'amaterial']),
   tabIndex: PropTypes.number,


### PR DESCRIPTION
<!---
- Be as descriptive as possible when explaining what was changed.
- Link to an issue if one exists
-->
### 🔦 Summary
We wanted to be able to have a growing input area, that starts with 1 row.
So We introduced a new prop called minRows that allows this to be possible.

### ✅ Checklist
- [ ] 👨‍💻 API change is approved by the UI Infra Developers <!--- Please tag the relevant team member -->
- [ ✅] 👨‍🎨 UX change is approved by the Design System UX <!--- Please tag the relevant team member -->
- 📚 Change is documented
  - [✅ ] Story
  - [✅ ] API description
- 🔬 Change is tested
  - [ ] Component
  - [✅ ] Visual test
