### PR TITLE
<InputArea/> Driver - add support for uncontrolled components

### DIFF
--- a/src/InputArea/InputArea.driver.js
+++ b/src/InputArea/InputArea.driver.js
@@ -19,10 +19,12 @@ const inputAreaDriverFactory = ({ element }) => {
     trigger: (trigger, event) =>
       ReactTestUtils.Simulate[trigger](textArea, event),
     focus: () => textArea.focus(),
-    enterText: text =>
+    enterText: text => {
+      textArea.value = text;
       ReactTestUtils.Simulate.change(textArea, {
         target: { name, value: text },
-      }),
+      });
+    },
     getValue: () => textArea.value,
     getName: () => name,
     getPlaceholder: () => textArea.placeholder,


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!---
- Be as descriptive as possible when explaining what was changed.
- Link to an issue if one exists
-->
### 🔦 Summary
InputArea.driver currently does not support the enterText() method on uncontrolled components. This is because it only simulates the change event, which has no effect unless someone is listening to it and updating the value.

A similar issue was solved for the `<Input/>` component using the same method, in [an earlier pull request](https://github.com/wix/wix-style-react/pull/2705/).

<!--- Please mark all checkbox. If one is not relevant - delete it -->
### ✅ Checklist
- 🔬 Change is tested
  - [✅] Component
