### PR TITLE
Unidrivers - Refactor : Add enhance-unidriver, ReactAdapter with isFocused.

### DIFF
--- a/scripts/generate-testkit-exports/templates/enzyme.js
+++ b/scripts/generate-testkit-exports/templates/enzyme.js
@@ -2,4 +2,4 @@
 import {
   enzymeTestkitFactoryCreator,
   enzymeUniTestkitFactoryCreator,
-} from 'wix-ui-test-utils/enzyme';
+} from './creators/enzyme';

--- a/scripts/generate-testkit-exports/templates/vanilla.js
+++ b/scripts/generate-testkit-exports/templates/vanilla.js
@@ -2,4 +2,4 @@
 import {
   testkitFactoryCreator,
   uniTestkitFactoryCreator,
-} from 'wix-ui-test-utils/vanilla';
+} from './creators/react-jsdom';

--- a/test/utils/react/index.js
+++ b/test/utils/react/index.js
@@ -1,6 +1,6 @@
 import { render } from 'react-testing-library';
 import { Simulate } from 'react-dom/test-utils';
-import { reactUniDriver } from 'unidriver';
+import { reactEnhancedUniDriver } from '../../../testkit/unidriver/adapters/ReactAdapter';
 
 const getElement = ({ rendered, dataHook }) => {
   return dataHook
@@ -13,8 +13,8 @@ const getElement = ({ rendered, dataHook }) => {
  * with and extra `driver` property.
  *
  * The returned render function arguments:
- * @param [React.Element] jsx a jsx element to render
- * @param [string] dataHook if provided then the driver would be created with the element which is found by the dataHook. If not provided then it assumes that the rendered root element is the component's root element and it will be used for the driver.
+ * @param {React.Element} jsx - a jsx element to render
+ * @param {string} dataHook - if provided then the driver would be created with the element which is found by the dataHook. If not provided then it assumes that the rendered root element is the component's root element and it will be used for the driver.
  */
 export const createRendererWithDriver = driverFactory => (jsx, dataHook) => {
   const rendered = render(jsx);
@@ -36,18 +36,14 @@ export const createRendererWithDriver = driverFactory => (jsx, dataHook) => {
  * with and extra `driver` property which is a Unidriver.
  *
  * The returned render function arguments:
- * @param [React.Element] jsx a jsx element to render
- * @param [string] dataHook if provided then the driver would be created with the element which is found by the dataHook. If not provided then it assumes that the rendered root element is the component's root element and it will be used for the driver.
+ * @param {React.Element} jsx - a jsx element to render
+ * @param {string} dataHook - if provided then the driver would be created with the element which is found by the dataHook. If not provided then it assumes that the rendered root element is the component's root element and it will be used for the driver.
  */
 export const createRendererWithUniDriver = driverFactory => (jsx, dataHook) => {
   const rendered = render(jsx);
 
   const element = getElement({ rendered, dataHook });
-  const driver = driverFactory(
-    reactUniDriver(element),
-    reactUniDriver(document.body),
-    reactUniDriver(document),
-  );
+  const driver = driverFactory(reactEnhancedUniDriver(element));
   return {
     ...rendered,
     driver,

--- a/test/utils/unidriver/ReactBase.js
+++ b/test/utils/unidriver/ReactBase.js
@@ -5,7 +5,7 @@ import { Simulate } from 'react-dom/test-utils';
  *
  * @param {UniDriver} base
  */
-export function ReactBase(base, document) {
+export function ReactBase(base) {
   const htmlElement = () => {
     if (base.type !== 'react') {
       throw new Error('Supported only in React/DOM.');
@@ -63,11 +63,7 @@ export function ReactBase(base, document) {
       elm.focus();
       Simulate.focus(elm); // TODO: Is this redundant?
     },
-    isFocus: async () => {
-      return (
-        (await document.getNative()).activeElement === (await htmlElement())
-      );
-    },
+    isFocus: () => base.isFocused(),
     blur: async () => {
       const elm = await htmlElement();
       elm.blur();

--- a/testkit/creators/enzyme.js
+++ b/testkit/creators/enzyme.js
@@ -1,0 +1,19 @@
+// This is a copy of wix-ui-test-utils/enzyme/enzyme.tsx
+// TODO: if this works well, then move it to wix-ui-test-utils
+import { reactEnhancedUniDriver } from '../unidriver/adapters/ReactAdapter';
+
+export { enzymeTestkitFactoryCreator } from 'wix-ui-test-utils/enzyme';
+
+export function enzymeUniTestkitFactoryCreator(driverFactory) {
+  return obj => {
+    const regexp = new RegExp(`^<[^>]+data-hook="${obj.dataHook}"`);
+    const component = obj.wrapper.findWhere(
+      n =>
+        n.length > 0 && typeof n.type() === 'string' && regexp.test(n.html()),
+    );
+    const element =
+      component.length > 0 ? component.first().getDOMNode() : undefined;
+    const base = reactEnhancedUniDriver(element);
+    return driverFactory(base);
+  };
+}

--- a/testkit/creators/react-jsdom.js
+++ b/testkit/creators/react-jsdom.js
@@ -1,0 +1,27 @@
+// This is a copy of wix-ui-test-utils/vanilla/vanilla.tsx
+// TODO: if this works well, then move it to wix-ui-test-utils
+import ReactDOM from 'react-dom';
+import { reactEnhancedUniDriver } from '../unidriver/adapters/ReactAdapter';
+
+export { testkitFactoryCreator } from 'wix-ui-test-utils/vanilla';
+
+const getElement = ({ wrapper, dataHook }) => {
+  const domInstance = ReactDOM.findDOMNode(wrapper);
+
+  if (domInstance) {
+    const dataHookOnInstance = domInstance.attributes.getNamedItem(
+      'data-hook',
+    ) || { value: '' };
+
+    return dataHook === dataHookOnInstance.value
+      ? domInstance
+      : domInstance.querySelector(`[data-hook='${dataHook}']`);
+  }
+};
+
+export function uniTestkitFactoryCreator(driverFactory) {
+  return testkitArgs => {
+    const element = getElement(testkitArgs);
+    return driverFactory(reactEnhancedUniDriver(element));
+  };
+}

--- a/testkit/enzyme.js
+++ b/testkit/enzyme.js
@@ -9,7 +9,7 @@
 import {
   enzymeTestkitFactoryCreator,
   enzymeUniTestkitFactoryCreator,
-} from 'wix-ui-test-utils/enzyme';
+} from './creators/enzyme';
 
 const load = module => {
   const MODULE_META_KEYS = ['__esModule'];

--- a/testkit/index.js
+++ b/testkit/index.js
@@ -9,7 +9,7 @@
 import {
   testkitFactoryCreator,
   uniTestkitFactoryCreator,
-} from 'wix-ui-test-utils/vanilla';
+} from './creators/react-jsdom';
 
 const load = module => {
   const MODULE_META_KEYS = ['__esModule'];

--- a/testkit/unidriver/adapters/ReactAdapter.js
+++ b/testkit/unidriver/adapters/ReactAdapter.js
@@ -1,0 +1,17 @@
+import { reactUniDriver } from 'unidriver';
+import { enhanceUnidriver } from '../enhance-unidriver';
+
+/**
+ * This is an enhanced ReactAdpater.
+ * Used for adding methods which the Unidriver team consideres bad-practice, but we don't.
+ *
+ * @param {Element} element
+ * @returns {EnhancedUniDriver}
+ */
+export function reactEnhancedUniDriver(element) {
+  return enhanceUnidriver(reactUniDriver(element), base => ({
+    isFocused: async () => {
+      return document.activeElement === (await base.getNative());
+    },
+  }));
+}

--- a/testkit/unidriver/enhance-unidriver.js
+++ b/testkit/unidriver/enhance-unidriver.js
@@ -1,0 +1,31 @@
+/**
+ * Adds extra methods to a Unidriver
+ *
+ * @param {*} baseUniDriver
+ * @param {*} createExtraMethods receives (baseDriver, enhance, enhanceList), returns an object with extra methods. Extra methods will NOT override base unidriver methods.
+ * @returns enhacned Unidriver with extra methods
+ */
+export function enhanceUnidriver(baseUniDriver, createExtraMethods) {
+  const { $, $$, ...rest } = baseUniDriver;
+
+  function enhance(_baseUniDriver) {
+    return enhanceUnidriver(_baseUniDriver, createExtraMethods);
+  }
+
+  function enhanceList(baseUniDriverList) {
+    return {
+      get: idx => enhance(baseUniDriverList.get(idx)),
+      text: baseUniDriverList.text,
+      count: baseUniDriverList.count,
+      map: baseUniDriverList.map,
+      filter: predicate => enhanceList(baseUniDriverList.filter(predicate)),
+    };
+  }
+
+  return {
+    ...createExtraMethods(baseUniDriver, enhance, enhanceList),
+    ...rest,
+    $: selector => enhance(baseUniDriver.$(selector)),
+    $$: selector => enhanceList(baseUniDriver.$$(selector)),
+  };
+}

--- a/testkit/unidriver/enhance-unidriver.spec.js
+++ b/testkit/unidriver/enhance-unidriver.spec.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { enhanceUnidriver } from './enhance-unidriver';
+import { createRendererWithUniDriver, cleanup } from '../../test/utils/unit';
+
+describe('EnhancedUniDriver', () => {
+  afterEach(() => {
+    cleanup();
+  });
+  const render = createRendererWithUniDriver(base => base);
+
+  it('should add extra methods', async () => {
+    const { driver } = render(
+      <div>
+        <div data-hook="hook1">Hello 1</div>
+        <div data-hook="hook2">Hello 2</div>
+      </div>,
+    );
+    const enhanced = enhanceUnidriver(driver, (base, enhance) => ({
+      dataHook: dataHook => {
+        return enhance(base.$(`[data-hook=${dataHook}]`));
+      },
+      foo: () => 'foo',
+    }));
+
+    // TODO: extract expections to different `it` tests
+    expect(typeof enhanced.dataHook).toEqual('function');
+    expect(enhanced.foo()).toEqual('foo');
+    expect(await enhanced.dataHook('hook1').exists()).toBe(true);
+    expect(enhanced.dataHook('hook1').foo()).toEqual('foo');
+    expect(typeof enhanced.dataHook('hook2').dataHook).toEqual('function');
+    expect(await enhanced.$(`[data-hook=hook1]`).text()).toEqual('Hello 1');
+    expect(
+      await enhanced
+        .$$(`[data-hook*=hook]`)
+        .get(0)
+        .text(),
+    ).toEqual('Hello 1');
+    expect(
+      await enhanced
+        .$$(`[data-hook*=hook]`)
+        .get(1)
+        .text(),
+    ).toEqual('Hello 2');
+  });
+});


### PR DESCRIPTION
### Why ReactBase approach is bad

Well, ReactBase was a hack that takes into account only the React-JSDOM test platform. 
Some methods were implemented in ReactBase that should be in all adapters (as WSR team see it, but Unidriver team disagree).

Once we'll want to implement those methods for all platforms, we'll need to add more platform dependent imports to ReactBase (And rename it to EnhancedBase). This will create a mix-up were tests running in one platform, would import stuff that belongs to another platform).


This refactor changes the strategy of "solving" Unidriver issues:
- from : using ReactBase as a react-only solution inside a component's Unidriver implementation
- to: Using a proper React Unidriver Adapter which enhances the original UniDriver.

This solution is good for methods like `isFocused` which CAN be implemented in all platforms, but UniDriver team is currently refusing to do so.

In this PR I am not implementing all platform adapters.

### Unidriver Migration Scope

We decided that the first-step migration would deal only with React-JSDOM platform.
But we are also writing new component with unidriver, and we need (want) methods that don't exist in Unidriver (and won't be added there).

So we have no choice but to extend/enhance the Unidriver adapters, and create an abstraction over Unidriver that extends the Unidriver API.

@shlomitc your opinion?
@GabiGrin FYI