### PR TITLE
<Input/> - fix prop validation warning

### DIFF
--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -70,7 +70,11 @@ class Input extends Component {
       );
     }
 
-    if (this._isClearFeatureEnabled && this._isControlled) {
+    if (
+      this._isClearFeatureEnabled &&
+      this._isControlled &&
+      !props.updateControlledOnClear
+    ) {
       deprecationLog(
         `<Input/> - Clearing the value in a controlled component through onChange() will be deprectead in next major version. Pass updateControlledOnClear prop and use the onClear() callback to apply the new behavior`,
       );


### PR DESCRIPTION
To reproduce:
https://codesandbox.io/s/50xr88n0jk

Input component shows a warning in the browser console also when the new prop updateControlledOnClear is provided.