### PR TITLE
Allow user to set max height

### DIFF
--- a/src/DropdownBase/DropdownBase.js
+++ b/src/DropdownBase/DropdownBase.js
@@ -286,6 +286,7 @@ class DropdownBase extends React.PureComponent {
       options,
       minWidth,
       maxWidth,
+      maxHeight,
     } = this.props;
 
     const { open, selectedId } = this.state;

--- a/src/DropdownBase/DropdownBase.js
+++ b/src/DropdownBase/DropdownBase.js
@@ -32,6 +32,8 @@ class DropdownBase extends React.PureComponent {
     minWidth: PropTypes.number,
     /** The maximum width applied to the list */
     maxWidth: PropTypes.number,
+    /** the maximum height applied to the list */
+    maxHeight: PropTypes.number,
 
     /**
      * The target component to be rendered. If a regular node is paseed, it'll be rendered as-is.
@@ -318,6 +320,7 @@ class DropdownBase extends React.PureComponent {
             }}
           >
             <DropdownLayout
+              maxHeightPixals={maxHeight}
               dataHook="dropdown-base-dropdownlayout"
               ref={r => (this._dropdownLayoutRef = r)}
               selectedId={selectedId}

--- a/src/DropdownBase/DropdownBase.js
+++ b/src/DropdownBase/DropdownBase.js
@@ -321,8 +321,8 @@ class DropdownBase extends React.PureComponent {
             }}
           >
             <DropdownLayout
-              maxHeightPixals={maxHeight}
               dataHook="dropdown-base-dropdownlayout"
+              maxHeightPixels={maxHeight}
               ref={r => (this._dropdownLayoutRef = r)}
               selectedId={selectedId}
               options={options}


### PR DESCRIPTION
Currently,  `<DropdownBase />` uses `<DropdownLayout />`, which have a default height of 260px. A user of `<DropdownLayout /> can change this property, but it isn't accessible  to a user of `<DropdownBase />`. 

I've added a `maxHeight` property to `<DropdownBase />`, which is then passed to `<DropdownLayout />`