### PR TITLE
<DataTable> - use row reference for rowDetails instead of row number

### DIFF
--- a/src/DataTable/DataTable.js
+++ b/src/DataTable/DataTable.js
@@ -29,7 +29,7 @@ DataTableHeader.propTypes = {
 class DataTable extends React.Component {
   constructor(props) {
     super(props);
-    let state = { selectedRows: {} };
+    let state = { selectedRows: new Map() };
     if (props.infiniteScroll) {
       state = { ...state, ...this.createInitialScrollingState(props) };
     }
@@ -142,7 +142,7 @@ class DataTable extends React.Component {
   onRowClick = (rowData, rowNum) => {
     const { onRowClick, rowDetails } = this.props;
     onRowClick && onRowClick(rowData, rowNum);
-    rowDetails && this.toggleRowDetails(rowNum);
+    rowDetails && this.toggleRowDetails(rowData);
   };
 
   renderRow = (rowData, rowNum, style) => {
@@ -228,7 +228,7 @@ class DataTable extends React.Component {
     ];
 
     if (rowDetails) {
-      const showDetails = !!this.state.selectedRows[rowNum];
+      const showDetails = !!this.state.selectedRows.get(rowData);
 
       rowsToRender.push(
         <tr
@@ -294,13 +294,17 @@ class DataTable extends React.Component {
   };
 
   toggleRowDetails = selectedRow => {
-    let selectedRows = { [selectedRow]: !this.state.selectedRows[selectedRow] };
-    if (this.props.allowMultiDetailsExpansion && !this.props.virtualized) {
-      selectedRows = Object.assign({}, this.state.selectedRows, {
-        [selectedRow]: !this.state.selectedRows[selectedRow],
-      });
-    }
-    this.setState({ selectedRows });
+    const { selectedRows } = this.state;
+
+    const allowMultipleRowDetails =
+      this.props.allowMultiDetailsExpansion && !this.props.virtualized;
+
+    const newSelectedRows = new Map([
+      ...(allowMultipleRowDetails ? [...selectedRows] : []),
+      [selectedRow, !selectedRows.get(selectedRow)],
+    ]);
+
+    this.setState({ selectedRows: newSelectedRows });
   };
 
   renderVirtualizedRow = ({ index, style }) =>


### PR DESCRIPTION
### 🔦 Summary

`rowDetails` is displayed according to row numbers saved in the component's state.
When row are appended to the beginning of the data, the state is not updated accordingly.
As a result, if a row is appended when another row's `rowDetails` is expanded, the `rowDetails` is shifted to a different row (due to invalid row numbers state)

### Checklist

- [ ] Change is tested - This fix is related to state changing over time - the only way to test it is to implement a consuming component that updates the state. I'm not sure if it's worth it, WDYT?
- [ ] Animation flickering - When appending rows, the `rowDetails` is positioned correctly but for some reason it re-triggers the expand animations
