### PR TITLE
Chromatic - enable build in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "test5:types": "npm run test:types",
     "test6:sanity": "npm run lint && npm run sanity",
     "test7:performance": "npm run test:performance",
-    "test8:chromatic": "if [  \"$agentType\" = \"pullrequest\" ]; then npm run test:chromatic; fi;",
+    "test8:chromatic": "npm run test:chromatic",
     "------performance analysis tools": "",
     "bundles:analyse": "npm run analyse --prefix .perfer",
     "------can be removed?": "",


### PR DESCRIPTION
This PR is enabling chromatic running in master (tc.dev). If we see that it blocks our pipeline somehow we can always disable it.