### PR TITLE
Remove caret from ui core

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wix-style-react",
   "description": "wix-style-react",
-  "version": "6.58.0",
+  "version": "6.59.0",
   "main": "./dist/src/index.js",
   "module": "./dist/es/src/index.js",
   "sideEffects": [

--- a/package.json
+++ b/package.json
@@ -236,7 +236,7 @@
     "wix-animations": "^1.0.276",
     "wix-eventually": "^2.2.0",
     "wix-ui-backoffice": "^1.0.339",
-    "wix-ui-core": "^2.0.174",
+    "wix-ui-core": "2.0.542",
     "wix-ui-icons-common": "^2.0.9",
     "wix-ui-test-utils": "^1.0.151"
   },


### PR DESCRIPTION
Removing the caret from `wix-ui-core` dependency.
Making version 2.0.542 its final.