### PR TITLE
`<Tooltip/>` - Change z-index to be higher than Modal's

### DIFF
--- a/src/ZIndex.js
+++ b/src/ZIndex.js
@@ -1,8 +1,8 @@
 const ZIndexValues = {
   Page: 1,
-  Tooltip: 2000,
   Notification: 4000,
   Modal: 5000,
+  Tooltip: 6000,
 };
 
 export function ZIndex(layerName) {

--- a/src/ZIndex.scss
+++ b/src/ZIndex.scss
@@ -8,4 +8,7 @@ $zIndex_PAGE: 1;
 */
 $zIndex_NOTIFICATION: 4000;
 $zIndex_MODAL: 5000;
+/*
+ * Making Tooltip higher than Modal, assumes that when a modal is Opened, then all Tooltip's are closed.
+ */ 
 $zIndex_TOOLTIP: 6000;

--- a/src/ZIndex.scss
+++ b/src/ZIndex.scss
@@ -4,10 +4,8 @@
  */
 $zIndex_PAGE: 1;
 /* 
-* This value is probably related to current BM header's z-index value.
-* Header is 2000
-* FIXME: Fix zIndex, make it above BM Header.
+* The following values assume that the BM's Header has zIndex 2000
 */
-$zIndex_TOOLTIP: 2000;
 $zIndex_NOTIFICATION: 4000;
 $zIndex_MODAL: 5000;
+$zIndex_TOOLTIP: 6000;


### PR DESCRIPTION
Resolves https://github.com/wix/wix-style-react/issues/3226

See
https://github.com/wix/wix-style-react/pull/3237#issuecomment-479795126