### PR TITLE
<Table/> - support `React.RefObject` type for `scrollElement` prop

### DIFF
--- a/src/DataTable/index.d.ts
+++ b/src/DataTable/index.d.ts
@@ -25,7 +25,7 @@ export interface DataTableProps {
   hasMore?: boolean;
   loader?: React.ReactNode;
   useWindow?: boolean;
-  scrollElement?: HTMLElement;
+  scrollElement?: HTMLElement | React.RefObject<any>;
   rowVerticalPadding?: DataTableRowVerticalPadding;
   /**
    * @deprecated

--- a/test/types/DataTable.tsx
+++ b/test/types/DataTable.tsx
@@ -1,10 +1,10 @@
-import * as React from "react";
-import DataTable from "../../src/DataTable";
-import { dataTableTestkitFactory } from "../../dist/testkit";
-import { dataTableTestkitFactory as dataTableEnzymeTestkitFactory } from "../../dist/testkit/enzyme";
-import { dataTableTestkitFactory as dataTablePuppeteerTestkitFactory } from "../../dist/testkit/puppeteer";
-import * as enzyme from "enzyme";
-import * as puppeteer from "puppeteer";
+import * as React from 'react';
+import DataTable from '../../src/DataTable';
+import { dataTableTestkitFactory } from '../../dist/testkit';
+import { dataTableTestkitFactory as dataTableEnzymeTestkitFactory } from '../../dist/testkit/enzyme';
+import { dataTableTestkitFactory as dataTablePuppeteerTestkitFactory } from '../../dist/testkit/puppeteer';
+import * as enzyme from 'enzyme';
+import * as puppeteer from 'puppeteer';
 
 function DataTableWithMandatoryProps() {
   return <DataTable columns={[]} />;
@@ -16,20 +16,20 @@ function DataTableWithAllProps() {
       allowMultiDetailsExpansion
       columns={[
         {
-          align: "center",
+          align: 'center',
           infoTooltipProps: {},
-          render: (_row, _num) => "text",
+          render: (_row, _num) => 'text',
           sortDescending: true,
           sortable: true,
-          title: "title",
+          title: 'title',
           important: true,
-          style: { width: "10px" },
-          width: "10px"
-        }
+          style: { width: '10px' },
+          width: '10px',
+        },
       ]}
       data={[{}]}
       dataHook="hook"
-      dynamicRowClass={(_rowData, _rowNum) => ""}
+      dynamicRowClass={(_rowData, _rowNum) => ''}
       hasMore
       hideHeader
       id="id"
@@ -46,8 +46,8 @@ function DataTableWithAllProps() {
       rowDataHook="string"
       rowDetails={(_rowData, _rowNum) => <span />}
       rowVerticalPadding="large"
-      scrollElement={document.createElement("div")}
-      selectedRowsIds={[1, "2"]}
+      scrollElement={document.createElement('div')}
+      selectedRowsIds={[1, '2']}
       showHeaderWhenEmpty
       showLastRowDivider
       skin="neutral"
@@ -69,21 +69,25 @@ function DataTableWithAllProps() {
   );
 }
 
+function DataTableWithRefScrollElement() {
+  return <DataTable scrollElement={React.createRef()} columns={[]} />;
+}
+
 async function testkits() {
   const testkit = dataTableTestkitFactory({
-    dataHook: "hook",
-    wrapper: document.createElement("div")
+    dataHook: 'hook',
+    wrapper: document.createElement('div'),
   });
 
   const enzymeTestkit = dataTableEnzymeTestkitFactory({
-    dataHook: "hook",
-    wrapper: enzyme.mount(<div />)
+    dataHook: 'hook',
+    wrapper: enzyme.mount(<div />),
   });
 
   const browser = await puppeteer.launch();
   const page = await browser.newPage();
   const puppeteerTestkit = await dataTablePuppeteerTestkitFactory({
-    dataHook: "hook",
-    page
+    dataHook: 'hook',
+    page,
   });
 }

--- a/test/types/Table.tsx
+++ b/test/types/Table.tsx
@@ -1,10 +1,10 @@
-import * as React from "react";
-import Table from "../../src/Table";
-import { tableTestkitFactory } from "../../dist/testkit";
-import { tableTestkitFactory as tableEnzymeTestkitFactory } from "../../dist/testkit/enzyme";
-import { tableTestkitFactory as tablePuppeteerTestkitFactory } from "../../dist/testkit/puppeteer";
-import * as enzyme from "enzyme";
-import * as puppeteer from "puppeteer";
+import * as React from 'react';
+import Table from '../../src/Table';
+import { tableTestkitFactory } from '../../dist/testkit';
+import { tableTestkitFactory as tableEnzymeTestkitFactory } from '../../dist/testkit/enzyme';
+import { tableTestkitFactory as tablePuppeteerTestkitFactory } from '../../dist/testkit/puppeteer';
+import * as enzyme from 'enzyme';
+import * as puppeteer from 'puppeteer';
 
 function tableWithMandatoryProps() {
   return <Table columns={[]} />;
@@ -17,7 +17,7 @@ function tableWithAllProps() {
       data={[]}
       dataHook="hook"
       deselectRowsByDefault
-      dynamicRowClass={(_rowData, _rowNum) => ""}
+      dynamicRowClass={(_rowData, _rowNum) => ''}
       hasMore
       hideBulkSelectionCheckbox
       hideHeader
@@ -36,7 +36,7 @@ function tableWithAllProps() {
       rowDataHook="hook"
       rowDetails={(_rowData, rowNum) => <span />}
       rowVerticalPadding="large"
-      scrollElement={document.createElement("div")}
+      scrollElement={document.createElement('div')}
       selectedIds={[1, 2, 3]}
       selectionDisabled
       showHeaderWhenEmpty
@@ -53,42 +53,45 @@ function tableWithAllProps() {
       withWrapper
       columns={[
         {
-          align: "center",
+          align: 'center',
           important: true,
           infoTooltipProps: {},
           render: (_row, _rowNum) => <span />,
           sortDescending: true,
           sortable: true,
-          style: { font: "14px" },
+          style: { font: '14px' },
           title: <span />,
-          width: "10"
-        }
+          width: '10',
+        },
       ]}
     />
   );
 }
 
-function testInstanceMethods() {
-  const instance = new Table({columns: []});
-  instance.setSelectedIds([1,2,3]);
+function tableWithRefScrollElement() {
+  return <Table scrollElement={React.createRef()} columns={[]} />;
+}
 
+function testInstanceMethods() {
+  const instance = new Table({ columns: [] });
+  instance.setSelectedIds([1, 2, 3]);
 }
 
 async function testkits() {
   const testkit = tableTestkitFactory({
-    dataHook: "hook",
-    wrapper: document.createElement("div")
+    dataHook: 'hook',
+    wrapper: document.createElement('div'),
   });
 
   const enzymeTestkit = tableEnzymeTestkitFactory({
-    dataHook: "hook",
-    wrapper: enzyme.mount(<div />)
+    dataHook: 'hook',
+    wrapper: enzyme.mount(<div />),
   });
 
   const browser = await puppeteer.launch();
   const page = await browser.newPage();
   const puppeteerTestkit = await tablePuppeteerTestkitFactory({
-    dataHook: "hook",
-    page
+    dataHook: 'hook',
+    page,
   });
 }


### PR DESCRIPTION
This PR adds a missing (but optional) type `React.RefObject` to `scrollElement` prop.