### PR TITLE
DataTable: when receive new page of items rerender the table any way,…

### DIFF
--- a/src/DataTable/DataTable.js
+++ b/src/DataTable/DataTable.js
@@ -43,21 +43,13 @@ class DataTable extends React.Component {
     let isLoadingMore = false;
     if (this.props.infiniteScroll && nextProps.data !== this.props.data) {
       if (nextProps.data instanceof Array && this.props.data instanceof Array) {
-        if (
-          this.props.data.every((elem, index) => {
-            return (
-              nextProps.data.length > index && nextProps.data[index] === elem
-            );
-          })
-        ) {
-          isLoadingMore = true;
-          const lastPage = this.calcLastPage(nextProps);
-          const currentPage =
-            this.state.currentPage < lastPage
-              ? this.state.currentPage + 1
-              : this.state.currentPage;
-          this.setState({ lastPage, currentPage });
-        }
+        isLoadingMore = true;
+        const lastPage = this.calcLastPage(nextProps);
+        const currentPage =
+          this.state.currentPage < lastPage
+            ? this.state.currentPage + 1
+            : this.state.currentPage;
+        this.setState({ lastPage, currentPage });
       }
       if (!isLoadingMore) {
         this.setState(this.createInitialScrollingState(nextProps));


### PR DESCRIPTION
… delete the condition that check the new items are the same items (by ref) like the current items
 
As i describe in the issue:
https://github.com/wix/wix-style-react/issues/3350

In case of infinite scroll , when i scroll down to new page of items. the loader disappear and the new page doesn't render even after they are fetched (until i don't scroll the table again).
It happens because in `componentWillReceiveProps` there is a checking that the new items are the same items (by ref) like the current items. and it's not relevant because for example my item is mobx computed. so i just delete this if.

As desc
<!---
Thanks for submitting a pull request 😄 !
-->
