### PR TITLE
Dependency: update `jscodeshift` (now doesn't use deprecated `nomnom` package)

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
     "hoist-non-react-methods": "^1.1.0",
     "is-image": "^1.0.1",
     "is-url": "^1.2.2",
-    "jscodeshift": "^0.5.1",
+    "jscodeshift": "^0.6.4",
     "lodash": "^4.17.4",
     "moment": "2.22.2",
     "omit": "^1.0.1",


### PR DESCRIPTION
Due to `nomnom` deprecation, I get such a warning on my project install:

> npm WARN deprecated nomnom@1.8.1: Package no longer supported. Contact support@npmjs.com for more info.


`nomnom` is coming from `jscodeshift` which is a dependency of `wix-style-react` 

Since version `jscodeshift@0.6.2` it doesn't use `nomnom` anymore: https://github.com/facebook/jscodeshift/commit/3fc6ca1c1e4b95c13123cab59270057e33a0418a
