### PR TITLE
`<Page/>` - Add `z-index: 1` to `PageWrapper`

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,7 +208,8 @@
       "<rootDir>/test/jest-setup.js"
     ],
     "setupFilesAfterEnv": [
-      "wix-ui-test-utils/jest-setup"
+      "wix-ui-test-utils/jest-setup",
+      "<rootDir>/test/jest-setup-after-env.js"
     ],
     "moduleNameMapper": {
       "\\.(?!\\st).(css|less|scss)$": "identity-obj-proxy"

--- a/scripts/generate-testkit-exports/list-all-components.js
+++ b/scripts/generate-testkit-exports/list-all-components.js
@@ -16,6 +16,7 @@ const NON_COMPONENT_FOLDER_NAMES = [
   'Deprecated',
   'Typography',
   'Animations',
+  '__mocks__',
 ];
 
 const matches = haystack => needle => haystack.some(h => needle === h);

--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -6,6 +6,7 @@ import styles from './Modal.scss';
 import { colors, flexPositions, positions } from './ModalConstants';
 import WixComponent from '../BaseComponents/WixComponent';
 import X from '../new-icons/X';
+import { ZIndex } from '../ZIndex';
 
 const CHILDREN_WRAPPER_DIV_ID = 'modal-children-container';
 
@@ -84,7 +85,7 @@ class Modal extends WixComponent {
         left: 0,
         right: 0,
         bottom: 0,
-        zIndex: 11 + (zIndex || 0),
+        zIndex: ZIndex.MODAL + (zIndex || 0),
         backgroundColor: null, // null disables the property, use css instead
         // Overriding defaults - END
         display: 'flex',

--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -85,7 +85,7 @@ class Modal extends WixComponent {
         left: 0,
         right: 0,
         bottom: 0,
-        zIndex: ZIndex.MODAL + (zIndex || 0),
+        zIndex: ZIndex('Modal') + (zIndex || 0),
         backgroundColor: null, // null disables the property, use css instead
         // Overriding defaults - END
         display: 'flex',

--- a/src/Page/Page.js
+++ b/src/Page/Page.js
@@ -458,12 +458,13 @@ class Page extends WixComponent {
   }
 
   render() {
-    const { className, minWidth } = this.props;
+    const { className, minWidth, zIndex } = this.props;
 
     return (
       <div
         data-hook="wsr-page-wrapper"
         className={classNames(s.pageWrapper, className)}
+        style={{ zIndex }}
       >
         <div
           data-hook="page"
@@ -538,6 +539,8 @@ Page.propTypes = {
     }
   }).isRequired,
 
+  /** z-index of the Page */
+  zIndex: PropTypes.number,
   /** When true the page will use height: 100% and not require a parent of `display: flex;flex-flow: column;`. Also Page.Content's may grow using `min-height: inherit`. Supports Page.Sticky. New header minimization approach.*/
   upgrade: PropTypes.bool, // This Upgrade prop is only for documentation, the actual use is in index.js
 };

--- a/src/Page/Page.private.driver.js
+++ b/src/Page/Page.private.driver.js
@@ -31,4 +31,8 @@ export class PagePrivateDriver {
   getScrollAmount() {
     return this.scrollableContainer.scrollTop;
   }
+
+  getStyle() {
+    return this.element.style;
+  }
 }

--- a/src/Page/Page.scss
+++ b/src/Page/Page.scss
@@ -1,5 +1,6 @@
 @import '../common';
 @import '../Grid/GridConstants.scss';
+@import '../ZIndex';
 
 $page-side-padding: 48px;
 $headerBottomPadding: 24px;
@@ -17,10 +18,11 @@ $zIndexLayerStep: 100;
    */
 $stickyZIndex: 11000;
 $fixedContainerZIndex: $stickyZIndex + $zIndexLayerStep;
-
+   
 .pageWrapper {
   overflow-x: auto;
   height: 100%;
+  z-index: zIndex("PAGE");
 
   .page {
     position: relative;

--- a/src/Page/Page.scss
+++ b/src/Page/Page.scss
@@ -12,7 +12,7 @@ $zIndexLayerStep: 100;
 /* z-index is needed so that non-sticky content with 'position: relative' would not overlay above the sticky content.
    Need to be height than any component that may fit into a sticky page content.
    Currently:
-    - InputErrorSuffix uses 10000 (Likely to appear in a sticky TableToolbar)
+    - InputErrorSuffix's content uses 10000 (Likely to appear in a sticky TableToolbar)
     - Tooltip uses 2000
     - ToggleButton uses 1000
    */

--- a/src/Page/Page.spec.js
+++ b/src/Page/Page.spec.js
@@ -138,6 +138,37 @@ describe('Page', () => {
       // TODO:
     });
   });
+
+  describe('zIndex', () => {
+    it('should NOT have zIndex in inline style by default', () => {
+      const driver = PagePrivateDriver.fromJsxElement(
+        <Page>
+          <Page.Header title="title" />
+          <Page.Content>
+            <Content />
+          </Page.Content>
+        </Page>,
+      );
+
+      expect(driver.getStyle()['z-index']).toBe('');
+    });
+
+    it('should have provided zIndex in inline style', () => {
+      const driver = PagePrivateDriver.fromJsxElement(
+        <Page zIndex={7}>
+          <Page.Header title="title" />
+          <Page.Content>
+            <Content />
+          </Page.Content>
+        </Page>,
+      );
+
+      console.log('driver.getComputedStyle()= ', driver.getComputedStyle());
+
+      expect(driver.getStyle()['z-index']).toBe('7');
+    });
+  });
+
   describe('Header layer', () => {
     it('should NOT block clicks on content close to header', () => {});
     it('should NOT block clicks on content close to header when MiniHeader appears', () => {});

--- a/src/Page/Page.spec.js
+++ b/src/Page/Page.spec.js
@@ -163,8 +163,6 @@ describe('Page', () => {
         </Page>,
       );
 
-      console.log('driver.getComputedStyle()= ', driver.getComputedStyle());
-
       expect(driver.getStyle()['z-index']).toBe('7');
     });
   });

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -147,7 +147,7 @@ class Tooltip extends WixComponent {
     hideTrigger: 'mouseleave',
     showDelay: 200,
     hideDelay: 0,
-    zIndex: ZIndex.TOOLTIP,
+    zIndex: ZIndex('Tooltip'),
     maxWidth: '204px',
     onClickOutside: null,
     onShow: null,

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -7,6 +7,7 @@ import position from './TooltipPosition';
 import styles from './TooltipContent.scss';
 import { TooltipContainerStrategy } from './TooltipContainerStrategy';
 import throttle from 'lodash/throttle';
+import { ZIndex } from '../ZIndex';
 
 const renderSubtreeIntoContainer = ReactDOM.unstable_renderSubtreeIntoContainer;
 
@@ -146,7 +147,7 @@ class Tooltip extends WixComponent {
     hideTrigger: 'mouseleave',
     showDelay: 200,
     hideDelay: 0,
-    zIndex: 2000,
+    zIndex: ZIndex.TOOLTIP,
     maxWidth: '204px',
     onClickOutside: null,
     onShow: null,

--- a/src/Tooltip/TooltipContent.scss
+++ b/src/Tooltip/TooltipContent.scss
@@ -1,9 +1,10 @@
 @import './common.scss';
 @import '../common.scss';
+@import '../ZIndex.scss';
 
 .root {
   position: absolute;
-  z-index: 2000;
+  z-index: zIndex(TOOLTIP);
 }
 
 @mixin arrow($side, $color) {

--- a/src/ZIndex.js
+++ b/src/ZIndex.js
@@ -19,7 +19,18 @@ const ZIndexObj = Object.keys(ZIndexVars).reduce((acc, name) => {
   return acc;
 }, {});
 
+function isProduction() {
+  // If node-sass didn't work properly, then we are not in production,
+  // but probably in `generate-autodocs-registry`
+  return ZIndexVars.zIndexPage !== '$zIndex_PAGE';
+}
+
 export function ZIndex(layerName) {
+  if (!isProduction()) {
+    // This is a Hack for generate-autodocs-registry to work
+    // See this Issues: https://github.com/wix/yoshi/issues/1156
+    return '';
+  }
   const zIndexValue = ZIndexObj[layerName];
   if (!zIndexValue) {
     throw new Error(
@@ -29,4 +40,6 @@ export function ZIndex(layerName) {
     );
   }
   return zIndexValue;
+
+  // return '';
 }

--- a/src/ZIndex.js
+++ b/src/ZIndex.js
@@ -1,0 +1,6 @@
+import ZIndexVars from './ZIndex.scss';
+
+export const ZIndex = {
+  PAGE: Number(ZIndexVars['ZIndex_PAGE']),
+  MODAL: Number(ZIndexVars['ZIndex_MODAL']),
+};

--- a/src/ZIndex.js
+++ b/src/ZIndex.js
@@ -3,4 +3,5 @@ import ZIndexVars from './ZIndex.scss';
 export const ZIndex = {
   PAGE: Number(ZIndexVars['ZIndex_PAGE']),
   MODAL: Number(ZIndexVars['ZIndex_MODAL']),
+  TOOLTIP: Number(ZIndexVars['ZIndex_TOOLTIP']),
 };

--- a/src/ZIndex.js
+++ b/src/ZIndex.js
@@ -2,7 +2,7 @@ import ZIndexVars from './ZIndex.scss';
 
 /* Creates an object like this:
 
- export const ZIndex = {
+ const ZIndex = {
    Page: 1,
    Modal: 11,
    Tooltip: 2000,

--- a/src/ZIndex.js
+++ b/src/ZIndex.js
@@ -1,7 +1,32 @@
 import ZIndexVars from './ZIndex.scss';
 
-export const ZIndex = {
-  PAGE: Number(ZIndexVars['ZIndex_PAGE']),
-  MODAL: Number(ZIndexVars['ZIndex_MODAL']),
-  TOOLTIP: Number(ZIndexVars['ZIndex_TOOLTIP']),
-};
+/* Creates an object like this:
+
+ export const ZIndex = {
+   Page: 1,
+   Modal: 11,
+   Tooltip: 2000,
+ };
+
+ It basically:
+  - Strips the 'zIndex' prefix
+  - parses to int Number
+*/
+const ZIndexObj = Object.keys(ZIndexVars).reduce((acc, name) => {
+  const parsedValue = parseInt(ZIndexVars[name]);
+  const shortName = name.replace('zIndex', '');
+  acc[shortName] = isNaN(parsedValue) ? null : parsedValue;
+  return acc;
+}, {});
+
+export function ZIndex(layerName) {
+  const zIndexValue = ZIndexObj[layerName];
+  if (!zIndexValue) {
+    throw new Error(
+      `ZIndex: Layer with name ${layerName} does NOT exist. Layers = ${Object.keys(
+        ZIndexObj,
+      ).join(', ')}`,
+    );
+  }
+  return zIndexValue;
+}

--- a/src/ZIndex.scss
+++ b/src/ZIndex.scss
@@ -10,14 +10,19 @@ $zIndex_PAGE: 1;
  */
 $zIndex_MODAL: 11;
 
+$zIndex_TOOLTIP: 2001;
+
 :export {
   ZIndex_PAGE: $zIndex_PAGE;
   ZIndex_MODAL: $zIndex_MODAL;
+  ZIndex_TOOLTIP: $zIndex_TOOLTIP;
+  
 }
 
 $z-layers: (
   "PAGE": $zIndex_PAGE,
-  "MODAL": $zIndex_MODAL
+  "MODAL": $zIndex_MODAL,
+  "TOOLTIP": $zIndex_TOOLTIP
 );
 
 @function zIndex($layer) {

--- a/src/ZIndex.scss
+++ b/src/ZIndex.scss
@@ -1,0 +1,29 @@
+/* 
+ * This value is related to current BM z-index values of Header and Sidebar.
+ * Sidebar is 2, so Page should be beneeth it.
+ */
+$zIndex_PAGE: 1;
+/* 
+ * This value is related to current BM z-index values of Header and Sidebar.
+ * Header is 2000, so Modal should be above it.
+ * FIXME: Fix zIndex, make it above BM Header.
+ */
+$zIndex_MODAL: 11;
+
+:export {
+  ZIndex_PAGE: $zIndex_PAGE;
+  ZIndex_MODAL: $zIndex_MODAL;
+}
+
+$z-layers: (
+  "PAGE": $zIndex_PAGE,
+  "MODAL": $zIndex_MODAL
+);
+
+@function zIndex($layer) {
+  @if not map-has-key($z-layers, $layer) {
+    @warn "No layer found for `#{$layer}` in $z-layers map. Property omitted.";
+  }
+
+  @return map-get($z-layers, $layer);
+}

--- a/src/ZIndex.scss
+++ b/src/ZIndex.scss
@@ -10,13 +10,12 @@ $zIndex_PAGE: 1;
  */
 $zIndex_MODAL: 11;
 
-$zIndex_TOOLTIP: 2001;
+$zIndex_TOOLTIP: 2000;
 
 :export {
-  ZIndex_PAGE: $zIndex_PAGE;
-  ZIndex_MODAL: $zIndex_MODAL;
-  ZIndex_TOOLTIP: $zIndex_TOOLTIP;
-  
+  zIndexPage: $zIndex_PAGE;
+  zIndexModal: $zIndex_MODAL;
+  zIndexTooltip: $zIndex_TOOLTIP;
 }
 
 $z-layers: (

--- a/src/__mocks__/ZIndex.js
+++ b/src/__mocks__/ZIndex.js
@@ -1,0 +1,3 @@
+export function ZIndex() {
+  return null;
+}

--- a/test/jest-setup-after-env.js
+++ b/test/jest-setup-after-env.js
@@ -1,0 +1,1 @@
+jest.mock('../src/ZIndex');


### PR DESCRIPTION
Resolves #3083 

### What Changed
- Extracted a `Zindex.scss` and `Zindex.js` - This is just a refactor "start" of having Zindexs in one place.
- Add zIndex to `Page` (This affects only `<Page upgrade/>`)

### Temp Fix
This is actually a temporary fix since the real fix should come from the BusinessManager.
See this [Jira Ticket](https://jira.wixpress.com/browse/WOS2-1721)

Once BM applies the `z-index: 1` to the content-area, then we can remove the zIndex from Page.
> The `ZIndex` infrastructure will still be needed for Modals and other Layers.

### The Big Picture
See this [WIP Issue](https://github.com/wix-a/wsr-issues-erez/issues/34)