### PR TITLE
Fix clickRowCheckbox in <Table> teskit

### DIFF
--- a/src/Table/Table.driver.js
+++ b/src/Table/Table.driver.js
@@ -8,9 +8,8 @@ const tableDriverFactory = ({ element, eventTrigger }) => {
   });
   const getTitlebar = () =>
     element.querySelector('[data-hook="table-title-bar"]');
-  const getRowSelectionCell = index => dataTableDriver.getCell(index, 0);
   const getRowCheckbox = index =>
-    getRowSelectionCell(index).querySelector('[data-hook="row-select"]');
+    dataTableDriver.getCell(index, 0).querySelector('[data-hook="row-select"]');
   const getRowCheckboxDriver = index =>
     checkboxDriverFactory({
       element: getRowCheckbox(index),
@@ -63,10 +62,10 @@ const tableDriverFactory = ({ element, eventTrigger }) => {
       deprecationLog(
         '"clickRowChecbox" method is deprecated (because of typo) and will be removed in next major release, please use "clickRowCheckbox" driver method',
       );
-      return getRowSelectionCell(index).click();
+      return eventTrigger.click(getRowCheckbox(index));
     },
     /** Click the row selection checkbox */
-    clickRowCheckbox: index => getRowSelectionCell(index).click(),
+    clickRowCheckbox: index => eventTrigger.click(getRowCheckbox(index)),
     /** Click the bulk-selection checkbox */
     clickBulkSelectionCheckbox: () => getBulkSelectionCheckboxDriver().click(),
     /** Is row selected by index */

--- a/src/Table/Table.driver.js
+++ b/src/Table/Table.driver.js
@@ -8,8 +8,9 @@ const tableDriverFactory = ({ element, eventTrigger }) => {
   });
   const getTitlebar = () =>
     element.querySelector('[data-hook="table-title-bar"]');
+  const getRowSelectionCell = index => dataTableDriver.getCell(index, 0);
   const getRowCheckbox = index =>
-    dataTableDriver.getCell(index, 0).querySelector('[data-hook="row-select"]');
+    getRowSelectionCell(index).querySelector('[data-hook="row-select"]');
   const getRowCheckboxDriver = index =>
     checkboxDriverFactory({
       element: getRowCheckbox(index),
@@ -62,10 +63,10 @@ const tableDriverFactory = ({ element, eventTrigger }) => {
       deprecationLog(
         '"clickRowChecbox" method is deprecated (because of typo) and will be removed in next major release, please use "clickRowCheckbox" driver method',
       );
-      return getRowCheckboxDriver(index).click();
+      return getRowSelectionCell(index).click();
     },
     /** Click the row selection checkbox */
-    clickRowCheckbox: index => getRowCheckbox(index).click(),
+    clickRowCheckbox: index => getRowSelectionCell(index).click(),
     /** Click the bulk-selection checkbox */
     clickBulkSelectionCheckbox: () => getBulkSelectionCheckboxDriver().click(),
     /** Is row selected by index */

--- a/src/Table/Table.uni.driver.js
+++ b/src/Table/Table.uni.driver.js
@@ -5,8 +5,10 @@ import deprecationLog from '../utils/deprecationLog';
 
 export const tableUniDriverFactory = base => {
   const dataTableDriver = dataTablePrivateUniDriverFactory(base);
+  const getRowSelectionCell = async index =>
+    await dataTableDriver.getCell(index, 0);
   const getRowCheckbox = async index =>
-    (await dataTableDriver.getCell(index, 0)).$('[data-hook="row-select"]');
+    (await getRowSelectionCell(index)).$('[data-hook="row-select"]');
   const getRowCheckboxDriver = async index =>
     checkboxUniDriverFactory(await getRowCheckbox(index));
   const getBulkSelectionCheckboxDriver = async () => {
@@ -53,9 +55,9 @@ export const tableUniDriverFactory = base => {
       deprecationLog(
         '"clickRowChecbox" method is deprecated (because of typo) and will be removed in next major release, please use "clickRowCheckbox" driver method',
       );
-      return (await getRowCheckbox(index)).click();
+      return (await getRowSelectionCell(index)).click();
     },
-    clickRowCheckbox: async index => (await getRowCheckbox(index)).click(),
+    clickRowCheckbox: async index => (await getRowSelectionCell(index)).click(),
     /** Click the bulk-selection checkbox */
     clickBulkSelectionCheckbox: async () =>
       (await getBulkSelectionCheckboxDriver()).click(),

--- a/src/Table/Table.uni.driver.js
+++ b/src/Table/Table.uni.driver.js
@@ -10,11 +10,6 @@ export const tableUniDriverFactory = base => {
     (await dataTableDriver.getCell(index, 0)).$('[data-hook="row-select"]');
   const getRowCheckboxDriver = async index =>
     checkboxUniDriverFactory(await getRowCheckbox(index));
-  const simulateClick =
-    base.type === 'react'
-      ? // eslint-disable-next-line no-restricted-properties
-        async element => Simulate.click(await element.getNative())
-      : async element => base.click();
   const getBulkSelectionCheckboxDriver = async () => {
     const cell = await dataTableDriver.getHeaderCell(0);
     return checkboxUniDriverFactory(await cell.$('[data-hook="table-select"]'));
@@ -59,9 +54,9 @@ export const tableUniDriverFactory = base => {
       deprecationLog(
         '"clickRowChecbox" method is deprecated (because of typo) and will be removed in next major release, please use "clickRowCheckbox" driver method',
       );
-      return simulateClick(await getRowCheckbox(index));
+      return (await getRowCheckbox(index)).click();
     },
-    clickRowCheckbox: async index => simulateClick(await getRowCheckbox(index)),
+    clickRowCheckbox: async index => (await getRowCheckbox(index)).click(),
     /** Click the bulk-selection checkbox */
     clickBulkSelectionCheckbox: async () =>
       (await getBulkSelectionCheckboxDriver()).click(),

--- a/src/Table/Table.uni.driver.js
+++ b/src/Table/Table.uni.driver.js
@@ -2,7 +2,6 @@ import { baseUniDriverFactory, getElement } from '../../test/utils/unidriver';
 import { dataTablePrivateUniDriverFactory } from '../DataTable/DataTable.private.uni.driver';
 import { checkboxUniDriverFactory } from '../Checkbox/Checkbox.uni.driver';
 import deprecationLog from '../utils/deprecationLog';
-import { Simulate } from 'react-dom/test-utils';
 
 export const tableUniDriverFactory = base => {
   const dataTableDriver = dataTablePrivateUniDriverFactory(base);

--- a/src/Table/Table.uni.driver.js
+++ b/src/Table/Table.uni.driver.js
@@ -2,15 +2,19 @@ import { baseUniDriverFactory, getElement } from '../../test/utils/unidriver';
 import { dataTablePrivateUniDriverFactory } from '../DataTable/DataTable.private.uni.driver';
 import { checkboxUniDriverFactory } from '../Checkbox/Checkbox.uni.driver';
 import deprecationLog from '../utils/deprecationLog';
+import { Simulate } from 'react-dom/test-utils';
 
 export const tableUniDriverFactory = base => {
   const dataTableDriver = dataTablePrivateUniDriverFactory(base);
-  const getRowSelectionCell = async index =>
-    await dataTableDriver.getCell(index, 0);
   const getRowCheckbox = async index =>
-    (await getRowSelectionCell(index)).$('[data-hook="row-select"]');
+    (await dataTableDriver.getCell(index, 0)).$('[data-hook="row-select"]');
   const getRowCheckboxDriver = async index =>
     checkboxUniDriverFactory(await getRowCheckbox(index));
+  const simulateClick =
+    base.type === 'react'
+      ? // eslint-disable-next-line no-restricted-properties
+        async element => Simulate.click(await element.getNative())
+      : async element => base.click();
   const getBulkSelectionCheckboxDriver = async () => {
     const cell = await dataTableDriver.getHeaderCell(0);
     return checkboxUniDriverFactory(await cell.$('[data-hook="table-select"]'));
@@ -55,9 +59,9 @@ export const tableUniDriverFactory = base => {
       deprecationLog(
         '"clickRowChecbox" method is deprecated (because of typo) and will be removed in next major release, please use "clickRowCheckbox" driver method',
       );
-      return (await getRowSelectionCell(index)).click();
+      return simulateClick(await getRowCheckbox(index));
     },
-    clickRowCheckbox: async index => (await getRowSelectionCell(index)).click(),
+    clickRowCheckbox: async index => simulateClick(await getRowCheckbox(index)),
     /** Click the bulk-selection checkbox */
     clickBulkSelectionCheckbox: async () =>
       (await getBulkSelectionCheckboxDriver()).click(),


### PR DESCRIPTION
### 🔦 Summary
In https://github.com/wix/wix-style-react/pull/4759, we moved the click handler from the `<Input>` handle to the cell's `<td>` element.
This causes [contacts-web build](http://tc.dev.wixpress.com/viewLog.html?buildId=113652212&buildTypeId=Wix_CRM_Contacts_ContactsWeb) and [sites-list build](http://tc.dev.wixpress.com/viewLog.html?buildId=113655850&buildTypeId=SitesList_SitesList) to break.

This PR is meant to fix it, by making the testkit methods click the cell and not the checkbox.

I have no idea how come `Table.spec.js`, which uses the same testkit methods, didn't help. I'd love to hear your view on this.