### PR TITLE
`<Tooltip/>` - revert back to inline-block to make it work

### DIFF
--- a/src/Tooltip/TooltipNext/Tooltip.st.css
+++ b/src/Tooltip/TooltipNext/Tooltip.st.css
@@ -30,7 +30,6 @@
 .root {
   -st-extends: Tooltip;
   -st-states: size(enum(small, medium));
-  display: inline;
 }
 
 


### PR DESCRIPTION
This PR is changing back to `inline-block` because other options that I tried just don't work. The trebling content part is not fixed, but at least the tooltip calculation part is ok.