### PR TITLE
<VariableInput/> - change composition to use FormField's suffix 

### DIFF
--- a/stories/VariableInput/examples.js
+++ b/stories/VariableInput/examples.js
@@ -21,14 +21,12 @@ const _actionExample = ({
   required = false,
   labelPlacement = false,
 } = {}) => `
-<div style={{position: 'relative', ${
-  labelPlacement ? `minHeight: '66px', paddingTop: '30px',` : ''
-}}}>
   <FormField
     ${labelPlacement === 'right' ? '' : 'label="Variable Input"'}
     ${info ? 'infoContent="I help you to fill info"' : ''}
     ${required ? 'required' : ''}
     ${labelPlacement ? `labelPlacement="${labelPlacement}"` : ''}
+    ${action ? `suffix={${dropDown}}` : ''}
     >
       <VariableInput
         initialValue="${initialValue}"
@@ -38,12 +36,6 @@ const _actionExample = ({
         ${action ? `ref={ref => {this._ref = ref}}` : ''}
       />
   </FormField>
-  <Box position="absolute" top={3} right={${
-    labelPlacement === 'right' ? 40 : 0
-  }}>
-      ${action ? dropDown : ''}
-  </Box>
-</div>
 `;
 const _cellWrapper = (title, content) => {
   return `<Cell>

--- a/stories/VariableInput/index.story.js
+++ b/stories/VariableInput/index.story.js
@@ -46,8 +46,7 @@ export default {
     columns([
       description({
         title: 'Description',
-        text: `Variable Input enables the user to insert given tags (variables) as well as free text inside an input. This component can be used to build various forms.
-        Variable Input is a composition of 3 individual components: FormField, VariableInput. It might include Dropdown to insert new variables`,
+        text: `Variable Input enables the user to insert given tags (variables) as well as free text inside an input. This component can be used to build various forms.`,
       }),
     ]),
 
@@ -68,6 +67,13 @@ export default {
               story="TextButton"
             >{`<TextButton/>`}</LinkTo>,
             'Component to trigger the action',
+          ],
+          [
+            <LinkTo
+              kind={Category.BETA}
+              story="PopoverMenu"
+            >{`<PopoverMenu/>`}</LinkTo>,
+            'Component to insert new variables',
           ],
           [
             <LinkTo


### PR DESCRIPTION
This PR changes the docs to show a better practice to compose the VariableInput with some actions using the FormField's suffix prop.