### PR TITLE
<Table /> - exposed virtualized table List ref

### DIFF
--- a/src/DataTable/DataTable.js
+++ b/src/DataTable/DataTable.js
@@ -337,11 +337,13 @@ class DataTable extends React.Component {
       data,
       virtualizedTableHeight,
       virutalizedListRef,
+      onVirtualizedListScroll,
     } = this.props;
     return (
       <div data-hook={dataHook}>
         <List
           ref={virutalizedListRef}
+          onScroll={onVirtualizedListScroll}
           className={classNames(this.style.table, this.style.virtualized)}
           height={virtualizedTableHeight}
           itemCount={data.length}
@@ -606,7 +608,9 @@ DataTable.propTypes = {
   /** ++EXPERIMENTAL++ Set virtualized table row height */
   virtualizedLineHeight: PropTypes.number,
   /** ++EXPERIMENTAL++ Set ref on virtualized List containing table rows */
-  virutalizedListRef: PropTypes.function,
+  virutalizedListRef: PropTypes.any,
+  /** ++EXPERIMENTAL++ callback when virtualized List scrolled */
+  onVirtualizedListScroll: PropTypes.function,
   /** array of selected ids in the table. Note that `isRowSelected` prop provides greater selection logic flexibility and is recommended to use instead. */
   selectedRowsIds: PropTypes.arrayOf(
     PropTypes.oneOfType([PropTypes.string, PropTypes.number]),

--- a/src/DataTable/DataTable.js
+++ b/src/DataTable/DataTable.js
@@ -332,10 +332,16 @@ class DataTable extends React.Component {
   };
 
   renderVirtualizedTable = () => {
-    const { dataHook, data, virtualizedTableHeight } = this.props;
+    const {
+      dataHook,
+      data,
+      virtualizedTableHeight,
+      virutalizedListRef,
+    } = this.props;
     return (
       <div data-hook={dataHook}>
         <List
+          ref={virutalizedListRef}
           className={classNames(this.style.table, this.style.virtualized)}
           height={virtualizedTableHeight}
           itemCount={data.length}
@@ -599,6 +605,8 @@ DataTable.propTypes = {
   virtualizedTableHeight: PropTypes.number,
   /** ++EXPERIMENTAL++ Set virtualized table row height */
   virtualizedLineHeight: PropTypes.number,
+  /** ++EXPERIMENTAL++ Set ref on virtualized List containing table rows */
+  virutalizedListRef: PropTypes.function,
   /** array of selected ids in the table. Note that `isRowSelected` prop provides greater selection logic flexibility and is recommended to use instead. */
   selectedRowsIds: PropTypes.arrayOf(
     PropTypes.oneOfType([PropTypes.string, PropTypes.number]),

--- a/src/DataTable/DataTable.js
+++ b/src/DataTable/DataTable.js
@@ -610,7 +610,7 @@ DataTable.propTypes = {
   /** ++EXPERIMENTAL++ Set ref on virtualized List containing table rows */
   virutalizedListRef: PropTypes.any,
   /** ++EXPERIMENTAL++ callback when virtualized List scrolled */
-  onVirtualizedListScroll: PropTypes.function,
+  onVirtualizedListScroll: PropTypes.any,
   /** array of selected ids in the table. Note that `isRowSelected` prop provides greater selection logic flexibility and is recommended to use instead. */
   selectedRowsIds: PropTypes.arrayOf(
     PropTypes.oneOfType([PropTypes.string, PropTypes.number]),

--- a/src/DataTable/DataTable.js
+++ b/src/DataTable/DataTable.js
@@ -336,12 +336,12 @@ class DataTable extends React.Component {
       dataHook,
       data,
       virtualizedTableHeight,
-      virutalizedListRef,
+      virtualizedListRef,
     } = this.props;
     return (
       <div data-hook={dataHook}>
         <List
-          ref={virutalizedListRef}
+          ref={virtualizedListRef}
           className={classNames(this.style.table, this.style.virtualized)}
           height={virtualizedTableHeight}
           itemCount={data.length}
@@ -606,7 +606,7 @@ DataTable.propTypes = {
   /** ++EXPERIMENTAL++ Set virtualized table row height */
   virtualizedLineHeight: PropTypes.number,
   /** ++EXPERIMENTAL++ Set ref on virtualized List containing table rows */
-  virutalizedListRef: PropTypes.any,
+  virtualizedListRef: PropTypes.any,
   /** array of selected ids in the table. Note that `isRowSelected` prop provides greater selection logic flexibility and is recommended to use instead. */
   selectedRowsIds: PropTypes.arrayOf(
     PropTypes.oneOfType([PropTypes.string, PropTypes.number]),

--- a/src/DataTable/DataTable.js
+++ b/src/DataTable/DataTable.js
@@ -337,13 +337,11 @@ class DataTable extends React.Component {
       data,
       virtualizedTableHeight,
       virutalizedListRef,
-      onVirtualizedListScroll,
     } = this.props;
     return (
       <div data-hook={dataHook}>
         <List
           ref={virutalizedListRef}
-          onScroll={onVirtualizedListScroll}
           className={classNames(this.style.table, this.style.virtualized)}
           height={virtualizedTableHeight}
           itemCount={data.length}
@@ -609,8 +607,6 @@ DataTable.propTypes = {
   virtualizedLineHeight: PropTypes.number,
   /** ++EXPERIMENTAL++ Set ref on virtualized List containing table rows */
   virutalizedListRef: PropTypes.any,
-  /** ++EXPERIMENTAL++ callback when virtualized List scrolled */
-  onVirtualizedListScroll: PropTypes.any,
   /** array of selected ids in the table. Note that `isRowSelected` prop provides greater selection logic flexibility and is recommended to use instead. */
   selectedRowsIds: PropTypes.arrayOf(
     PropTypes.oneOfType([PropTypes.string, PropTypes.number]),

--- a/src/Page/Page.js
+++ b/src/Page/Page.js
@@ -519,6 +519,8 @@ Page.propTypes = {
   minWidth: PropTypes.number,
   /** Sets the height of the page (in px/vh/etc.) */
   height: PropTypes.string,
+  /** PageHeader prop minimized */
+  minimizedHeader: PropTypes.bool,
   /** Sets padding of the sides of the page */
   sidePadding: PropTypes.number,
   /** A css class to be applied to the component's root element */

--- a/src/Page/Page.js
+++ b/src/Page/Page.js
@@ -277,11 +277,8 @@ class Page extends WixComponent {
 
   _renderHeader() {
     const { minimized } = this.state;
-    const { minimizedHeader } = this.props;
     const { PageHeader: PageHeaderChild } = this._getNamedChildren();
     const dataHook = 'page-header-wrapper';
-    const isMinimized =
-      typeof minimizedHeader === 'undefined' ? minimized : minimizedHeader;
 
     return (
       PageHeaderChild && (
@@ -289,14 +286,14 @@ class Page extends WixComponent {
           data-hook={dataHook}
           key={dataHook}
           className={classNames(s.headerWrapper, {
-            [s.minimized]: isMinimized,
+            [s.minimized]: minimized,
           })}
           ref={ref => {
             this.headerWrapperRef = ref;
           }}
         >
           {React.cloneElement(PageHeaderChild, {
-            minimized: isMinimized,
+            minimized: minimized,
             hasBackgroundImage: this._hasBackgroundImage(),
             upgrade: true,
           })}
@@ -519,8 +516,6 @@ Page.propTypes = {
   minWidth: PropTypes.number,
   /** Sets the height of the page (in px/vh/etc.) */
   height: PropTypes.string,
-  /** PageHeader prop minimized */
-  minimizedHeader: PropTypes.bool,
   /** Sets padding of the sides of the page */
   sidePadding: PropTypes.number,
   /** A css class to be applied to the component's root element */

--- a/src/Page/Page.js
+++ b/src/Page/Page.js
@@ -293,7 +293,7 @@ class Page extends WixComponent {
           }}
         >
           {React.cloneElement(PageHeaderChild, {
-            minimized: minimized,
+            minimized,
             hasBackgroundImage: this._hasBackgroundImage(),
             upgrade: true,
           })}

--- a/src/Page/Page.js
+++ b/src/Page/Page.js
@@ -277,8 +277,11 @@ class Page extends WixComponent {
 
   _renderHeader() {
     const { minimized } = this.state;
+    const { minimizedHeader } = this.props;
     const { PageHeader: PageHeaderChild } = this._getNamedChildren();
     const dataHook = 'page-header-wrapper';
+    const isMinimized =
+      typeof minimizedHeader === 'undefined' ? minimized : minimizedHeader;
 
     return (
       PageHeaderChild && (
@@ -286,14 +289,14 @@ class Page extends WixComponent {
           data-hook={dataHook}
           key={dataHook}
           className={classNames(s.headerWrapper, {
-            [s.minimized]: minimized,
+            [s.minimized]: isMinimized,
           })}
           ref={ref => {
             this.headerWrapperRef = ref;
           }}
         >
           {React.cloneElement(PageHeaderChild, {
-            minimized,
+            minimized: isMinimized,
             hasBackgroundImage: this._hasBackgroundImage(),
             upgrade: true,
           })}

--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -296,6 +296,8 @@ Table.propTypes = {
   virtualizedTableHeight: PropTypes.number,
   /** ++EXPERIMENTAL++ Set virtualized table row height */
   virtualizedLineHeight: PropTypes.number,
+  /** ++EXPERIMENTAL++ Set ref on virtualized List containing table rows */
+  virutalizedListRef: PropTypes.function,
   /** The width of the fixed table. Can be in percentages or pixels. */
   width: PropTypes.string,
   /** Table styling. Supports `standard` and `neutral`. */

--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -298,8 +298,6 @@ Table.propTypes = {
   virtualizedLineHeight: PropTypes.number,
   /** ++EXPERIMENTAL++ Set ref on virtualized List containing table rows */
   virutalizedListRef: PropTypes.any,
-  /** ++EXPERIMENTAL++ callback when virtualized List scrolled */
-  onVirtualizedListScroll: PropTypes.any,
   /** The width of the fixed table. Can be in percentages or pixels. */
   width: PropTypes.string,
   /** Table styling. Supports `standard` and `neutral`. */

--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -297,7 +297,7 @@ Table.propTypes = {
   /** ++EXPERIMENTAL++ Set virtualized table row height */
   virtualizedLineHeight: PropTypes.number,
   /** ++EXPERIMENTAL++ Set ref on virtualized List containing table rows */
-  virutalizedListRef: PropTypes.any,
+  virtualizedListRef: PropTypes.any,
   /** The width of the fixed table. Can be in percentages or pixels. */
   width: PropTypes.string,
   /** Table styling. Supports `standard` and `neutral`. */

--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -298,6 +298,8 @@ Table.propTypes = {
   virtualizedLineHeight: PropTypes.number,
   /** ++EXPERIMENTAL++ Set ref on virtualized List containing table rows */
   virutalizedListRef: PropTypes.function,
+  /** ++EXPERIMENTAL++ callback when virtualized List scrolled */
+  onVirtualizedListScroll: PropTypes.function,
   /** The width of the fixed table. Can be in percentages or pixels. */
   width: PropTypes.string,
   /** Table styling. Supports `standard` and `neutral`. */

--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -297,9 +297,9 @@ Table.propTypes = {
   /** ++EXPERIMENTAL++ Set virtualized table row height */
   virtualizedLineHeight: PropTypes.number,
   /** ++EXPERIMENTAL++ Set ref on virtualized List containing table rows */
-  virutalizedListRef: PropTypes.function,
+  virutalizedListRef: PropTypes.any,
   /** ++EXPERIMENTAL++ callback when virtualized List scrolled */
-  onVirtualizedListScroll: PropTypes.function,
+  onVirtualizedListScroll: PropTypes.any,
   /** The width of the fixed table. Can be in percentages or pixels. */
   width: PropTypes.string,
   /** Table styling. Supports `standard` and `neutral`. */


### PR DESCRIPTION
### 🔦 Summary
Exposed virtualized table content List reference via prop. Trying to use `<Page />`  together with virtualized `<Table />` and get header shrinking functionality on scroll as in https://wix-style-react.now.sh/?selectedKind=Components%2FPage%20Examples&selectedStory=3.%20Stretched%20Table%20In%20Page&full=0&addons=0&stories=1&panelRight=0 . The problem is that `<Page />` header  shrinks when content is scrolled, so I need somehow scroll table when page is scrolled. Having ref to the virutalized list would help that.