### PR TITLE
stop using autoSizeInput

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,7 +190,6 @@
     "react-day-picker": "^7.0.7",
     "react-dnd": "^2.5.1",
     "react-dnd-html5-backend": "^5.0.1",
-    "react-input-autosize": "^2.2.1",
     "react-modal": "^3.3.2",
     "react-motion": "^0.4.7",
     "react-portal": "^4.1.5",

--- a/src/MultiSelect/MultiSelect.js
+++ b/src/MultiSelect/MultiSelect.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import AutosizeInput from 'react-input-autosize';
 import classNames from 'classnames';
 
 import InputWithOptions from '../InputWithOptions/InputWithOptions';
@@ -181,13 +180,7 @@ class MultiSelect extends InputWithOptions {
 
   static autoSizeInput = ({ className, 'data-ref': dataRef, ...rest }) => {
     const inputClassName = classNames(className, styles.autoSizeInput);
-    return (
-      <AutosizeInput
-        {...rest}
-        inputRef={dataRef}
-        inputClassName={inputClassName}
-      />
-    );
+    return <input {...rest} ref={dataRef} className={inputClassName} />;
   };
 }
 

--- a/src/MultiSelect/MultiSelect.scss
+++ b/src/MultiSelect/MultiSelect.scss
@@ -1,3 +1,4 @@
 .autoSizeInput {
-  min-width: 0px;
+  width: 1px;
+  min-width: 1px;
 }


### PR DESCRIPTION
MultiSelect is using InputWithTags
Because of InputWithTags Flexi behavior of gorwing the items, we can simply use width and min-width of 1px on an input field, and it would grow and shrink depending on it's content, without breaking a the line.