### PR TITLE
`<Tooltip/>`, `<Popover/>`, `EllipsisHOC` - migrate to dynamic loading

### DIFF
--- a/src/DropdownBase/test/DropdownBase.spec.js
+++ b/src/DropdownBase/test/DropdownBase.spec.js
@@ -127,7 +127,7 @@ describe('DropdownBase', () => {
     const onClickOutsideFn = jest.fn();
 
     const driver = createDriver(
-      <DropdownBase {...defaultProps} onClickOutside={onClickOutsideFn}>
+      <DropdownBase {...defaultProps} open onClickOutside={onClickOutsideFn}>
         <div>Hello</div>
       </DropdownBase>,
     );

--- a/src/InputWithOptions/InputWithOptions.spec.js
+++ b/src/InputWithOptions/InputWithOptions.spec.js
@@ -423,12 +423,18 @@ describe('InputWithOptions', () => {
 
     it('should trigger callback function on clicking outside', async () => {
       const handleClickOutside = jest.fn();
-      const { driver } = createDriver(
+
+      const { driver, dropdownLayoutDriver } = createDriver(
         <InputWithOptions
           options={options}
+          closeOnSelect={false}
           onClickOutside={handleClickOutside}
         />,
       );
+
+      await driver.pressKey('ArrowDown');
+      expect(await dropdownLayoutDriver.isShown()).toBe(true);
+
       await driver.outsideClick();
       expect(handleClickOutside).toHaveBeenCalled();
     });

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Popover as CorePopover } from 'wix-ui-core/dist/src/components/popover';
+import { PopoverNext as CorePopover } from 'wix-ui-core/dist/src/components/popover-next';
 import { buildChildrenObject } from 'wix-ui-core/dist/src/utils';
 import requestAnimationFramePolyfill from '../utils/request-animation-frame';
 

--- a/src/Tooltip/TooltipNext/Tooltip.js
+++ b/src/Tooltip/TooltipNext/Tooltip.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Tooltip as CoreTooltip } from 'wix-ui-core/dist/src/components/tooltip';
+import { TooltipNext } from 'wix-ui-core';
 import Text from '../../Text';
 import styles from './Tooltip.st.css';
 
@@ -105,7 +105,7 @@ class Tooltip extends React.PureComponent {
     } = this.props;
 
     return (
-      <CoreTooltip
+      <TooltipNext
         {...rest}
         {...(dataHook ? { 'data-hook': dataHook } : {})}
         {...styles('root', { size }, this.props)}
@@ -120,7 +120,7 @@ class Tooltip extends React.PureComponent {
         showArrow
       >
         {children}
-      </CoreTooltip>
+      </TooltipNext>
     );
   }
 }

--- a/src/Tooltip/TooltipNext/Tooltip.js
+++ b/src/Tooltip/TooltipNext/Tooltip.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { TooltipNext } from 'wix-ui-core';
+import { TooltipNext } from 'wix-ui-core/dist/src/components/tooltip-next';
 import Text from '../../Text';
 import styles from './Tooltip.st.css';
 

--- a/src/common/EllipsisHOC/EllipsisHOC.js
+++ b/src/common/EllipsisHOC/EllipsisHOC.js
@@ -3,7 +3,7 @@ import { withEllipsedTooltipNext } from 'wix-ui-core/dist/src/hocs/EllipsedToolt
 import { ZIndex } from '../../ZIndex';
 import tooltip from './EllipsisHOC.st.css';
 
-export const EllipsisHOC = React.forwardRef(({ Component, props }, ref) => {
+export default React.forwardRef(({ Component, props }, ref) => {
   const {
     flip,
     fixed,

--- a/src/common/EllipsisHOC/EllipsisHOC.js
+++ b/src/common/EllipsisHOC/EllipsisHOC.js
@@ -3,7 +3,7 @@ import { withEllipsedTooltipNext } from 'wix-ui-core/dist/src/hocs/EllipsedToolt
 import { ZIndex } from '../../ZIndex';
 import tooltip from './EllipsisHOC.st.css';
 
-export default React.forwardRef(({ Component, props }, ref) => {
+export const EllipsisHOC = React.forwardRef(({ Component, props }, ref) => {
   const {
     flip,
     fixed,

--- a/src/common/EllipsisHOC/EllipsisHOC.js
+++ b/src/common/EllipsisHOC/EllipsisHOC.js
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { withEllipsedTooltip } from 'wix-ui-core/dist/src/hocs/EllipsedTooltip';
+import { withEllipsedTooltipNext } from 'wix-ui-core/dist/src/hocs/EllipsedTooltip';
 import { ZIndex } from '../../ZIndex';
 import tooltip from './EllipsisHOC.st.css';
 
@@ -34,7 +34,7 @@ export default React.forwardRef(({ Component, props }, ref) => {
 
   const EllipsedComponent = useMemo(
     () =>
-      withEllipsedTooltip({
+      withEllipsedTooltipNext({
         showTooltip,
         tooltipProps,
       })(Component),

--- a/src/common/EllipsisHOC/index.js
+++ b/src/common/EllipsisHOC/index.js
@@ -10,12 +10,7 @@ import {
   number,
 } from 'prop-types';
 
-/**
- * Here we need to use loadable for now because React.lazy is
- * not supporting SSR yet.
- */
-import loadable from '@loadable/component';
-import { retry } from './utils';
+import Ellipsed from './EllipsisHOC';
 
 const validTooltipProps = [
   'flip',
@@ -45,8 +40,6 @@ const fallbackEllipsis = {
   whiteSpace: 'noWrap',
 };
 
-const LazyEllipsisHOC = loadable(() => retry(() => import('./EllipsisHOC')));
-
 const Comp /** @autodocs-component */ = Component => {
   return React.memo(
     React.forwardRef(({ ellipsis, ...props }, ref) => {
@@ -54,7 +47,7 @@ const Comp /** @autodocs-component */ = Component => {
 
       if (ellipsis) {
         return (
-          <LazyEllipsisHOC
+          <Ellipsed
             ref={ref}
             fallback={
               <Component


### PR DESCRIPTION
This PR is a preparation to migrate Tooltip to dynamic loading.