### PR TITLE
test(*): disable animations and transitions for visual eyes tests

### DIFF
--- a/.storybook-test/stories.scss
+++ b/.storybook-test/stories.scss
@@ -4,3 +4,8 @@ html {
   padding: 0;
   margin: 0;
 }
+
+* {
+  transition: none !important;
+  animation: none !important;
+}

--- a/src/Accordion/test/Accordion.visual.js
+++ b/src/Accordion/test/Accordion.visual.js
@@ -12,8 +12,8 @@ export const text =
 storiesOf('Accordion', module).add('simple', () => (
   <Accordion
     items={[
-      { title: 'First Row', children: <Text>${text}</Text> },
-      { title: 'Second Row', children: <Text>${text}</Text> },
+      { title: 'First Row', children: <Text>{text}</Text> },
+      { title: 'Second Row', children: <Text>{text}</Text> },
     ]}
   />
 ));
@@ -23,14 +23,14 @@ storiesOf('Accordion', module).add('withButton', () => (
     items={[
       {
         title: 'First Row With Button',
-        children: <Text>${text}</Text>,
+        children: <Text>{text}</Text>,
         buttonType: 'button',
         expandLabel: 'Show More',
         collapseLabel: 'Less',
       },
       {
         title: 'Second Row With Icon',
-        children: <Text>${text}</Text>,
+        children: <Text>{text}</Text>,
         icon: <InfoCircle />,
         expandLabel: 'Show More',
         collapseLabel: 'Less',
@@ -45,24 +45,24 @@ storiesOf('Accordion', module).add('multiple', () => (
     items={[
       {
         title: 'First Initially Open Row',
-        children: <Text>${text}</Text>,
+        children: <Text>{text}</Text>,
         open: true,
         collapseLabel: 'Less',
       },
       {
         title: 'Second Row',
-        children: <Text>${text}</Text>,
+        children: <Text>{text}</Text>,
         open: true,
         collapseLabel: 'Less',
       },
       {
         title: 'Third Row',
-        children: <Text>${text}</Text>,
+        children: <Text>{text}</Text>,
         collapseLabel: 'Less',
       },
       {
         title: 'Disable Row',
-        children: <Text>${text}</Text>,
+        children: <Text>{text}</Text>,
         collapseLabel: 'Less',
         disabled: true,
       },
@@ -81,7 +81,7 @@ storiesOf('Accordion', module).add('inCard', () => (
           expandLabel: 'More',
           collapseLabel: 'Less',
           buttonType: 'button',
-          children: <Text>${text}</Text>,
+          children: <Text>{text}</Text>,
         },
       ]}
     />


### PR DESCRIPTION
visual tests sometimes flake due to animations. for example, accordion
component has expanding animation which takes some miliseconds to
complete

it could be that snapshot is taken during the animation, resulting in
considerable visual diff and a broken build.

an easy remedy is to simply disable any css transition and animation delays and durations