### PR TITLE
use render props instead of cloneElement for actionBar

### DIFF
--- a/src/PageHeader/PageHeader.js
+++ b/src/PageHeader/PageHeader.js
@@ -214,7 +214,9 @@ export default class PageHeader extends WixComponent {
             })}
             data-hook="page-header-actionbar"
           >
-            {React.cloneElement(actionsBar, { minimized, hasBackgroundImage })}
+            {
+              typeof actionsBar === 'function'? actionsBar({ minimized, hasBackgroundImage }): actionsBar
+            }
           </div>
         )}
       </div>
@@ -242,7 +244,7 @@ PageHeader.propTypes = {
   /** The callback when back button is clicked */
   onBackClicked: PropTypes.func,
   /** A placeholder for a component that can contain actions / anything else. It should be a React component that receives `minimized` and `hasBackgroundImage` props. */
-  actionsBar: PropTypes.node,
+  actionsBar: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
 
   /** @hidden internal for new Page*/
   upgrade: PropTypes.bool,

--- a/src/PageHeader/PageHeader.private.driver.js
+++ b/src/PageHeader/PageHeader.private.driver.js
@@ -1,0 +1,24 @@
+import { createDriverFactory } from 'wix-ui-test-utils/driver-factory';
+
+export class PageHeaderPrivateDriver {
+  constructor({ element, eventTrigger }) {
+    this.element = element;
+    this.eventTrigger = eventTrigger;
+  }
+
+  static fromJsxElement(jsxElement) {
+    const driverFactory = ({ element, eventTrigger }) =>
+      new PageHeaderPrivateDriver({ element, eventTrigger });
+    return createDriverFactory(driverFactory)(jsxElement);
+  }
+
+  byDataHook(dataHook) {
+    return this.element.querySelector(`[data-hook="${dataHook}"]`);
+  }
+
+  existsByDataHook = dataHook => !!this.byDataHook(dataHook);
+
+  propExists(dataHook, prop) {
+    return !!this.byDataHook(dataHook).getAttribute(prop);
+  }
+}

--- a/src/PageHeader/PageHeader.spec.js
+++ b/src/PageHeader/PageHeader.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PageHeader from './PageHeader';
 import pageHeaderDriverFactory from './PageHeader.driver';
+import { PageHeaderPrivateDriver } from './PageHeader.private.driver';
 import { createRendererWithDriver, cleanup } from '../../test/utils/unit';
 import Button from '../Button';
 import Breadcrumbs from '../Breadcrumbs/Breadcrumbs';
@@ -247,6 +248,30 @@ describe('PageHeader', () => {
       expect(driver.isSubtitleExists()).toBeFalsy();
       expect(driver.isBreadcrumbsExists()).toBeTruthy();
       expect(driver.breadcrumbsText()).toBe(altTitle);
+    });
+  });
+
+  describe('render actionsBar using render props', () => {
+    it('should not pass minimized and hasBackgroundImage props to element', () => {
+      const actionBarDiv = <div data-hook="action-bar-div"></div>;
+      const pageHeader = <PageHeader minimized hasBackgroundImage title={title} actionsBar={actionBarDiv} />;
+      const driver = PageHeaderPrivateDriver.fromJsxElement(pageHeader);
+
+      expect(driver.existsByDataHook('action-bar-div')).toEqual(true);
+      expect(driver.propExists('action-bar-div', 'minimized')).toEqual(false);
+      expect(driver.propExists('action-bar-div', 'hasBackgroundImage')).toEqual(false);
+    });
+
+    it('should pass minimized and hasBackgroundImage props to function', () => {
+      const actionBarDiv = ({minimized, hasBackgroundImage}) =>
+        (minimized && hasBackgroundImage) ?
+        <div data-hook="action-bar-with-props"></div> :
+        <div data-hook="action-bar-with-no-props"></div>;
+      const pageHeader = <PageHeader minimized hasBackgroundImage title={title} actionsBar={actionBarDiv} />;
+      const driver = PageHeaderPrivateDriver.fromJsxElement(pageHeader);
+
+      expect(driver.existsByDataHook('action-bar-with-props')).toEqual(true);
+      expect(driver.existsByDataHook('action-bar-with-no-props')).toEqual(false);
     });
   });
 });


### PR DESCRIPTION
solves issue: https://github.com/wix/wix-style-react/issues/2891
by using render props instead of cloneElement for actionBar
@hepiyellow 
@nitayneeman 