### PR TITLE
(WIP) <modal> puppeteer testkit API doesn't work

### DIFF
--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -135,7 +135,7 @@ class Modal extends WixComponent {
     };
 
     const modalClasses = `${styles.modal} ${styles[theme]}`;
-    const portalClassName = classnames(styles.portal, {
+    const portalClassName = classnames(styles.portal, 'portal', {
       [styles.portalNonScrollable]: !scrollable,
     });
 

--- a/src/Modal/Modal.uni.driver.js
+++ b/src/Modal/Modal.uni.driver.js
@@ -1,7 +1,7 @@
 import { baseUniDriverFactory } from '../../test/utils/unidriver';
 
 export const modalUniDriverFactory = (base, body) => {
-  const getPortal = () => body.$('.portal');
+  const getPortal = () => body;
   const getOverlay = () => body.$('.ReactModal__Overlay');
   const getContent = () => body.$('.ReactModal__Content');
   const getCloseButton = () => body.$('[data-hook="modal-close-button"]');

--- a/src/Modal/Modal.uni.driver.js
+++ b/src/Modal/Modal.uni.driver.js
@@ -1,7 +1,7 @@
 import { baseUniDriverFactory } from '../../test/utils/unidriver';
 
 export const modalUniDriverFactory = (base, body) => {
-  const getPortal = () => body;
+  const getPortal = () => body.$('.portal');
   const getOverlay = () => body.$('.ReactModal__Overlay');
   const getContent = () => body.$('.ReactModal__Content');
   const getCloseButton = () => body.$('[data-hook="modal-close-button"]');


### PR DESCRIPTION
### 🔦 Summary

The modal test kit for puppeteer doesn't find the portal element and therefore his API doesn't work, probably because the portal classname becomes a hash.

So I just added a raw `portal` classname to the `react-modal` portal.

### ✅ Checklist

- 🔬 Change is tested
  - [x] Component
