### PR TITLE
<TableActionCell/> - add `divider` field for the secondary actions

### DIFF
--- a/src/TableActionCell/TableActionCell.driver.js
+++ b/src/TableActionCell/TableActionCell.driver.js
@@ -1,8 +1,9 @@
-import popoverMenuDriverFactory from '../PopoverMenu/PopoverMenu.driver';
-import { PopoverMenuTestkit } from '../../testkit/beta';
-import tooltipDriverFactory from '../Tooltip/Tooltip.driver';
-import buttonDriverFactory from '../Deprecated/Button/Button.driver.js';
 import { INTERNAL_DRIVER_SYMBOL } from '../../test/utils/private-drivers';
+import { PopoverMenuTestkit } from '../../testkit/beta';
+import buttonDriverFactory from '../Deprecated/Button/Button.driver.js';
+import popoverMenuDriverFactory from '../PopoverMenu/PopoverMenu.driver';
+import tooltipDriverFactory from '../Tooltip/Tooltip.driver';
+import { dataHooks } from './constants';
 
 const tableActionCellDriverFactory = ({ element, wrapper, component }) => {
   const getPrimaryActionPlaceholder = () =>
@@ -99,7 +100,7 @@ const tableActionCellDriverFactory = ({ element, wrapper, component }) => {
     clickPopoverMenu: () =>
       upgrade
         ? getHiddenActionsPopoverMenuDriver()
-            .getTriggerElement('table-action-cell-trigger-element')
+            .getTriggerElement(dataHooks.triggerElement)
             .click()
         : getHiddenActionsPopoverMenuDriver().click(),
     /** Click on a hidden secondary action (requires the <PopoverMenu/> to be open) */

--- a/src/TableActionCell/TableActionCell.js
+++ b/src/TableActionCell/TableActionCell.js
@@ -1,16 +1,16 @@
-import React from 'react';
 import PropTypes from 'prop-types';
-import More from 'wix-ui-icons-common/More';
+import React from 'react';
 import ChevronRight from 'wix-ui-icons-common/ChevronRight';
-
-import style from './TableActionCell.st.css';
-import HoverSlot from './HoverSlot';
-import Tooltip from '../Tooltip/Tooltip';
+import More from 'wix-ui-icons-common/More';
+import PopoverMenu from '../beta/PopoverMenu';
 import Button from '../Deprecated/Button';
 import IconButton from '../IconButton';
-import PopoverMenu from '../beta/PopoverMenu';
 import OldPopoverMenu from '../PopoverMenu';
 import OldPopoverMenuItem from '../PopoverMenuItem';
+import Tooltip from '../Tooltip/Tooltip';
+import { dataHooks } from './constants';
+import HoverSlot from './HoverSlot';
+import style from './TableActionCell.st.css';
 
 /* eslint-disable react/prop-types */
 function renderPrimaryAction({ text, theme, onClick, disabled }) {
@@ -71,10 +71,7 @@ function renderHiddenActions(actions, popoverMenuProps, upgrade) {
       placement="top"
       textSize="small"
       triggerElement={
-        <IconButton
-          skin="inverted"
-          dataHook="table-action-cell-trigger-element"
-        >
+        <IconButton skin="inverted" dataHook={dataHooks.triggerElement}>
           <More />
         </IconButton>
       }
@@ -210,7 +207,7 @@ TableActionCell.propTypes = {
    * `disabled` is an optional prop for the secondary action to be disabled
    * `dataHook` is an optional prop for accessing the action in tests
    * 'disabledDescription' is an optional prop that indicates what string to display in tooltip when action is visible and disabled (if non is provided, the text prop is used)
-   * 'divider' is an optional prop to display a divider between the items (supported only when `upgrade` prop is enabled)
+   * 'divider' is an optional prop to display a divider between the action items (supported only when `upgrade` prop is enabled)
    */
   secondaryActions: PropTypes.arrayOf(
     PropTypes.shape({

--- a/src/TableActionCell/TableActionCell.js
+++ b/src/TableActionCell/TableActionCell.js
@@ -80,16 +80,21 @@ function renderHiddenActions(actions, popoverMenuProps, upgrade) {
       }
       {...popoverMenuProps}
     >
-      {actions.map(({ text, icon, onClick, disabled, dataHook }, index) => (
-        <PopoverMenu.MenuItem
-          key={index}
-          dataHook={dataHook || 'table-action-cell-popover-menu-item'}
-          prefixIcon={icon}
-          onClick={() => onClick()}
-          text={text}
-          disabled={disabled}
-        />
-      ))}
+      {actions.map(
+        ({ text, icon, onClick, disabled, dataHook, divider }, index) =>
+          !divider ? (
+            <PopoverMenu.MenuItem
+              key={index}
+              dataHook={dataHook || 'table-action-cell-popover-menu-item'}
+              prefixIcon={icon}
+              onClick={() => onClick()}
+              text={text}
+              disabled={disabled}
+            />
+          ) : (
+            <PopoverMenu.Divider />
+          ),
+      )}
     </PopoverMenu>
   ) : (
     <OldPopoverMenu
@@ -205,6 +210,7 @@ TableActionCell.propTypes = {
    * `disabled` is an optional prop for the secondary action to be disabled
    * `dataHook` is an optional prop for accessing the action in tests
    * 'disabledDescription' is an optional prop that indicates what string to display in tooltip when action is visible and disabled (if non is provided, the text prop is used)
+   * 'divider' is an optional prop to display a divider between the items (supported only when `upgrade` prop is enabled)
    */
   secondaryActions: PropTypes.arrayOf(
     PropTypes.shape({
@@ -214,6 +220,7 @@ TableActionCell.propTypes = {
       disabled: PropTypes.bool,
       dataHook: PropTypes.string,
       disabledDescription: PropTypes.string,
+      divider: PropTypes.bool,
     }),
   ),
 

--- a/src/TableActionCell/constants.js
+++ b/src/TableActionCell/constants.js
@@ -1,0 +1,3 @@
+export const dataHooks = {
+  triggerElement: 'table-action-cell-trigger-element',
+};

--- a/src/TableActionCell/docs/examples/SecondaryWithDividerExample.js
+++ b/src/TableActionCell/docs/examples/SecondaryWithDividerExample.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import TableActionCell from 'wix-style-react/TableActionCell';
+import Download from 'wix-ui-icons-common/Download';
+import Duplicate from 'wix-ui-icons-common/Duplicate';
+import style from '../TableActionCell.story.st.css';
+
+const Example = () => (
+  <div className={style.exampleRow}>
+    <TableActionCell
+      upgrade
+      secondaryActions={[
+        {
+          text: 'Download',
+          icon: <Download />,
+          onClick: () => window.alert('Download action was triggered.'),
+        },
+        {
+          divider: true,
+        },
+        {
+          text: 'Duplicate',
+          icon: <Duplicate />,
+          onClick: () => window.alert('Duplicate action was triggered.'),
+        },
+      ]}
+      numOfVisibleSecondaryActions={0}
+    />
+  </div>
+);
+
+export default Example;

--- a/src/TableActionCell/docs/index.story.js
+++ b/src/TableActionCell/docs/index.story.js
@@ -44,6 +44,9 @@ import DisabledSecondaryExampleRaw from '!raw-loader!./examples/DisabledSecondar
 import DisabledPrimaryExample from './examples/DisabledPrimaryExample';
 import DisabledPrimaryExampleRaw from '!raw-loader!./examples/DisabledPrimaryExample';
 
+import SecondaryWithDividerExample from './examples/SecondaryWithDividerExample';
+import SecondaryWithDividerExampleRaw from '!raw-loader!./examples/SecondaryWithDividerExample';
+
 const primaryActionOptions1 = {
   text: 'Details',
   theme: 'fullblue',
@@ -210,6 +213,15 @@ export default {
           code={DisabledPrimaryExampleRaw}
         >
           <DisabledPrimaryExample />
+        </CodeExample>
+      </div>
+
+      <div className={style.example}>
+        <CodeExample
+          title="Secondary Actions with Divider"
+          code={SecondaryWithDividerExampleRaw}
+        >
+          <SecondaryWithDividerExample />
         </CodeExample>
       </div>
     </div>

--- a/src/TableActionCell/test/TableActionCell.private.uni.driver.js
+++ b/src/TableActionCell/test/TableActionCell.private.uni.driver.js
@@ -1,0 +1,12 @@
+import { dataHooks } from '../constants';
+
+export const TableActionCellPrivateDriverFactory = base => {
+  return {
+    // TODO: This unidriver was created mainly for the visual tests, however,
+    // we do need to migrate to a public unidriver at some point
+    // ...publicDriver,
+
+    clickSecondaryActions: () =>
+      base.$(`[data-hook="${dataHooks.triggerElement}"]`).click(),
+  };
+};

--- a/src/TableActionCell/test/TableActionCell.visual.js
+++ b/src/TableActionCell/test/TableActionCell.visual.js
@@ -1,0 +1,77 @@
+import { storiesOf } from '@storybook/react';
+import React from 'react';
+import Download from 'wix-ui-icons-common/Download';
+import Star from 'wix-ui-icons-common/Star';
+import { uniTestkitFactoryCreator } from 'wix-ui-test-utils/vanilla';
+import Box from '../../Box';
+import TableActionCell from '../TableActionCell';
+import { TableActionCellPrivateDriverFactory } from './TableActionCell.private.uni.driver';
+
+const interactiveDataHook = 'interactive-tableactioncell';
+
+const tableActionCellUniTestkitFactory = uniTestkitFactoryCreator(
+  TableActionCellPrivateDriverFactory,
+);
+
+const createDriver = dataHook =>
+  tableActionCellUniTestkitFactory({
+    wrapper: document.body,
+    dataHook,
+  });
+
+class InteractiveEyeTest extends React.Component {
+  async componentDidMount() {
+    this.props.componentDidMount();
+  }
+
+  render() {
+    const { componentDidMount, ...restProps } = this.props;
+
+    return (
+      <Box padding={20}>
+        <TableActionCell dataHook={interactiveDataHook} {...restProps} />
+      </Box>
+    );
+  }
+}
+
+const interactiveTests = [
+  {
+    describe: 'Secondary Actions',
+    its: [
+      {
+        it: 'Should display a divider',
+        props: {
+          upgrade: true,
+          secondaryActions: [
+            {
+              text: 'Star',
+              icon: <Star />,
+            },
+            { divider: true },
+            {
+              text: 'Download',
+              icon: <Download />,
+            },
+          ],
+          numOfVisibleSecondaryActions: 0,
+        },
+        componentDidMount: async () => {
+          const driver = createDriver(interactiveDataHook);
+          await driver.clickSecondaryActions();
+        },
+      },
+    ],
+  },
+];
+
+interactiveTests.forEach(({ describe, its }) => {
+  its.forEach(({ it, props, componentDidMount }) => {
+    storiesOf(
+      `TableActionCell${describe ? '/' + describe : ''}`,
+      module,
+    ).add(it, () => (
+      <InteractiveEyeTest {...props} componentDidMount={componentDidMount} />
+    ));
+  });
+});


### PR DESCRIPTION
This PR extends `secondaryActions` prop to allow displaying a divider between the actions.

A few notes:
1. Requested by a consumer
2. Approved by UX
3. Works only with `upgrade` prop
4. The private Unidriver was created only for the tests (at this point), but we definitely need to migrate to a public driver in the future

Usage:
```jsx
<TableActionCell
  upgrade
  alwaysShowSecondaryActions
  numOfVisibleSecondaryActions={0}
  primaryAction={{
    onClick: () => console.log("Details action called!"),
    text: 'Details',
    theme: 'fullblue'
  }}
  secondaryActions={[
    {
      icon: <Icons.Star />,
      text: 'Star'
    },
    { divider: true },
    {
      icon: <Icons.Download />,
      text: 'Download'
    }
  ]}
/>
```