### PR TITLE
fix forgotten static method

### DIFF
--- a/src/Search/Search.js
+++ b/src/Search/Search.js
@@ -61,10 +61,12 @@ class Search extends WixComponent {
     };
   }
 
-  getDerivedStateFromProps(props, state) {
+  static getDerivedStateFromProps(props, state) {
+    const isControlled = 'value' in props && 'onChange' in props;
+
     return {
       ...state,
-      inputValue: props.value,
+      inputValue: isControlled ? props.value : state.inputValue,
     };
   }
 


### PR DESCRIPTION
@argshook, we forgot to turn getDerivedStateFromProps to the static method. So I changed it a bit, all tests are passed, check it please.