### PR TITLE
omit getDerivedStateFromProps for the Search component

### DIFF
--- a/src/Search/Search.js
+++ b/src/Search/Search.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { polyfill } from 'react-lifecycles-compat';
 import isEmpty from 'lodash/isEmpty';
 
 import InputWithOptions from '../InputWithOptions';
@@ -203,4 +202,4 @@ class Search extends WixComponent {
   }
 }
 
-export default polyfill(Search);
+export default Search;

--- a/src/Search/Search.js
+++ b/src/Search/Search.js
@@ -61,15 +61,6 @@ class Search extends WixComponent {
     };
   }
 
-  static getDerivedStateFromProps(props, state) {
-    const isControlled = 'value' in props && 'onChange' in props;
-
-    return {
-      ...state,
-      inputValue: isControlled ? props.value : state.inputValue,
-    };
-  }
-
   componentDidUpdate(prevProps) {
     if (prevProps.value !== this.props.value) {
       this.setState({ inputValue: this.props.value });


### PR DESCRIPTION
@argshook hi! Let's discuss this change.
It seems like we don't need it because we reset the `value` in `componentDidUpdate`. What do you think?