### PR TITLE
<FloatingHelper/> - Fix TypeScript types

### DIFF
--- a/src/FloatingHelper/index.d.ts
+++ b/src/FloatingHelper/index.d.ts
@@ -1,129 +1,40 @@
 import * as React from 'react';
-import {FloatingHelperContent} from "./FloatingHelperContent/FloatingHelperContent";
+import { FloatingHelperContent } from './FloatingHelperContent/FloatingHelperContent';
+import { OmitPolyfill } from '../common';
+
 export type FloatingHelperProps = import('wix-ui-core/dist/src/createHOC').WixComponentProps &
   FloatingHelperPropsInner;
 
-export default class FloatingHelper extends React.PureComponent<FloatingHelperProps> {
+export default class FloatingHelper extends React.PureComponent<
+  FloatingHelperProps
+> {
   open: () => void;
   close: () => void;
   static Content: typeof FloatingHelperContent;
 }
 
+export type FloatingHelperAppearance = 'dark' | 'light';
 
-export enum Appearance {
-  dark = 'dark',
-  light = 'light',
-}
-
-export interface FloatingHelperOwnProps {
+interface FloatingHelperOwnProps {
   width?: string | number;
   target: React.ReactNode;
   content: React.ReactNode;
-  onClose?: Function;
-  appearance?: Appearance;
-}
-
-export interface PickedClosablePopoverPropsHack {
-  /** Controls wether the popover's content is initially opened (In Uncontrolled mode only) */
-  initiallyOpened?: boolean;
-  /** Controls wether the popover's content is shown or not (aka Controlled mode).
-   * When undefined, then the component is Uncontrolled. See open/close behaviour section in docs. */
-  opened?: boolean;
-  /** The location to display the content. possible values: 'auto-start',
-       'auto',
-       'auto-end',
-       'top-start',
-       'top',
-       'top-end',
-       'right-start',
-       'right',
-       'right-end',
-       'bottom-end',
-       'bottom',
-       'bottom-start',
-       'left-end',
-       'left',
-       'left-start' */
-  placement: FloatingHelperPopoverPlacement;
-  /** Enables calculations in relation to a dom element. possible values: 'scrollParent', 'viewport', 'window' or an Element. See PopperJs docs: https://popper.js.org/popper-documentation.html#modifiers..preventOverflow.boundariesElement */
-  appendTo?: FloatingHelperPopoverAppendTo;
-  /** Callback to call when the popover content is requested to be opened (Uncontrolled mode only)*/
   onOpen?: Function;
+  onClose?: Function;
+  appearance?: FloatingHelperAppearance;
+  opened?: boolean;
+  initiallyOpened?: boolean;
 }
 
-export type PickedClosablePopoverProps = Pick<
-  ClosablePopoverProps,
-  | 'initiallyOpened'
-  | 'opened'
-  | 'target'
-  | 'onClose'
-  | 'onOpen'
-  | 'placement'
-  | 'appendTo'
->;
+type FloatingHelperPropsInner = FloatingHelperPopoverProps & FloatingHelperOwnProps;
 
-export type FloatingHelperPropsInner = PickedClosablePopoverProps &
-  FloatingHelperOwnProps &
-  PickedClosablePopoverPropsHack;
+type PopoverProps = import('wix-ui-core/dist/src/components/popover').PopoverProps;
 
-/* Closable Popover */
-export type FloatingHelperPopover = import('wix-ui-core/dist/src/components/popover').Popover;
-export type FloatingHelperPopoverProps = import('wix-ui-core/dist/src/components/popover').PopoverProps;
-export type FloatingHelperPopoverPlacement = import('wix-ui-core/dist/src/components/popover').Placement;
-export type FloatingHelperPopoverAppendTo = import('wix-ui-core/dist/src/components/popover').AppendTo;
-
-export interface ClosablePopoverState {
-  open?: boolean;
-  mode?: Mode;
-}
-
-export enum Mode {
-  Hover = 'hover',
-  ClickToClose = 'click-to-close',
-}
-
-export interface ClosablePopoverState {
-  open?: boolean;
-  mode?: Mode;
-}
-
-export type PickedPopoverProps = Pick<
-  FloatingHelperPopoverProps,
-  | 'className'
-  | 'placement'
+type FloatingHelperPopoverProps = OmitPolyfill<
+  PopoverProps,
+  | 'shown'
+  | 'onMouseEnter'
+  | 'onMouseLeave'
   | 'showArrow'
-  | 'moveBy'
-  | 'hideDelay'
-  | 'showDelay'
-  | 'moveArrowTo'
-  | 'appendTo'
-  | 'timeout'
+  | 'width'
 >;
-
-export interface ClosablePopoverActions {
-  /** Closes the popover content*/
-  close: () => void;
-}
-
-export interface ClosablePopoverOwnProps {
-  /** Controls wether the popover's content is shown or not.
-   * When undefined, then the component is Uncontrolled,
-   * It is initially open, and it can be closed by close-action */
-  opened?: boolean;
-  /** Controls wether the popover's content is initially opened (in Uncontrolled mode only) */
-  initiallyOpened?: boolean;
-  /** The popover's content, given as a function that receives control-actions and renders the contet.
-   * In Uncontrolled mode, this function is still called only once.
-   */
-  content: (closable: ClosablePopoverActions) => React.ReactNode;
-  /** The popover's target element*/
-  target: React.ReactNode;
-  /** Callback to call when the popover content is requested to be opened (Uncontrolled mode only) */
-  onOpen?: Function;
-  /** callback to call when the popover content is requested to be closed (Uncontrolled mode only). NOTE: this callback is called when the close timeout (if exists) starts */
-  onClose?: Function;
-  /** Disable close on mouseLeave */
-  closeOnMouseLeave?: boolean;
-}
-
-export type ClosablePopoverProps = PickedPopoverProps & ClosablePopoverOwnProps;

--- a/src/FloatingHelper/index.d.ts
+++ b/src/FloatingHelper/index.d.ts
@@ -26,15 +26,10 @@ interface FloatingHelperOwnProps {
   initiallyOpened?: boolean;
 }
 
-type FloatingHelperPropsInner = FloatingHelperPopoverProps & FloatingHelperOwnProps;
-
-type PopoverProps = import('wix-ui-core/dist/src/components/popover').PopoverProps;
+type FloatingHelperPropsInner = FloatingHelperPopoverProps &
+  FloatingHelperOwnProps;
 
 type FloatingHelperPopoverProps = OmitPolyfill<
-  PopoverProps,
-  | 'shown'
-  | 'onMouseEnter'
-  | 'onMouseLeave'
-  | 'showArrow'
-  | 'width'
+  import('wix-ui-core/dist/src/components/popover').PopoverProps,
+  'shown' | 'onMouseEnter' | 'onMouseLeave' | 'showArrow' | 'width'
 >;

--- a/src/FloatingHelper/index.d.ts
+++ b/src/FloatingHelper/index.d.ts
@@ -5,7 +5,7 @@ import { OmitPolyfill } from '../common';
 export type FloatingHelperProps = import('wix-ui-core/dist/src/createHOC').WixComponentProps &
   FloatingHelperPropsInner;
 
-export default class FloatingHelper extends React.PureComponent<
+declare class FloatingHelper extends React.PureComponent<
   FloatingHelperProps
 > {
   open: () => void;
@@ -33,3 +33,5 @@ type FloatingHelperPopoverProps = OmitPolyfill<
   import('wix-ui-core/dist/src/components/popover').PopoverProps,
   'shown' | 'onMouseEnter' | 'onMouseLeave' | 'showArrow' | 'width'
 >;
+
+export default FloatingHelper;

--- a/test/types/FloatingHelper.tsx
+++ b/test/types/FloatingHelper.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import FloatingHelper, { Appearance } from '../../src/FloatingHelper';
+import FloatingHelper from '../../src/FloatingHelper';
 import { floatingHelperTestkitFactory } from '../../dist/testkit';
 import { floatingHelperTestkitFactory as floatingHelperEnzymeTestkitFactory } from '../../dist/testkit/enzyme';
 import * as enzyme from 'enzyme';
@@ -19,12 +19,13 @@ function FloatingHelperWithAllProps() {
       target={<div />}
       content={<div />}
       onClose={() => {}}
-      placement={'auto'}
-      appearance={Appearance.dark}
+      placement="auto"
+      appearance="dark"
       initiallyOpened={false}
       opened
       appendTo={'viewport'}
       onOpen={() => {}}
+      zIndex={123}
     >
       <FloatingHelper.Content
         body="hello"


### PR DESCRIPTION
This PR simplifies `FloatingHelper` TypeScript types. I think initially we copied types from backoffice and this included types for ClosablePopover - which probably should not be exposed at all as it is an internal implementation of FloatingHelper (as far as wix-style-react is concerned).

After this clean-up users can import only the following:

```ts
import { FloatingHelper, FloatingHelperProps, FloatingHelperAppearance } from 'wix-style-react';
```

Also modified the types to accept more Popover props - since we spread all rest props on Popover here (and there are users already relying on this): 
https://github.com/wix/wix-ui-backoffice/blob/a985fbc1dde62b22a9db731522990f03d84576b6/src/components/FloatingHelper/ClosablePopover/ClosablePopover.tsx#L151-L152