### PR TITLE
<PopoverMenu> adjust popover menu appendTo prop type

### DIFF
--- a/src/PopoverMenu/PopoverMenu.js
+++ b/src/PopoverMenu/PopoverMenu.js
@@ -7,7 +7,6 @@ import More from '../new-icons/More';
 import PopoverMenuItem from '../PopoverMenuItem';
 import classnames from 'classnames';
 import {
-  any,
   oneOf,
   oneOfType,
   bool,

--- a/src/PopoverMenu/PopoverMenu.js
+++ b/src/PopoverMenu/PopoverMenu.js
@@ -12,6 +12,8 @@ import {
   oneOfType,
   bool,
   element,
+  func,
+  instanceOf,
   number,
   string,
   func,
@@ -45,7 +47,7 @@ class PopoverMenu extends WixComponent {
      */
     appendToParent: bool,
     /** An element which will contain the popover  */
-    appendTo: any,
+    appendTo: oneOfType([element, instanceOf(Element), func, oneOf(['window', 'scrollParent', 'viewPort', 'parent'])]),
     /** Sets a zIndex to the popover  */
     zIndex: number,
     showArrow: bool,

--- a/src/PopoverMenu/PopoverMenu.js
+++ b/src/PopoverMenu/PopoverMenu.js
@@ -7,6 +7,7 @@ import More from '../new-icons/More';
 import PopoverMenuItem from '../PopoverMenuItem';
 import classnames from 'classnames';
 import {
+  any,
   oneOf,
   oneOfType,
   bool,
@@ -44,7 +45,7 @@ class PopoverMenu extends WixComponent {
      */
     appendToParent: bool,
     /** An element which will contain the popover  */
-    appendTo: element,
+    appendTo: any,
     /** Sets a zIndex to the popover  */
     zIndex: number,
     showArrow: bool,

--- a/src/PopoverMenu/PopoverMenu.js
+++ b/src/PopoverMenu/PopoverMenu.js
@@ -11,7 +11,6 @@ import {
   oneOfType,
   bool,
   element,
-  func,
   instanceOf,
   number,
   string,


### PR DESCRIPTION
the prop type for popover menu is very specific and does not correlate to the <Tooltip> component it uses. (it is spamming us with prop type warnings since we use a DOM element)
