### PR TITLE
`<Button />` - ellipsed text

### DIFF
--- a/perfer.config.js
+++ b/perfer.config.js
@@ -10,7 +10,7 @@ const files = [
   ['BarChart.bundle.min.js', 43],
   ['Box.bundle.min.js', 5],
   ['Breadcrumbs.bundle.min.js', 11],
-  ['Button.bundle.min.js', 10],
+  ['Button.bundle.min.js', 11],
   ['Calendar.bundle.min.js', 74],
   ['CalendarPanel.bundle.min.js', 75],
   ['CalendarPanelFooter.bundle.min.js', 81],

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import { ButtonNext } from 'wix-ui-core/dist/src/components/button-next';
 import { generateDataAttr } from '../utils/generateDataAttr';
 import { isMadefor } from '../FontUpgrade/utils';
+import ellipsisHOC from '../common/EllipsisHOC';
 
 import styles from './Button.st.css';
 
@@ -85,10 +86,21 @@ class Button extends PureComponent {
         )}
         data-hook={dataHook}
       >
-        {children}
+        <EllipsedContent ellipsis>{children}</EllipsedContent>
       </ButtonNext>
     );
   }
 }
+
+const EllipsedContent = ellipsisHOC(({ children, ...rest }) => (
+  <span {...rest}>{children}</span>
+));
+
+EllipsedContent.propTypes = {
+  /** String based node */
+  children: node,
+
+  ...ellipsisHOC.propTypes,
+};
 
 export default Button;

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -15,6 +15,7 @@ import {
   object,
   bool,
   func,
+  PropTypes,
 } from 'prop-types';
 
 class Button extends PureComponent {
@@ -54,6 +55,8 @@ class Button extends PureComponent {
     children: node,
     /** String based data hook */
     dataHook: string,
+    /** Text ellipsis  */
+    ellipsis: bool,
   };
 
   static defaultProps = {
@@ -71,6 +74,7 @@ class Button extends PureComponent {
       fullWidth,
       children,
       dataHook,
+      ellipsis,
       ...rest
     } = this.props;
 
@@ -86,7 +90,7 @@ class Button extends PureComponent {
         )}
         data-hook={dataHook}
       >
-        <EllipsedContent ellipsis>{children}</EllipsedContent>
+        <EllipsedContent ellipsis={ellipsis}>{children}</EllipsedContent>
       </ButtonNext>
     );
   }
@@ -100,7 +104,7 @@ EllipsedContent.propTypes = {
   /** String based node */
   children: node,
 
-  ...ellipsisHOC.propTypes,
+  tooltipProps: PropTypes.shape(ellipsisHOC.propTypes),
 };
 
 export default Button;

--- a/src/Button/Button.st.css
+++ b/src/Button/Button.st.css
@@ -49,6 +49,8 @@
 .root::content {
   display: flex;
   align-items: center;
+  justify-content: center;
+  width: 100%;
 }
 
 .root:hover {

--- a/src/Button/docs/examples.js
+++ b/src/Button/docs/examples.js
@@ -96,6 +96,6 @@ export const custom = `
 
 export const ellipsis = `
 <div style={{ width: '50px' }}>
-  <Button size="medium" fullWidth={true}>Ellipsis</Button>
+  <Button size="medium" fullWidth={true} ellipsis={true}>Ellipsis</Button>
 </div>
 `;

--- a/src/Button/docs/examples.js
+++ b/src/Button/docs/examples.js
@@ -93,3 +93,9 @@ export const custom = `
   </Box>
 </Layout>
 `;
+
+export const ellipsis = `
+<div style={{ width: '50px' }}>
+  <Button size="medium" fullWidth={true}>Ellipsis</Button>
+</div>
+`;

--- a/src/Button/docs/index.story.js
+++ b/src/Button/docs/index.story.js
@@ -117,7 +117,7 @@ export default {
           example({
             title: 'Ellipsis',
             text:
-              'If a button container is too small or you set a fixed with to a button and the text does not fit, it will have an ellipsis with a tooltip.',
+              'If a Button parent container is too small and the text does not fit then Button can have ellipsis enabled by passing `ellipsis="true"`',
             source: examples.ellipsis,
           }),
         ],

--- a/src/Button/docs/index.story.js
+++ b/src/Button/docs/index.story.js
@@ -113,6 +113,13 @@ export default {
                 `,
             source: examples.custom,
           }),
+
+          example({
+            title: 'Ellipsis',
+            text:
+              'If a button container is too small or you set a fixed with to a button and the text does not fit, it will have an ellipsis with a tooltip.',
+            source: examples.ellipsis,
+          }),
         ],
       }),
 

--- a/src/Button/index.d.ts
+++ b/src/Button/index.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import {OmitPolyfill} from '../common';
-import {IconElement} from '../common';
+import { OmitPolyfill } from '../common';
+import { IconElement } from '../common';
 
 export type ButtonWithAsProp<T> =
   | ButtonAsButtonProps<T>
@@ -42,6 +42,7 @@ export type ButtonProps = ButtonWithAsProp<{
   prefixIcon?: IconElement;
   disabled?: boolean;
   dataHook?: string;
+  ellipsis?: boolean;
 }>;
 
 export default class Button extends React.Component<ButtonProps> {}


### PR DESCRIPTION
### 🔦 Summary

Make Button text ellipsed when it is too long.

### ✅ Checklist

- [ ] 👨‍💻 API change is approved by the UI Infra Developers
- [ ] 👨‍🎨 UX change is approved by the Design System UX
- 📚 Change is documented
  - [X] Story
  - [ ] API description
  - [ ] Cheatsheet
  - [ ] Other (explain)
- 🔬 Change is tested
  - [ ] Component
  - [ ] Visual test
