### PR TITLE
Adding the Cheatsheet to the generator 

### DIFF
--- a/.wuf/generator/codemods/components-index-file.js
+++ b/.wuf/generator/codemods/components-index-file.js
@@ -1,0 +1,21 @@
+module.exports = (file, api, options) => {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  const { ComponentName } = options;
+
+  const exports = root.find(j.ExportNamedDeclaration).paths();
+
+  j(exports[exports.length - 1]).insertAfter(
+    `
+/**
+ * Unclassified Components.
+ * TODO: move to the relevant family
+ */
+export const unclassifiedComponentsNames = {
+   ${ComponentName}: ' ${ComponentName}',
+};
+    `,
+  );
+
+  return root.toSource();
+};

--- a/.wuf/generator/codemods/index.js
+++ b/.wuf/generator/codemods/index.js
@@ -19,4 +19,19 @@ module.exports = [
     dist: 'perfer.config.js',
     description: 'Add new threshold for new component',
   },
+  {
+    codemod: 'components-index-file.js',
+    dist: 'stories/symbolsComponentsMapping/components.js',
+    description : 'Add component to components mapping file'
+  },
+  {
+    codemod: 'symbols-index-file.js',
+    dist: 'stories/symbolsComponentsMapping/symbols.js',
+    description: 'Add UX symbol to symbols mapping file'
+  },
+  {
+    codemod: 'symbol-to-component-file.js',
+    dist: 'stories/symbolsComponentsMapping/families/unclassifiedFamily.js',
+    description: 'Add symbol to component mapping',
+  }
 ];

--- a/.wuf/generator/codemods/symbol-to-component-file.js
+++ b/.wuf/generator/codemods/symbol-to-component-file.js
@@ -1,0 +1,30 @@
+module.exports = (file, api, options) => {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  const { componentName, ComponentName } = options;
+
+  root.get().node.program.body.push(
+    `
+/* Placeholder file when generating a new component */
+
+/**
+ * TODO: move to the relevant family file
+ */
+ import { unclassifiedSymbols } from '../symbols';
+ import {
+  unclassifiedComponentsNames as componentsNames,
+  sharedComponentsNames,
+ } from '../components';
+
+ export const unclassifiedSymbolsToComponents = {
+    [unclassifiedSymbols.${componentName}]: [
+        componentsNames.${ComponentName} ,
+        sharedComponentsNames.FormField
+    ]
+ };
+    `
+  );
+
+  return root.toSource();
+};

--- a/.wuf/generator/codemods/symbols-index-file.js
+++ b/.wuf/generator/codemods/symbols-index-file.js
@@ -1,0 +1,21 @@
+module.exports = (file, api, options) => {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  const { componentName, ComponentName } = options;
+
+  const exports = root.find(j.ExportNamedDeclaration).paths();
+
+  j(exports[exports.length - 1]).insertAfter(
+    `
+/**
+ * Unclassified UX symbol.
+ * TODO: move to the relevant family
+ */
+export const unclassifiedSymbols = {
+  ${componentName}: '13.1 ${ComponentName}',
+};
+    `,
+  );
+
+  return root.toSource();
+};

--- a/stories/Introduction/Cheatsheet/ComponentsCheatsheet.js
+++ b/stories/Introduction/Cheatsheet/ComponentsCheatsheet.js
@@ -3,6 +3,7 @@ import { Container, Row } from 'wix-style-react/Grid';
 import Page from 'wix-style-react/Page';
 
 // importing components by family type
+import UnclassifiedFamily from './componentsFamilies/UnclassifiedFamily';
 import FoundationFamily from './componentsFamilies/FoundationFamily';
 import LayoutFamily from './componentsFamilies/LayoutFamily/LayoutFamily';
 import InputFamily from './componentsFamilies/InputFamily';
@@ -19,6 +20,7 @@ import ContentWidgetsFamily from './componentsFamilies/ContentWidgetsFamily';
 class ComponentsCheatsheet extends React.Component {
   render() {
     const componentsFamiliesArr = [
+      UnclassifiedFamily,
       FoundationFamily,
       LayoutFamily,
       InputFamily,

--- a/stories/Introduction/Cheatsheet/componentsFamilies/UnclassifiedFamily.js
+++ b/stories/Introduction/Cheatsheet/componentsFamilies/UnclassifiedFamily.js
@@ -1,0 +1,16 @@
+/* Placeholder file for unclassified family when generating a new component */
+
+/* eslint-disable no-console */
+import React from 'react';
+import { FamilyStructure } from '../sharedComponents';
+
+const UnclassifiedFamily = () => {
+  return (
+    <FamilyStructure
+      title="TODO: should be removed"
+      showPreview
+    ></FamilyStructure>
+  );
+};
+
+export default UnclassifiedFamily;

--- a/stories/Introduction/Cheatsheet/sharedComponents/FamilyStructure.js
+++ b/stories/Introduction/Cheatsheet/sharedComponents/FamilyStructure.js
@@ -4,29 +4,30 @@ import { Container, Row, Col } from 'wix-style-react/Grid';
 import Card from 'wix-style-react/Card';
 import Heading from 'wix-style-react/Heading';
 
-const FamilyStructure = ({ title, children, showPreview }) => (
-  <Card>
-    <Card.Header title={title} />
-    <Card.Content>
-      <Container fluid>
-        <Row>
-          <Col span={4}>
-            <Heading appearance="H5" light>
-              INDEX NAME & I.C.
-            </Heading>
-          </Col>
-          <Col span={8}>
-            {showPreview && (
+const FamilyStructure = ({ title, children, showPreview }) =>
+  children ? (
+    <Card>
+      <Card.Header title={title} />
+      <Card.Content>
+        <Container fluid>
+          <Row>
+            <Col span={4}>
               <Heading appearance="H5" light>
-                PREVIEW
+                INDEX NAME & I.C.
               </Heading>
-            )}
-          </Col>
-        </Row>
-        {children}
-      </Container>
-    </Card.Content>
-  </Card>
-);
+            </Col>
+            <Col span={8}>
+              {showPreview && (
+                <Heading appearance="H5" light>
+                  PREVIEW
+                </Heading>
+              )}
+            </Col>
+          </Row>
+          {children}
+        </Container>
+      </Card.Content>
+    </Card>
+  ) : null;
 
 export default FamilyStructure;

--- a/stories/symbolsComponentsMapping/families/unclassifiedFamily.js
+++ b/stories/symbolsComponentsMapping/families/unclassifiedFamily.js
@@ -1,0 +1,1 @@
+/* Placeholder file when generating a new component */


### PR DESCRIPTION
### 🔦 Summary
Adding the generated components to the Cheatsheet.
Resolves #4885 

### ✅ Checklist
#### Maping the symbol to the names of the components:
  - [x] Adding the component name to the components index. **Codemod** `components-index-file.js`.
  - [x] Adding a symbol name to UX symbols index. **Codemod**  `symbols-file.js`.
  - [x] Adding an example of Symbol To Component mapping. **Codemod** `symbol-to-component-file.js`.

#### Adding an example to the cheatsheet:
  - [ ] Adding the generated example to `<UnclassifiedFamily/>`



