### PR TITLE
Small changes - preparation to wsr8

### DIFF
--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -202,6 +202,9 @@ class Input extends Component {
       ref: this.extractRef,
       className: classNames(styles.input, {
         [styles.disabled]: !!disabled,
+        [styles.withPrefix]: !!prefix, // For testing
+        [styles.withSuffix]: visibleSuffixCount, // For testing
+        [styles.withSuffixes]: visibleSuffixCount > 1, // For testing
       }),
       id,
       name,

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -180,13 +180,6 @@ class Input extends Component {
       suffix,
     });
 
-    const inputClassNames = classNames(styles.input, {
-      [styles.disabled]: !!disabled,
-      [styles.withPrefix]: !!prefix,
-      [styles.withSuffix]: visibleSuffixCount,
-      [styles.withSuffixes]: visibleSuffixCount > 1,
-    });
-
     const ariaAttribute = {};
     Object.keys(this.props)
       .filter(key => key.startsWith('aria'))
@@ -207,7 +200,9 @@ class Input extends Component {
       'data-hook': 'wsr-input',
       style: { textOverflow },
       ref: this.extractRef,
-      className: inputClassNames,
+      className: classNames(styles.input, {
+        [styles.disabled]: !!disabled,
+      }),
       id,
       name,
       disabled,
@@ -219,7 +214,6 @@ class Input extends Component {
       onFocus: this._onFocus,
       onBlur: this._onBlur,
       onKeyDown: this._onKeyDown,
-      onDoubleClick: this._onDoubleClick,
       onPaste,
       placeholder,
       tabIndex,

--- a/src/InputArea/InputArea.js
+++ b/src/InputArea/InputArea.js
@@ -160,7 +160,6 @@ class InputArea extends React.PureComponent {
             onKeyDown={this._onKeyDown}
             onChange={this._onChange}
             onInput={onInput}
-            onDoubleClick={this._onDoubleClick}
             placeholder={placeholder}
             tabIndex={tabIndex}
             autoFocus={autoFocus}

--- a/src/MultiSelect/MultiSelect.driver.js
+++ b/src/MultiSelect/MultiSelect.driver.js
@@ -31,6 +31,8 @@ const multiSelectDriverFactory = ({ element }) => {
 
     /** returns the number of tags selected in the input */
     numberOfTags: () => tags.length,
+
+    /** returns true if a custom suffix exists */
     customSuffixExists: () =>
       !!inputWrapper.querySelector('[data-hook="custom-suffix"]'),
 

--- a/src/MultiSelect/MultiSelect.uni.driver.d.ts
+++ b/src/MultiSelect/MultiSelect.uni.driver.d.ts
@@ -14,6 +14,7 @@ export interface MultiSelectUniDriver
     inputWrapperIsDisabled: () => Promise<any>;
     numberOfTags: () => Promise<number>;
     getTagLabelAt: (index: number) => Promise<string>;
+    pressCommaKey: () => Promise<void>;
     getTagDriverByTagId: (
       tagId: string,
     ) => Promise<

--- a/src/MultiSelect/MultiSelect.uni.driver.js
+++ b/src/MultiSelect/MultiSelect.uni.driver.js
@@ -52,6 +52,8 @@ export const multiselectUniDriverFactory = (base, body) => {
       tagPrivateUniDriverFactory(
         tags.filter(async tag => (await tag._prop('id')) === tagId).get(0),
       ),
+
+    /** returns true if a custom suffix exists */
     customSuffixExists: async () =>
       !!(await getInputWrapper()).querySelector('[data-hook="custom-suffix"]'),
   };

--- a/src/RichTextInputArea/RichTextInputArea.js
+++ b/src/RichTextInputArea/RichTextInputArea.js
@@ -10,7 +10,7 @@ import RichTextToolbar from './Toolbar/RichTextToolbar';
 import EditorUtilities from './EditorUtilities';
 import { RichTextInputAreaContext } from './RichTextInputAreaContext';
 import { defaultTexts } from './RichTextInputAreaTexts';
-import ErrorIndicator from '../ErrorIndicator';
+import StatusIndicator from '../StatusIndicator';
 
 const decorator = new CompositeDecorator([
   {
@@ -156,9 +156,10 @@ class RichTextInputArea extends React.PureComponent {
           />
           {hasError && (
             <span className={styles.errorIndicator}>
-              <ErrorIndicator
+              <StatusIndicator
                 dataHook="richtextarea-error-indicator"
-                errorMessage={statusMessage}
+                status="error"
+                message={statusMessage}
               />
             </span>
           )}

--- a/src/RichTextInputArea/RichTextInputArea.js
+++ b/src/RichTextInputArea/RichTextInputArea.js
@@ -35,44 +35,7 @@ const decorator = new CompositeDecorator([
 ]);
 
 class RichTextInputArea extends React.PureComponent {
-  static displayName = 'RichTextInputArea';
   static errorStatus = 'error';
-
-  static propTypes = {
-    /** Applied as data-hook HTML attribute that can be used in the tests */
-    dataHook: PropTypes.string,
-    /** Initial value to display in the editor */
-    initialValue: PropTypes.string,
-    /** Placeholder to display in the editor */
-    placeholder: PropTypes.string,
-    /** Disables the editor and toolbar */
-    disabled: PropTypes.bool,
-    /** Displays a status indicator */
-    status: PropTypes.oneOf(['error']),
-    /** Text to be shown within the tooltip of the status indicator */
-    statusMessage: PropTypes.string,
-    /** Callback function for changes: `onChange(htmlText, { plainText })` */
-    onChange: PropTypes.func,
-    /** Defines a maximum height for the editor (it grows by default) */
-    maxHeight: PropTypes.string,
-    /** Texts to be shown */
-    texts: PropTypes.shape({
-      toolbarButtons: PropTypes.shape(
-        mapValues(defaultTexts.toolbarButtons, () => PropTypes.string),
-      ),
-      insertionForm: PropTypes.shape({
-        ...mapValues(defaultTexts.insertionForm, () => PropTypes.string),
-        link: PropTypes.shape(
-          mapValues(defaultTexts.toolbarButtons.link, () => PropTypes.string),
-        ),
-      }),
-    }),
-  };
-
-  static defaultProps = {
-    initialValue: '<p></p>',
-    texts: {},
-  };
 
   constructor(props) {
     super(props);
@@ -200,5 +163,43 @@ class RichTextInputArea extends React.PureComponent {
     this._updateContentByValue(value);
   };
 }
+
+RichTextInputArea.displayName = 'RichTextInputArea';
+
+RichTextInputArea.propTypes = {
+  /** Applied as data-hook HTML attribute that can be used in the tests */
+  dataHook: PropTypes.string,
+  /** Initial value to display in the editor */
+  initialValue: PropTypes.string,
+  /** Placeholder to display in the editor */
+  placeholder: PropTypes.string,
+  /** Disables the editor and toolbar */
+  disabled: PropTypes.bool,
+  /** Displays a status indicator */
+  status: PropTypes.oneOf(['error']),
+  /** Text to be shown within the tooltip of the status indicator */
+  statusMessage: PropTypes.string,
+  /** Callback function for changes: `onChange(htmlText, { plainText })` */
+  onChange: PropTypes.func,
+  /** Defines a maximum height for the editor (it grows by default) */
+  maxHeight: PropTypes.string,
+  /** Texts to be shown */
+  texts: PropTypes.shape({
+    toolbarButtons: PropTypes.shape(
+      mapValues(defaultTexts.toolbarButtons, () => PropTypes.string),
+    ),
+    insertionForm: PropTypes.shape({
+      ...mapValues(defaultTexts.insertionForm, () => PropTypes.string),
+      link: PropTypes.shape(
+        mapValues(defaultTexts.toolbarButtons.link, () => PropTypes.string),
+      ),
+    }),
+  }),
+};
+
+RichTextInputArea.defaultProps = {
+  initialValue: '<p></p>',
+  texts: {},
+};
 
 export default RichTextInputArea;

--- a/src/RichTextInputArea/RichTextInputArea.scss
+++ b/src/RichTextInputArea/RichTextInputArea.scss
@@ -100,8 +100,8 @@ $padding: 12px;
 
 .errorIndicator {
   position: absolute;
-  top: 1px;
-  right: 5px;
+  top: 9px;
+  right: 12px;
 }
 
 .hidePlaceholder {

--- a/src/RichTextInputArea/RichTextInputArea.uni.driver.js
+++ b/src/RichTextInputArea/RichTextInputArea.uni.driver.js
@@ -1,26 +1,35 @@
 import { baseUniDriverFactory } from 'wix-ui-test-utils/base-driver';
 import ReactTestUtils from 'react-dom/test-utils';
 
-import { errorIndicatorDriverFactory } from '../ErrorIndicator/ErrorIndicator.uni.driver';
+import { statusIndicatorDriverFactory } from '../StatusIndicator/StatusIndicator.uni.driver';
+import { statusTypes } from '../VariableInput/constants';
 
 export const getContent = base => base.$('.public-DraftEditor-content');
 export const getPlaceholder = base =>
   base.$('.public-DraftEditorPlaceholder-root');
 
-const getErrorIndicator = base =>
-  base.$('[data-hook=richtextarea-error-indicator]');
-const errorIndicatorDriver = (base, body) =>
-  errorIndicatorDriverFactory(getErrorIndicator(base), body);
-
 export default (base, body) => {
+  const statusIndicatorDriver = statusIndicatorDriverFactory(
+    base.$(`[data-hook="richtextarea-error-indicator"]`),
+    body,
+  );
+
   return {
     ...baseUniDriverFactory(base, body),
     isDisabled: async () =>
       Boolean(await getContent(base).attr('contenteditable')),
-    hasError: async () => await getErrorIndicator(base).exists(),
+    hasError: async () => {
+      const exists = await statusIndicatorDriver.exists();
+      if (exists) {
+        const status = await statusIndicatorDriver.getStatus();
+        return status === statusTypes.error;
+      }
+
+      return false;
+    },
     getContent: () => getContent(base).text(),
     getPlaceholder: () => getPlaceholder(base).text(),
-    getErrorMessage: () => errorIndicatorDriver(base, body).getErrorMessage(),
+    getErrorMessage: statusIndicatorDriver.getMessage,
     enterText: async text => {
       const contentElement = await getContent(base).getNative(); // eslint-disable-line no-restricted-properties
 

--- a/src/RichTextInputArea/RichTextInputArea.uni.driver.js
+++ b/src/RichTextInputArea/RichTextInputArea.uni.driver.js
@@ -2,7 +2,6 @@ import { baseUniDriverFactory } from 'wix-ui-test-utils/base-driver';
 import ReactTestUtils from 'react-dom/test-utils';
 
 import { statusIndicatorDriverFactory } from '../StatusIndicator/StatusIndicator.uni.driver';
-import { statusTypes } from '../VariableInput/constants';
 
 export const getContent = base => base.$('.public-DraftEditor-content');
 export const getPlaceholder = base =>
@@ -18,15 +17,7 @@ export default (base, body) => {
     ...baseUniDriverFactory(base, body),
     isDisabled: async () =>
       Boolean(await getContent(base).attr('contenteditable')),
-    hasError: async () => {
-      const exists = await statusIndicatorDriver.exists();
-      if (exists) {
-        const status = await statusIndicatorDriver.getStatus();
-        return status === statusTypes.error;
-      }
-
-      return false;
-    },
+    hasError: statusIndicatorDriver.exists,
     getContent: () => getContent(base).text(),
     getPlaceholder: () => getPlaceholder(base).text(),
     getErrorMessage: statusIndicatorDriver.getMessage,

--- a/src/VariableInput/VariableInput.js
+++ b/src/VariableInput/VariableInput.js
@@ -3,71 +3,12 @@ import { string, func, shape, oneOf, node, bool, number } from 'prop-types';
 import { Editor, EditorState } from 'draft-js';
 
 import EditorUtilities from './EditorUtilities';
-import {
-  sizeTypes,
-  inputToTagsSize,
-  statusTypes,
-  dataHooks,
-} from './constants';
+import { sizeTypes, inputToTagsSize, dataHooks } from './constants';
 import styles from './VariableInput.st.css';
 import StatusIndicator from '../StatusIndicator';
 
 /** Input with variables as tags */
 class VariableInput extends React.PureComponent {
-  static displayName = 'VariableInput';
-
-  static propTypes = {
-    /** A single CSS class name to be appended to the Input's wrapper element. */
-    className: string,
-    /** Applied as data-hook HTML attribute that can be used in the tests */
-    dataHook: string,
-    /** When set to true this component is disabled */
-    disabled: bool,
-    /** Initial value to display in the editor */
-    initialValue: string,
-    /** When set to true, component will allow multiple lines, otherwise will scroll horizontaly and ignore return key*/
-    multiline: bool,
-    /** Callback function for changes while typing.
-     * `onChange(value: String): void` */
-    onChange: func,
-    /** Callback funciton after calling `insertVariable()` and `setValue()`
-     * `onSubmit(value: String): void` */
-    onSubmit: func,
-    /** Callback funciton when focusing out.`
-     * `onBlur(value: String): void` */
-    onBlur: func,
-    /** Use to display a status indication for the user.*/
-    status: oneOf(['error', 'warning']),
-    /** The status (error/warning) message to display when hovering the status icon, if not given or empty there will be no tooltip*/
-    statusMessage: node,
-    /** Placeholder to display in the editor */
-    placeholder: string,
-    /** Set height of component that fits the given number of rows */
-    rows: number,
-    /** Specifies the size of the input and variables*/
-    size: oneOf(['small', 'medium', 'large']),
-    /** Component will parse the variable keys, and convert them to tag bubble on blur and while using insertVariable.
-     * For each key variableParser will be called and should return a proper text for that key or false in case the key is invalid.
-     * `variableParser(key: String): String|boolean` */
-    variableParser: func,
-    /** Template for variables, will search and replace variables with the given prefix and suffix */
-    variableTemplate: shape({
-      prefix: string,
-      suffix: string,
-    }),
-  };
-  static defaultProps = {
-    initialValue: '',
-    multiline: true,
-    rows: 1,
-    size: sizeTypes.medium,
-    statusMessage: '',
-    variableParser: () => {},
-    variableTemplate: {
-      prefix: '{{',
-      suffix: '}}',
-    },
-  };
   constructor(props) {
     super(props);
     const { size, disabled } = props;
@@ -78,36 +19,12 @@ class VariableInput extends React.PureComponent {
       editorState: EditorState.createEmpty(decorator),
     };
   }
+
   componentDidMount() {
     const { initialValue } = this.props;
     this._setStringValue(initialValue);
   }
-  _renderIndicator = (status, statusMessage) => {
-    switch (status) {
-      case statusTypes.error:
-        return (
-          <span className={styles.indicatorWrapper}>
-            <StatusIndicator
-              dataHook={dataHooks.error}
-              status="error"
-              message={statusMessage}
-            />
-          </span>
-        );
-      case statusTypes.warning:
-        return (
-          <span className={styles.indicatorWrapper}>
-            <StatusIndicator
-              dataHook={dataHooks.warning}
-              status="warning"
-              warningMessage={statusMessage}
-            />
-          </span>
-        );
-      default:
-        return;
-    }
-  };
+
   render() {
     const {
       dataHook,
@@ -141,10 +58,19 @@ class VariableInput extends React.PureComponent {
           readOnly={disabled}
           {...(!multiline && singleLineProps)}
         />
-        {this._renderIndicator(status, statusMessage)}
+
+        {/* Status */}
+        <span className={styles.indicatorWrapper}>
+          <StatusIndicator
+            dataHook={dataHooks.indicator}
+            status={status}
+            message={statusMessage}
+          />
+        </span>
       </div>
     );
   }
+
   _handlePastedText = (text, html, editorState) => {
     /** We need to prevent new line when `multilne` is false,
      * here we are removing any new lines while pasting text   */
@@ -155,11 +81,14 @@ class VariableInput extends React.PureComponent {
     }
     return false;
   };
+
   _isEmpty = () =>
     this.state.editorState.getCurrentContent().getPlainText().length === 0;
+
   _inputToTagSize = inputSize => {
     return inputToTagsSize[inputSize] || VariableInput.defaultProps.size;
   };
+
   _toString = () => {
     const {
       variableTemplate: { prefix, suffix },
@@ -171,21 +100,26 @@ class VariableInput extends React.PureComponent {
       suffix,
     });
   };
+
   _onBlur = () => {
     const { onBlur = () => {} } = this.props;
     onBlur(this._toString());
   };
+
   _onSubmit = () => {
     const { onSubmit = () => {} } = this.props;
     onSubmit(this._toString());
   };
+
   _onChange = () => {
     const { onChange = () => {} } = this.props;
     onChange(this._toString());
   };
+
   _onEditorChange = editorState => {
     this._setEditorState(editorState);
   };
+
   _setEditorState = (editorState, onStateChanged = () => {}) => {
     const { editorState: editorStateBefore } = this.state;
     const {
@@ -218,6 +152,7 @@ class VariableInput extends React.PureComponent {
       onStateChanged();
     });
   };
+
   _stringToContentState = str => {
     const {
       variableParser = () => {},
@@ -235,6 +170,7 @@ class VariableInput extends React.PureComponent {
       content,
     });
   };
+
   _setStringValue = (str, afterUpdated = () => {}) => {
     const updatedEditorState = EditorState.moveSelectionToEnd(
       this._stringToContentState(str),
@@ -243,12 +179,14 @@ class VariableInput extends React.PureComponent {
       afterUpdated(updatedEditorState);
     });
   };
+
   /** Set value to display in the input */
   setValue = value => {
     this._setStringValue(value, () => {
       this._onSubmit();
     });
   };
+
   /** Insert variable at the input cursor position */
   insertVariable = value => {
     const { variableParser } = this.props;
@@ -260,4 +198,74 @@ class VariableInput extends React.PureComponent {
     });
   };
 }
+
+VariableInput.displayName = 'VariableInput';
+
+VariableInput.propTypes = {
+  /** A single CSS class name to be appended to the Input's wrapper element. */
+  className: string,
+
+  /** Applied as data-hook HTML attribute that can be used in the tests */
+  dataHook: string,
+
+  /** When set to true this component is disabled */
+  disabled: bool,
+
+  /** Initial value to display in the editor */
+  initialValue: string,
+
+  /** When set to true, component will allow multiple lines, otherwise will scroll horizontaly and ignore return key*/
+  multiline: bool,
+
+  /** Callback function for changes while typing.
+   * `onChange(value: String): void` */
+  onChange: func,
+
+  /** Callback funciton after calling `insertVariable()` and `setValue()`
+   * `onSubmit(value: String): void` */
+  onSubmit: func,
+
+  /** Callback funciton when focusing out.`
+   * `onBlur(value: String): void` */
+  onBlur: func,
+
+  /** Use to display a status indication for the user.*/
+  status: oneOf(['error', 'warning']),
+
+  /** The status (error/warning) message to display when hovering the status icon, if not given or empty there will be no tooltip*/
+  statusMessage: node,
+
+  /** Placeholder to display in the editor */
+  placeholder: string,
+
+  /** Set height of component that fits the given number of rows */
+  rows: number,
+
+  /** Specifies the size of the input and variables*/
+  size: oneOf(['small', 'medium', 'large']),
+
+  /** Component will parse the variable keys, and convert them to tag bubble on blur and while using insertVariable.
+   * For each key variableParser will be called and should return a proper text for that key or false in case the key is invalid.
+   * `variableParser(key: String): String|boolean` */
+  variableParser: func,
+
+  /** Template for variables, will search and replace variables with the given prefix and suffix */
+  variableTemplate: shape({
+    prefix: string,
+    suffix: string,
+  }),
+};
+
+VariableInput.defaultProps = {
+  initialValue: '',
+  multiline: true,
+  rows: 1,
+  size: sizeTypes.medium,
+  variableParser: () => {},
+  variableTemplate: {
+    prefix: '{{',
+    suffix: '}}',
+  },
+};
+
 export default VariableInput;

--- a/src/VariableInput/VariableInput.js
+++ b/src/VariableInput/VariableInput.js
@@ -9,9 +9,8 @@ import {
   statusTypes,
   dataHooks,
 } from './constants';
-import ErrorIndicator from '../ErrorIndicator';
-import WarningIndicator from '../WarningIndicator';
 import styles from './VariableInput.st.css';
+import StatusIndicator from '../StatusIndicator';
 
 /** Input with variables as tags */
 class VariableInput extends React.PureComponent {
@@ -88,17 +87,19 @@ class VariableInput extends React.PureComponent {
       case statusTypes.error:
         return (
           <span className={styles.indicatorWrapper}>
-            <ErrorIndicator
+            <StatusIndicator
               dataHook={dataHooks.error}
-              errorMessage={statusMessage}
+              status="error"
+              message={statusMessage}
             />
           </span>
         );
       case statusTypes.warning:
         return (
           <span className={styles.indicatorWrapper}>
-            <WarningIndicator
+            <StatusIndicator
               dataHook={dataHooks.warning}
+              status="warning"
               warningMessage={statusMessage}
             />
           </span>

--- a/src/VariableInput/VariableInput.js
+++ b/src/VariableInput/VariableInput.js
@@ -60,13 +60,15 @@ class VariableInput extends React.PureComponent {
         />
 
         {/* Status */}
-        <span className={styles.indicatorWrapper}>
-          <StatusIndicator
-            dataHook={dataHooks.indicator}
-            status={status}
-            message={statusMessage}
-          />
-        </span>
+        {status && (
+          <span className={styles.indicatorWrapper}>
+            <StatusIndicator
+              dataHook={dataHooks.indicator}
+              status={status}
+              message={statusMessage}
+            />
+          </span>
+        )}
       </div>
     );
   }

--- a/src/VariableInput/VariableInput.st.css
+++ b/src/VariableInput/VariableInput.st.css
@@ -99,8 +99,8 @@
 }
 .root .indicatorWrapper {
   position: absolute;
-  top: 3px;
-  right: 5px;
+  top: 6px;
+  right: 6px;
 }
 
 

--- a/src/VariableInput/VariableInput.st.css
+++ b/src/VariableInput/VariableInput.st.css
@@ -97,10 +97,15 @@
     border-color: value(R10);
     box-shadow: 0 0 0 3px value(R30);
 }
+
 .root .indicatorWrapper {
   position: absolute;
+  top: 9px;
+  right: 12px;
+}
+
+.root:size(small) .indicatorWrapper {
   top: 6px;
-  right: 6px;
 }
 
 

--- a/src/VariableInput/VariableInput.uni.driver.d.ts
+++ b/src/VariableInput/VariableInput.uni.driver.d.ts
@@ -6,11 +6,11 @@ export interface VariableInputUniDriver extends BaseUniDriver {
   /** Get the text content of the component*/
   getContent(): Promise<string>;
   /** Get the text content of the component placeholder*/
-  getPlaceholder(): Promise<string>
+  getPlaceholder(): Promise<string>;
   /** Enter text as value to the component*/
-  enterText(value:string): Promise<void>;
+  enterText(value: string): Promise<void>;
   /** Simulate blur event */
-  blur() : Promise<void>;
+  blur(): Promise<void>;
   /** Returns true if error indication exists */
   hasError(): Promise<boolean>;
   /** Get the error message content */

--- a/src/VariableInput/VariableInput.uni.driver.js
+++ b/src/VariableInput/VariableInput.uni.driver.js
@@ -1,19 +1,17 @@
-import { errorIndicatorDriverFactory } from '../ErrorIndicator/ErrorIndicator.uni.driver';
-import { warningIndicatorDriverFactory } from '../WarningIndicator/WarningIndicator.uni.driver';
-import { dataHooks } from './constants';
+import { statusIndicatorDriverFactory } from '../StatusIndicator/StatusIndicator.uni.driver';
+import { dataHooks, statusTypes } from './constants';
 import { baseUniDriverFactory, ReactBase } from '../../test/utils/unidriver';
 
 export const getContent = base => base.$('.public-DraftEditor-content');
 export const getPlaceholder = base =>
   base.$('.public-DraftEditorPlaceholder-root');
 
-const getErrorIndicator = base => base.$(`[data-hook=${dataHooks.error}]`);
-const errorIndicatorDriver = (base, body) =>
-  errorIndicatorDriverFactory(getErrorIndicator(base), body);
-const getWarningIndicator = base => base.$(`[data-hook=${dataHooks.warning}]`);
-const warningIndicatorDriver = (base, body) =>
-  warningIndicatorDriverFactory(getWarningIndicator(base), body);
 export default (base, body) => {
+  const statusIndicatorDriver = statusIndicatorDriverFactory(
+    base.$(`[data-hook=${dataHooks.indicator}]`),
+    body,
+  );
+
   return {
     ...baseUniDriverFactory(base, body),
     isDisabled: async () =>
@@ -37,10 +35,25 @@ export default (base, body) => {
         await page.$eval('.public-DraftEditor-content', e => e.blur());
       }
     },
-    hasError: async () => await getErrorIndicator(base).exists(),
-    getErrorMessage: () => errorIndicatorDriver(base, body).getErrorMessage(),
-    hasWarning: async () => await getWarningIndicator(base).exists(),
-    getWarningMessage: () =>
-      warningIndicatorDriver(base, body).getWarningMessage(),
+    hasError: async () => {
+      const exists = await statusIndicatorDriver.exists();
+      if (exists) {
+        const status = await statusIndicatorDriver.getStatus();
+        return status === statusTypes.error;
+      }
+
+      return false;
+    },
+    getErrorMessage: statusIndicatorDriver.getMessage,
+    hasWarning: async () => {
+      const exists = await statusIndicatorDriver.exists();
+      if (exists) {
+        const status = await statusIndicatorDriver.getStatus();
+        return status === statusTypes.warning;
+      }
+
+      return false;
+    },
+    getWarningMessage: statusIndicatorDriver.getMessage,
   };
 };

--- a/src/VariableInput/constants.js
+++ b/src/VariableInput/constants.js
@@ -5,8 +5,7 @@ export const sizeTypes = {
 };
 export const dataHooks = {
   tag: 'variableinput-tag',
-  error: 'variableinput-error-indicator',
-  warning: 'variableinput-warning-indicator',
+  indicator: 'variableinput-indicator',
 };
 export const inputToTagsSize = {
   small: 'tiny',

--- a/src/VariableInput/index.d.ts
+++ b/src/VariableInput/index.d.ts
@@ -24,4 +24,4 @@ export default class VariableInput extends React.PureComponent<VariableInputProp
 
 export type VariableInputSize = 'small' | 'medium' | 'large';
 
-export const SIZE: { [key in VariableInputSize]: VariableInputSize }
+export const SIZE: { [key in VariableInputSize]: VariableInputSize };

--- a/src/VariableInput/test/VariableInput.private.uni.driver.js
+++ b/src/VariableInput/test/VariableInput.private.uni.driver.js
@@ -9,6 +9,7 @@ export const getPlaceholder = base =>
 
 const getTagDriver = base =>
   tagUniDriverFactory(base.$(`[data-hook=${dataHooks.tag}]`));
+
 export default (base, body) => {
   return {
     ...publicDriverFactory(base, body),

--- a/src/VariableInput/test/VariableInput.spec.js
+++ b/src/VariableInput/test/VariableInput.spec.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import { createUniDriverFactory } from 'wix-ui-test-utils/uni-driver-factory';
-import { createRendererWithUniDriver } from '../../../test/utils/react';
+import {
+  createRendererWithUniDriver,
+  cleanup,
+} from '../../../test/utils/react';
 import publicDriverFactory from '../VariableInput.uni.driver';
 import privateDriverFactory from './VariableInput.private.uni.driver';
 import VariableInput from '../VariableInput';
@@ -8,6 +11,8 @@ import { sizeTypes } from '../constants';
 import { selectionBehaviorPolyfill } from '../../../testkit/polyfills';
 
 describe('VariableInput', () => {
+  afterEach(() => cleanup());
+
   const createDriver = createUniDriverFactory(privateDriverFactory);
   const variableEntity = {
     text: 'Page name',

--- a/src/VariableInput/test/VariableInput.visual.js
+++ b/src/VariableInput/test/VariableInput.visual.js
@@ -46,6 +46,14 @@ const tests = [
         },
       },
       {
+        it: '3 Row with status',
+        props: {
+          initialValue: 'Welcome to my {{page.name}} ',
+          rows: 3,
+          status: 'error',
+        },
+      },
+      {
         it: 'Disabled',
         props: {
           initialValue: 'Welcome to my {{page.name}} ',


### PR DESCRIPTION
Just some small changes to help with wsr8

Changes:
`<Input/>` - remove remains of previously deleted styles
`<Input/>` and `<InputArea/>` - remove `onDoubleClick ` that points to undefined function
`<MultiSelect/>` - fixed driver d.ts
`<RichTextInputArea/>` and `<VariableInput/>` - removed internal use of ErrorIndicator in favour of StatusIndicator - **No component or testkit API were changed but will in wsr8**  