### PR TITLE
<InputWithOptions /> testkit, fix when dropDirectionUp is true

### DIFF
--- a/src/InputWithOptions/InputWithOptions.driver.js
+++ b/src/InputWithOptions/InputWithOptions.driver.js
@@ -2,7 +2,9 @@ import inputDriverFactory from '../Input/Input.driver';
 import dropdownLayoutDriverFactory from '../DropdownLayout/DropdownLayout.driver';
 
 const inputWithOptionsDriverFactory = ({ element }) => {
-  const inputWrapper = element && element.childNodes[0];
+  const inputWrapper =
+    element && element.querySelector(`[data-hook=input-wrapper]`);
+
   const inputDriver =
     element &&
     inputDriverFactory({
@@ -12,7 +14,8 @@ const inputWithOptionsDriverFactory = ({ element }) => {
   const dropdownLayoutDriver =
     element &&
     dropdownLayoutDriverFactory({
-      element: element.childNodes[1].childNodes[0],
+      element: element.querySelector(`[data-hook=dropdown-layout-wrapper]`)
+        .childNodes[0],
     });
 
   const assertOptionsOpen = () => {

--- a/src/InputWithOptions/InputWithOptions.js
+++ b/src/InputWithOptions/InputWithOptions.js
@@ -171,7 +171,11 @@ class InputWithOptions extends WixComponent {
     return (
       <div>
         {dropDirectionUp ? this._renderDropdownLayout() : null}
-        <div data-input-parent className={this.inputClasses()}>
+        <div
+          data-input-parent
+          className={this.inputClasses()}
+          data-hook="input-wrapper"
+        >
           {this.renderInput()}
         </div>
         {!dropDirectionUp ? this._renderDropdownLayout() : null}

--- a/src/InputWithOptions/InputWithOptions.spec.js
+++ b/src/InputWithOptions/InputWithOptions.spec.js
@@ -80,6 +80,23 @@ describe('InputWithOptions', () => {
       expect(await dropdownLayoutDriver.isShown()).toBeFalsy();
     });
 
+    describe('dropDirectionUp property', () => {
+      it('should show DropdownLayout if text entered and dropdown direction is up', async () => {
+        const driver = createDriver(
+          <ControlledInputWithOptions
+            dropDirectionUp
+            showOptionsIfEmptyInput={false}
+            options={options}
+          />,
+        );
+
+        expect(await driver.dropdownLayoutDriver.isShown()).toBe(false);
+        await driver.inputDriver.focus();
+        await driver.inputDriver.enterText('some value');
+        expect(await driver.dropdownLayoutDriver.isShown()).toBe(true);
+      });
+    });
+
     describe('showOptionsIfEmptyInput property', () => {
       describe('show options if input is empty (default behaviour)', () => {
         it('should show DropdownLayout if input is empty and down arrow pressed', async () => {


### PR DESCRIPTION
### 🔦 Summary
<InputWithOptions /> testkit was failing when component with `dropDirectionUp` was rendered. This prop changes order of elements, but in testkit there was `element && element.childNodes[0]` which depends on the order. So changed testkit, that it would select by `data-hook`

### ✅ Checklist
- 🔬 Change is tested
  - [X] Component
