### PR TITLE
<FillButton/> - Added deprecation logs

### DIFF
--- a/src/FillButton/FillButton.js
+++ b/src/FillButton/FillButton.js
@@ -10,6 +10,7 @@ import Tooltip from '../Tooltip';
 import Proportion from '../Proportion';
 import { dataHooks } from './constants';
 import { parseColor, parseGradient, parseContrastColor } from './utils';
+import deprecationLog from '../utils/deprecationLog';
 
 const { iconSmall, iconMedium } = dataHooks;
 
@@ -26,7 +27,7 @@ class FillButton extends React.PureComponent {
     iconSize: PropTypes.oneOf(['small', 'medium']),
     /** components disable state */
     disabled: PropTypes.bool,
-    /** tooltip content value */
+    /** @deprecated tooltip content value */
     tooltipContent: PropTypes.node,
     /** fill value in string. Hex or gradient */
     fill: PropTypes.string,
@@ -37,6 +38,16 @@ class FillButton extends React.PureComponent {
   static defaultProps = {
     iconSize: 'small',
   };
+
+  constructor(props) {
+    super(props);
+
+    if (props.hasOwnProperty('tooltipContent')) {
+      deprecationLog(
+        '<FillButton/> - tooltipContent prop is deprecated, use tooltipProps={{ content: ... }} instead.',
+      );
+    }
+  }
 
   _getBackground = fill => {
     const { disabled } = this.props;
@@ -81,10 +92,10 @@ class FillButton extends React.PureComponent {
       <Tooltip
         appendTo="window"
         disabled={disabled}
+        content={tooltipContent}
         {...tooltipProps}
         upgrade
         dataHook={dataHook}
-        content={tooltipContent}
         size="small"
       >
         <Proportion className={styles.proportion}>

--- a/src/FillButton/docs/examples.js
+++ b/src/FillButton/docs/examples.js
@@ -1,18 +1,18 @@
 export const simple = `
-<Box height="24px"><FillButton  tooltipContent="hello there" /></Box>
+<Box height="24px"><FillButton tooltipProps={{ content: 'hello there' }} /></Box>
 `;
 
 export const fill = `
 <Box height="24px">
   <Layout cols={4}>
-    <FillButton fill="#3399ff"  tooltipContent="hello there"/>
-    <FillButton fill="linear-gradient(#DBE6B3, #D7E6B3)"  tooltipContent="hello there"/>
+    <FillButton fill="#3399ff" tooltipProps={{ content: 'hello there' }} />
+    <FillButton fill="linear-gradient(#DBE6B3, #D7E6B3)" tooltipProps={{content: "hello there"}} />
   </Layout>
 </Box>
 `;
 
 export const state = `
 <Box height="24px">
-    <FillButton fill="#3399ff" disabled  tooltipContent="hello there"/>
+    <FillButton fill="#3399ff" disabled tooltipProps={{ content: 'hello there' }} />
 </Box>
 `;

--- a/src/FillButton/docs/index.story.js
+++ b/src/FillButton/docs/index.story.js
@@ -33,7 +33,7 @@ export default {
 
   componentProps: {
     fill: '',
-    tooltipContent: 'hello there',
+    tooltipProps: { content: 'hello there' },
   },
 
   sections: [
@@ -43,7 +43,7 @@ export default {
         'https://github.com/wix/wix-style-react/tree/master/src/FillButton/',
       component: (
         <Box height="24px">
-          <FillButton tooltipContent="Hello there" />{' '}
+          <FillButton tooltipProps={{ content: 'hello there' }} />
         </Box>
       ),
     }),

--- a/src/FillButton/test/FillButton.spec.js
+++ b/src/FillButton/test/FillButton.spec.js
@@ -37,10 +37,10 @@ describe('FillButton', () => {
     });
   });
 
-  describe('`tooltipContent` prop', () => {
+  describe('`tooltipProps` prop', () => {
     it('[when] given should pass textual content to tooltip', async () => {
       const content = 'hello';
-      const { driver } = render(<FillButton tooltipContent={content} />);
+      const { driver } = render(<FillButton tooltipProps={{ content }} />);
       expect(await driver.getTooltipText()).toBe(content);
     });
   });


### PR DESCRIPTION
Preparation to WSR 8

`<FillButton/>` - Added deprecation log for prop `tooltipContent`
Fixed tooltipProps
Fixed all examples
Fixed test