### PR TITLE
Enable Tooltip testkit access appended content

### DIFF
--- a/src/Tooltip/Tooltip.driver.js
+++ b/src/Tooltip/Tooltip.driver.js
@@ -1,6 +1,7 @@
 import ReactTestUtils from 'react-dom/test-utils';
 import eventually from 'wix-eventually';
 import last from 'lodash/last';
+import * as ReactDom from 'react-dom';
 
 const arrowDirectionToPlacement = {
   top: 'bottom',
@@ -9,7 +10,7 @@ const arrowDirectionToPlacement = {
   right: 'left',
 };
 
-const tooltipDriverFactory = ({ element }) => {
+const tooltipDriverFactory = ({ element, wrapper }) => {
   const getContentRoot = () => {
     const contentRootHook = element.getAttribute('data-content-hook');
     if (!contentRootHook) {
@@ -17,7 +18,22 @@ const tooltipDriverFactory = ({ element }) => {
         `Tooltip.driver: contentRootHook attribute must exist on the Toolrip's root element`,
       );
     }
-    return document.body.querySelector(`[data-hook="${contentRootHook}"]`);
+    const root = document.body.querySelector(
+      `[data-hook="${contentRootHook}"]`,
+    );
+    if (root) {
+      return root;
+    }
+
+    try {
+      const domInstance = ReactDom.findDOMNode(wrapper);
+      return (
+        domInstance &&
+        domInstance.querySelector(`[data-hook="${contentRootHook}"]`)
+      );
+    } catch (ignore) {
+      return null;
+    }
   };
 
   const getTooltipContent = () => getContentRoot().querySelector('.tooltip');

--- a/src/Tooltip/Tooltip.driver.js
+++ b/src/Tooltip/Tooltip.driver.js
@@ -18,18 +18,11 @@ const tooltipDriverFactory = ({ element, wrapper }) => {
         `Tooltip.driver: contentRootHook attribute must exist on the Tooltip's root element`,
       );
     }
-    const root = document.body.querySelector(
-      `[data-hook="${contentRootHook}"]`,
-    );
-    if (root) {
-      return root;
-    }
 
     try {
-      const domInstance = ReactDom.findDOMNode(wrapper);
       return (
-        domInstance &&
-        domInstance.querySelector(`[data-hook="${contentRootHook}"]`)
+        document.body.querySelector(`[data-hook="${contentRootHook}"]`) ||
+        wrapper.getDOMNode().querySelector(`[data-hook="${contentRootHook}"]`)
       );
     } catch (ignore) {
       return null;

--- a/src/Tooltip/Tooltip.driver.js
+++ b/src/Tooltip/Tooltip.driver.js
@@ -15,7 +15,7 @@ const tooltipDriverFactory = ({ element, wrapper }) => {
     const contentRootHook = element.getAttribute('data-content-hook');
     if (!contentRootHook) {
       throw new Error(
-        `Tooltip.driver: contentRootHook attribute must exist on the Toolrip's root element`,
+        `Tooltip.driver: contentRootHook attribute must exist on the Tooltip's root element`,
       );
     }
     const root = document.body.querySelector(


### PR DESCRIPTION
### 🔦 Summary
When using `<Tooltip>`'s `appendTo`, `appendToParent` or `appendByPredicate`, the Tooltip's content is not appended to `document.body` but to the specified parent.

When using *Enzyme*, the tested component that contains the `<Tooltip>` might be mounted using Enzyme's `mount()`, which doesn't append the component to `docuemnt.body` by default.
In such cases, `getContentRoot` will not find the Tooltip's content under `document.body` and it needs to look for it under the testkit's `wrapper`.