### PR TITLE
<Text/> - migrate to visual tests and sections

### DIFF
--- a/src/Text/Text.e2e.js
+++ b/src/Text/Text.e2e.js
@@ -1,13 +1,10 @@
 import eyes from 'eyes.it';
-import autoExampleDriver from 'wix-storybook-utils/AutoExampleDriver';
 import {
   createStoryUrl,
-  scrollToElement,
   waitForVisibilityOf,
 } from 'wix-ui-test-utils/protractor';
 import { tooltipTestkitFactory } from 'wix-ui-core/dist/src/testkit/protractor';
 import { textTestkitFactory } from '../../testkit/protractor';
-import { SIZES, SKINS, WEIGHTS } from './constants';
 import { storySettings } from './docs/storySettings';
 
 describe('Text', () => {
@@ -28,50 +25,6 @@ describe('Text', () => {
     await waitForVisibilityOf(driver.element(), 'Cannot find Text');
     return driver;
   };
-
-  describe('AutoExample', () => {
-    let driver;
-    beforeAll(async () => {
-      driver = await init({ url: storyUrl, dataHook: 'storybook-text' });
-    });
-    afterEach(() => autoExampleDriver.reset());
-
-    eyes.it('should display correct content', async () => {
-      expect(await driver.getText()).toBe('Some text');
-    });
-
-    eyes.it('light prop', async () => {
-      await eyes.checkWindow('dark');
-
-      await autoExampleDriver.setProps({ light: true });
-      await waitForVisibilityOf(driver.element(), 'Cannot find Text');
-      await eyes.checkWindow('light');
-    });
-
-    eyes.it('size prop', async () => {
-      for (const size of Object.keys(SIZES)) {
-        await autoExampleDriver.setProps({ size });
-        await waitForVisibilityOf(driver.element(), 'Cannot find Text');
-        await eyes.checkWindow(size);
-      }
-    });
-
-    eyes.it('skin prop', async () => {
-      for (const skin of Object.keys(SKINS)) {
-        await autoExampleDriver.setProps({ skin });
-        await waitForVisibilityOf(driver.element(), 'Cannot find Text');
-        await eyes.checkWindow(skin);
-      }
-    });
-
-    eyes.it('weight prop', async () => {
-      for (const weight of Object.keys(WEIGHTS)) {
-        await autoExampleDriver.setProps({ weight });
-        await waitForVisibilityOf(driver.element(), 'Cannot find Text');
-        await eyes.checkWindow(weight);
-      }
-    });
-  });
 
   describe('with tooltip', () => {
     eyes.it(
@@ -99,18 +52,5 @@ describe('Text', () => {
         expect(await tooltipDriver.isContentElementExists()).toBeTruthy();
       },
     );
-  });
-
-  describe('anchors', () => {
-    const testName = 'should apply link styling only to direct <a> children';
-
-    eyes.it(testName, async () => {
-      const driver = await init({
-        url: storyUrlWithExamples,
-        dataHook: 'storybook-text-link',
-      });
-      await scrollToElement(driver.element());
-      await eyes.checkWindow(testName);
-    });
   });
 });

--- a/src/Text/docs/ExampleEllipsis.js
+++ b/src/Text/docs/ExampleEllipsis.js
@@ -1,8 +1,9 @@
+/* eslint-disable no-undef */
 import React from 'react';
 import Text from 'wix-style-react/Text';
 
-export default () => (
+render(
   <div data-hook="text-with-ellipses" style={{ width: '120px' }}>
     <Text ellipsis>very very long text</Text>
-  </div>
+  </div>,
 );

--- a/src/Text/docs/ExampleH1TagName.js
+++ b/src/Text/docs/ExampleH1TagName.js
@@ -1,8 +1,9 @@
+/* eslint-disable no-undef */
 import React from 'react';
 import Text from 'wix-style-react/Text';
 
-export default () => (
+render(
   <Text tagName="h1" dataHook="storybook-text-h1">
     Text
-  </Text>
+  </Text>,
 );

--- a/src/Text/docs/ExampleLink.js
+++ b/src/Text/docs/ExampleLink.js
@@ -1,7 +1,8 @@
+/* eslint-disable no-undef */
 import React from 'react';
 import Text from 'wix-style-react/Text';
 
-export default () => (
+render(
   <Text dataHook="storybook-text-link">
     Text component applies link styles to anchor elements that are{' '}
     <a
@@ -19,5 +20,5 @@ export default () => (
       </a>
     </span>{' '}
     are not styled (what you see is the default browser styles)
-  </Text>
+  </Text>,
 );

--- a/src/Text/docs/ExampleMultiline.js
+++ b/src/Text/docs/ExampleMultiline.js
@@ -1,4 +1,5 @@
+/* eslint-disable no-undef */
 import React from 'react';
 import Text from 'wix-style-react/Text';
 
-export default () => <Text>{'First line\nSecond line'}</Text>;
+render(<Text>{'First line\nSecond line'}</Text>);

--- a/src/Text/docs/ExampleTextTypography.js
+++ b/src/Text/docs/ExampleTextTypography.js
@@ -1,8 +1,9 @@
+/* eslint-disable no-undef */
 import React from 'react';
 import Text from 'wix-style-react/Text';
 import s from './styles.scss';
 
-export default () => (
+render(
   <div>
     <h3>Thin Text</h3>
     <ul className={s.root}>
@@ -456,5 +457,5 @@ export default () => (
         </span>
       </li>
     </ul>
-  </div>
+  </div>,
 );

--- a/src/Text/docs/index.story.js
+++ b/src/Text/docs/index.story.js
@@ -1,24 +1,31 @@
 import React from 'react';
-import CodeExample from 'wix-storybook-utils/CodeExample';
-
 import Text, { SIZES, SKINS, WEIGHTS } from '..';
-
-import TypographyExample from './ExampleTextTypography';
 import TypographyExampleRaw from '!raw-loader!./ExampleTextTypography';
-
-import MultilineExample from './ExampleMultiline';
 import MultilineExampleRaw from '!raw-loader!./ExampleMultiline';
-
-import EllipsisExample from './ExampleEllipsis';
 import EllipsisExampleRaw from '!raw-loader!./ExampleEllipsis';
-
-import H1TagNameExample from './ExampleH1TagName';
 import H1TagNameExampleRaw from '!raw-loader!./ExampleH1TagName';
-
-import LinkExample from './ExampleLink';
 import LinkExampleRaw from '!raw-loader!./ExampleLink';
+import exampleStyles from './styles.scss';
 
 import { storySettings } from './storySettings';
+import { baseScope } from '../../../stories/utils/LiveCodeExample';
+
+import {
+  tab,
+  code as baseCode,
+  importExample,
+  api,
+  testkit,
+  playground,
+} from 'wix-storybook-utils/Sections';
+
+const code = config =>
+  baseCode({
+    components: { ...baseScope, s: exampleStyles },
+    autoRender: false,
+    compact: true,
+    ...config,
+  });
 
 export default {
   category: storySettings.category,
@@ -38,27 +45,48 @@ export default {
     ellipsis: false,
   },
 
-  examples: (
-    <div>
-      <CodeExample title="Multiline Example" code={MultilineExampleRaw}>
-        <MultilineExample />
-      </CodeExample>
+  sections: [
+    tab({
+      title: 'Usage',
+      sections: [
+        importExample({
+          source: "import Text from 'wix-style-react/Text';",
+        }),
+        code({
+          title: 'Multiline',
+          description: 'Break a line using \\n character',
+          source: MultilineExampleRaw,
+        }),
+        code({
+          title: 'Ellipsis',
+          description:
+            'When the ellipsis prop is passed and the Text component is rendered in a small container, the component will get an ellispis and a helper tooltip',
+          source: EllipsisExampleRaw,
+        }),
+        code({
+          title: 'Custom Tag Name',
+          description:
+            'Text component can render a custom tag name, for example h1',
+          source: H1TagNameExampleRaw,
+        }),
+        code({
+          title: 'Link Example',
+          description:
+            'When an anchor tag (a) is a direct child of the Text, it will get predefined styles',
+          source: LinkExampleRaw,
+        }),
+        code({
+          title: 'Typography mapping',
+          description: 'Map prop names to actual definition',
+          source: TypographyExampleRaw,
+        }),
+      ],
+    }),
 
-      <CodeExample title="Ellipsis Example" code={EllipsisExampleRaw}>
-        <EllipsisExample />
-      </CodeExample>
-
-      <CodeExample title="Custom TagName Example" code={H1TagNameExampleRaw}>
-        <H1TagNameExample />
-      </CodeExample>
-
-      <CodeExample title="Link Example" code={LinkExampleRaw}>
-        <LinkExample />
-      </CodeExample>
-
-      <CodeExample title="Typography Examples" code={TypographyExampleRaw}>
-        <TypographyExample />
-      </CodeExample>
-    </div>
-  ),
+    ...[
+      { title: 'API', sections: [api()] },
+      { title: 'TestKit', sections: [testkit()] },
+      { title: 'Playground', sections: [playground()] },
+    ].map(tab),
+  ],
 };

--- a/src/Text/tests/Text.visual.js
+++ b/src/Text/tests/Text.visual.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import Text, { SIZES, WEIGHTS, SKINS } from '..';
+
+storiesOf('Text', module)
+  .add('default', () => <Text>Some Text</Text>)
+  .add('link', () => (
+    <Text>
+      <a href="/">Some Text</a>
+    </Text>
+  ))
+  .add('styles', () => (
+    <div style={{ backgroundColor: '#f0f4f7' }}>
+      {Object.keys(WEIGHTS).map(weight =>
+        Object.keys(SIZES).map(size =>
+          Object.keys(SKINS).map(skin =>
+            [false, true].map(light =>
+              [false, true].map(secondary => (
+                <span style={{ margin: '12px' }}>
+                  <Text
+                    key={`${weight} ${size} ${skin} ${light} ${secondary}`}
+                    size={size}
+                    weight={weight}
+                    skin={skin}
+                    light={light}
+                    secondary={secondary}
+                  >
+                    Some Text
+                  </Text>
+                </span>
+              )),
+            ),
+          ),
+        ),
+      )}
+    </div>
+  ));
+
+//TODO - ellipsis test is correct but the tooltip doesn't display on initial load, looks like a bug in the HOC
+// import ReactTestUtils from 'react-dom/test-utils';
+//   .add('ellipsis', () => <TextEllipsis />);
+
+// class TextEllipsis extends React.Component {
+//   componentDidMount() {
+//     setTimeout(() => {
+//       ReactTestUtils.Simulate.mouseEnter(
+//         document.querySelector('[data-hook="text-with-ellipsis"]'),
+//       );
+//     });
+//   }
+//   render() {
+//     return (
+//       <div style={{ width: '120px' }}>
+//         <Text ellipsis dataHook="text-with-ellipsis">
+//           very very long text
+//         </Text>
+//       </div>
+//     );
+//   }
+// }

--- a/src/Text/tests/Text.visual.js
+++ b/src/Text/tests/Text.visual.js
@@ -11,28 +11,32 @@ storiesOf('Text', module)
   ))
   .add('styles', () => (
     <div style={{ backgroundColor: '#f0f4f7' }}>
-      {Object.keys(WEIGHTS).map(weight =>
-        Object.keys(SIZES).map(size =>
-          Object.keys(SKINS).map(skin =>
-            [false, true].map(light =>
-              [false, true].map(secondary => (
-                <span style={{ margin: '12px' }}>
-                  <Text
-                    key={`${weight} ${size} ${skin} ${light} ${secondary}`}
-                    size={size}
-                    weight={weight}
-                    skin={skin}
-                    light={light}
-                    secondary={secondary}
-                  >
-                    Some Text
-                  </Text>
-                </span>
-              )),
-            ),
-          ),
-        ),
-      )}
+      {Object.keys(WEIGHTS).map(weight => (
+        <p>
+          {Object.keys(SIZES).map(size => (
+            <p>
+              {Object.keys(SKINS).map(skin =>
+                [false, true].map(light =>
+                  [false, true].map(secondary => (
+                    <span style={{ margin: '12px' }}>
+                      <Text
+                        key={`${weight} ${size} ${skin} ${light} ${secondary}`}
+                        size={size}
+                        weight={weight}
+                        skin={skin}
+                        light={light}
+                        secondary={secondary}
+                      >
+                        Some Text
+                      </Text>
+                    </span>
+                  )),
+                ),
+              )}
+            </p>
+          ))}
+        </p>
+      ))}
     </div>
   ));
 


### PR DESCRIPTION
still got some issues with the ellipsis visual test.
looks like it doesn't trigger on the initial rendering. in the protractor test, it worked only after scrolling.

The best option will be trying to solve it as part of the ellipsis HOC