### PR TITLE
Change root element to be inline-block

### DIFF
--- a/src/Text/Text.st.css
+++ b/src/Text/Text.st.css
@@ -20,6 +20,7 @@
     light,
     weight(enum(thin, normal, bold)), disabled;
 
+  display: inline-block;
   white-space: pre-line;
 }
 


### PR DESCRIPTION
Change root element to be from `inline` to `inline-block`
The reason for this change is that an `inline-block` allows to set a width and height on the element.
According to Zeplin, the height of the text should be fixed height.
After a short conversation with @wuwa we decided to change it.

Here's an example for the bug:
![image](https://user-images.githubusercontent.com/35173937/68776027-15afcf00-0638-11ea-9c03-2fe5895139bb.png)
Size: medium
left side as `inline` - **height: 18.86px** 👎🏼
right side as `inline-block`- **height: 24px** 👍🏼