### PR TITLE
`<Popover/>` - adding d.ts to popover protractor driver

### DIFF
--- a/src/Popover/Popover.protractor.driver.d.ts
+++ b/src/Popover/Popover.protractor.driver.d.ts
@@ -1,0 +1,3 @@
+import { PopoverDriver } from 'wix-ui-core/dist/src/components/popover/Popover.protractor.driver';
+
+export default PopoverDriver;


### PR DESCRIPTION
### 🔦 Summary
Adding protractor d.ts file to the `<Popover/>` driver. I need this for the `<FloatingHelper/>` migration.