### PR TITLE
stop unwanted click event

### DIFF
--- a/src/Checkbox/Checkbox.js
+++ b/src/Checkbox/Checkbox.js
@@ -130,6 +130,7 @@ class Checkbox extends WixComponent {
           checked={checked}
           disabled={disabled}
           onChange={disabled ? null : onChange}
+          onClick={e => e.stopPropagation()}
           style={{ display: 'none' }}
         />
 


### PR DESCRIPTION
### 🔦 Summary
MultiSelectCheckbox component has an annoying bug where you cant check the checkbox by clicking the node itself.
there is a click event on the input that causes the option that was just selected to get unselected right after.

you can reproduce the problem in the component [playground](https://wix-style-react.now.sh/?path=/story/components-api-components--multiselectcheckbox) - try to check the option by clicking the text/icons.


### ✅ Checklist
- 🔬 Change is tested
  - [x] Visual test
