### PR TITLE
<RichTextInputArea/> - hide placeholder after changing the block type

### DIFF
--- a/src/RichTextInputArea/EditorUtilities.js
+++ b/src/RichTextInputArea/EditorUtilities.js
@@ -1,7 +1,7 @@
 import { EditorState, SelectionState, Modifier, RichUtils } from 'draft-js';
 import { stateToHTML } from 'draft-js-export-html';
 
-import { entityTypes } from './RichTextInputAreaTypes';
+import { blockTypes, entityTypes } from './RichTextInputAreaTypes';
 
 /** Returns whether the specified style is applied on a block */
 const hasStyle = (editorState, style) => {
@@ -163,6 +163,17 @@ const convertToHtml = editorState => {
 
 const isEditorFocused = editorState => editorState.getSelection().getHasFocus();
 
+/** Returns true in case the editor's content doesn't contain any block which has a non-default type or text.
+    It means that if the user changes the block type before entering any text, the content will be considered as non-empty.
+ */
+const isEditorEmpty = editorState =>
+  !editorState.getCurrentContent().hasText() &&
+  editorState
+    .getCurrentContent()
+    .getBlockMap()
+    .first()
+    .getType() === blockTypes.unstyled;
+
 export default {
   hasStyle,
   hasBlockType,
@@ -174,4 +185,5 @@ export default {
   findLinkEntities,
   convertToHtml,
   isEditorFocused,
+  isEditorEmpty,
 };

--- a/src/RichTextInputArea/RichTextInputArea.js
+++ b/src/RichTextInputArea/RichTextInputArea.js
@@ -8,6 +8,7 @@ import {
   CompositeDecorator,
 } from 'draft-js';
 import mapValues from 'lodash/mapValues';
+import classNames from 'classnames';
 
 import styles from './RichTextInputArea.scss';
 import RichTextToolbar from './Toolbar/RichTextToolbar';
@@ -84,9 +85,16 @@ class RichTextInputArea extends React.PureComponent {
 
   render() {
     const { dataHook, placeholder } = this.props;
+    const isEditorEmpty = EditorUtilities.isEditorEmpty(this.state.editorState);
 
     return (
-      <div data-hook={dataHook} className={styles.root}>
+      <div
+        data-hook={dataHook}
+        className={classNames(
+          styles.root,
+          !isEditorEmpty && styles.hidePlaceholder,
+        )}
+      >
         <RichTextInputAreaContext.Provider
           value={{
             texts: this.state.texts,

--- a/src/RichTextInputArea/RichTextInputArea.private.uni.driver.js
+++ b/src/RichTextInputArea/RichTextInputArea.private.uni.driver.js
@@ -1,5 +1,6 @@
 import publicDriverFactory, {
-  getTextArea,
+  getContent,
+  getPlaceholder,
 } from './RichTextInputArea.uni.driver';
 
 import richTextToolbarPrivateDriverFactory from './Toolbar/RichTextToolbar.private.uni.driver';
@@ -10,7 +11,8 @@ export default base => {
     ...richTextToolbarPrivateDriverFactory(
       base.$('[data-hook=richtextarea-toolbar]'),
     ),
-    hoverTextArea: async () => await getTextArea(base).hover(),
-    clickTextArea: async () => await getTextArea(base).click(),
+    hasPlaceholder: () => getPlaceholder(base).exists(),
+    hoverTextArea: async () => await getContent(base).hover(),
+    clickTextArea: async () => await getContent(base).click(),
   };
 };

--- a/src/RichTextInputArea/RichTextInputArea.scss
+++ b/src/RichTextInputArea/RichTextInputArea.scss
@@ -46,6 +46,12 @@ $padding: 12px;
   }
 }
 
+.hidePlaceholder {
+  :global(.public-DraftEditorPlaceholder-root) {
+    display: none;
+  }
+}
+
 .toolbar {
   border: $border;
   border-bottom: 0;

--- a/src/RichTextInputArea/RichTextInputArea.spec.js
+++ b/src/RichTextInputArea/RichTextInputArea.spec.js
@@ -48,11 +48,25 @@ describe('RichTextInputArea', () => {
     });
 
     it('should render a placeholder', async () => {
-      const text = 'Some text';
-      const driver = createDriver(<RichTextInputArea placeholder={text} />);
+      const placeholderText = 'Placeholder';
+      const driver = createDriver(
+        <RichTextInputArea placeholder={placeholderText} />,
+      );
 
-      expect(await driver.exists()).toBe(true);
-      expect(await driver.getContent()).toBe(text);
+      expect(await driver.getContent()).toBe('');
+      expect(await driver.getPlaceholder()).toBe(placeholderText);
+    });
+
+    it('should not render the placeholder after inserting text', async () => {
+      const expectedText = 'Some text';
+      const driver = createDriver(
+        <RichTextInputArea placeholder="Placeholder" />,
+      );
+
+      await driver.enterText(expectedText);
+
+      expect(await driver.getContent()).toBe(expectedText);
+      expect(await driver.hasPlaceholder()).toBe(false);
     });
   });
 

--- a/src/RichTextInputArea/RichTextInputArea.uni.driver.js
+++ b/src/RichTextInputArea/RichTextInputArea.uni.driver.js
@@ -1,20 +1,23 @@
 import { baseUniDriverFactory } from 'wix-ui-test-utils/base-driver';
 import ReactTestUtils from 'react-dom/test-utils';
 
-export const getTextArea = base => base.$('.public-DraftEditor-content');
+export const getContent = base => base.$('.public-DraftEditor-content');
+export const getPlaceholder = base =>
+  base.$('.public-DraftEditorPlaceholder-root');
 
 export default base => {
   return {
     ...baseUniDriverFactory(base),
-    getContent: () => base.text(),
+    getContent: () => getContent(base).text(),
+    getPlaceholder: () => getPlaceholder(base).text(),
     enterText: async text => {
-      const textAreaNative = await getTextArea(base).getNative(); // eslint-disable-line no-restricted-properties
+      const contentElement = await getContent(base).getNative(); // eslint-disable-line no-restricted-properties
 
       // TODO: implement for puppeteer. Throw error if type is not handled
       if (base.type === 'react') {
-        ReactTestUtils.Simulate.beforeInput(textAreaNative, { data: text });
+        ReactTestUtils.Simulate.beforeInput(contentElement, { data: text });
       } else if (base.type === 'protractor') {
-        textAreaNative.sendKeys(text);
+        contentElement.sendKeys(text);
       }
     },
   };

--- a/src/RichTextInputArea/RichTextInputAreaTypes.js
+++ b/src/RichTextInputArea/RichTextInputAreaTypes.js
@@ -5,6 +5,7 @@ export const inlineStyleTypes = {
 };
 
 export const blockTypes = {
+  unstyled: 'unstyled',
   bulletedList: 'unordered-list-item',
   numberedList: 'ordered-list-item',
 };


### PR DESCRIPTION
This PR resolves the following bug:
![preview](https://user-images.githubusercontent.com/7141972/55558109-0789ef80-56f4-11e9-9a4f-09705e639e90.gif)

Related to issue:
wix-private/wsr-issues#35