### PR TITLE
Updated DropdownBase testkit docs

### DIFF
--- a/src/DropdownBase/DropdownBase.uni.driver.js
+++ b/src/DropdownBase/DropdownBase.uni.driver.js
@@ -41,7 +41,7 @@ export const dropdownBaseDriverFactory = (base, body) => {
     /** Click outside of the component */
     clickOutside: () => testkit(base, body).clickOutside(),
 
-    /** Options count */
+    /** Options count (requires the DropdownBase to be opened) */
     optionsCount: async () =>
       (await createDropdownLayoutDriver()).optionsLength(),
 


### PR DESCRIPTION
optionsCount also requires the dropdown to be opened

<!---
Thanks for submitting a pull request 😄 !
-->

<!---
- Be as descriptive as possible when explaining what was changed.
- Link to an issue if one exists
-->

### 🔦 Summary

Updated DropdownBase testkit docs, `optionsCount()` also requires the dropdown to be open

<!--- Please mark all checkbox. If one is not relevant - delete it -->

### ✅ Checklist
- 📚 Change is documented
  - [x] Other - the change is in the documentation.
- 🔬 Change is tested
  - [x] Component
