### PR TITLE
`<Tooltip/>` - Add appendTo default predicate for Modal

### DIFF
--- a/src/Tooltip/TooltipContainerStrategy.js
+++ b/src/Tooltip/TooltipContainerStrategy.js
@@ -1,6 +1,7 @@
 export class TooltipContainerStrategy {
   constructor(appendTo, appendToParent, appendByPredicate) {
     this._predicates = [
+      element => element.classList.contains('ReactModal__Overlay'),
       element =>
         element.getAttribute('data-class') === 'page-scrollable-content',
       element => element === document.body,

--- a/src/Tooltip/TooltipContainerStrategy.spec.js
+++ b/src/Tooltip/TooltipContainerStrategy.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { TooltipContainerStrategy } from './TooltipContainerStrategy';
 import { mount } from 'enzyme';
 import Page from '../Page';
+import Modal from '../Modal';
 
 describe('TooltipContainerStrategy', () => {
   it('should return body when element is null', () => {
@@ -82,6 +83,27 @@ describe('TooltipContainerStrategy', () => {
     const container = tooltipContainerStrategy.getContainer(element);
     expect(container.getAttribute('data-class')).toBe(
       'page-scrollable-content',
+    );
+  });
+
+  it('should return Modal overlay container when element is rendered inside a Modal within a Page', () => {
+    const tooltipContainerStrategy = new TooltipContainerStrategy(null, false);
+    let element;
+
+    mount(
+      <Page>
+        <Page.Header title="title" />
+        <Page.Content>
+          <Modal isOpen contentLabel="Modal Example" scrollableContent={false}>
+            <div ref={ref => (element = ref)} />
+          </Modal>
+        </Page.Content>
+      </Page>,
+    );
+
+    const container = tooltipContainerStrategy.getContainer(element);
+    expect(container.getAttribute('class').split(' ')).toEqual(
+      expect.arrayContaining(['ReactModal__Overlay']),
     );
   });
 });


### PR DESCRIPTION
Resolves #3226 

THis is a quick fix.

I think the predicate solution of Tooltip is not ideal.?

### Solution Using Context Provider

- I suggest a solution where we'll have a `<AppendToProvider/>` 
- The Modal will be such a provider and will provide a `defaultAppendToElement`
- `<Tooltip/>` will be a consumer, and will use the `defaultAppendToElement` instead of the predicate mechanism.

#### Pros

- This method is better since it puts the responsibility of setting the appendTo "base" NOT on the tooltip, but on the context in which the Tooltip is rendered in. So that we don't need to add predicates on ALL Tooltips under a Modal (In this case).
