### PR TITLE
Pass RowDataType to TableColumn

### DIFF
--- a/src/DataTable/index.d.ts
+++ b/src/DataTable/index.d.ts
@@ -77,9 +77,9 @@ export type DataTableColumnAlign = 'start' | 'center' | 'end';
 export type DataTableRowDataHookFn<RowData = RowDataDefaultType> = (rowData: RowData, rowNum: number) => string;
 export type DataTableSkin = 'standard' | 'neutral';
 export type DataTableRowVerticalPadding = 'medium' | 'large';
-export type DataTableColumn<RowData = RowDataDefaultType> = {
+export type DataTableColumn<RowDataType = RowDataDefaultType> = {
   title: React.ReactNode;
-  render: (row: RowData, rowNum: number) => React.ReactNode;
+  render: (row: RowDataType, rowNum: number) => React.ReactNode;
   width?: string;
   important?: boolean;
   sortable?: boolean;

--- a/src/Table/index.d.ts
+++ b/src/Table/index.d.ts
@@ -12,9 +12,9 @@ export interface TableProps<RowData = RowDataDefaultType> extends UsedDataTableP
   selectionDisabled?: boolean;
   deselectRowsByDefault?: boolean;
   withWrapper?: boolean;
-  onSortClick?(colData: TableColumn, colNum: number): void;
+  onSortClick?(colData: TableColumn<RowData>, colNum: number): void;
   totalSelectableCount?: number;
-  columns: TableColumn[];
+  columns: TableColumn<RowData>[];
 }
 
 export default class Table<RowData = RowDataDefaultType> extends React.Component<TableProps<RowData>> {
@@ -35,7 +35,7 @@ declare const Content: React.SFC<{
 }>;
 declare const BulkSelectionCheckbox: React.SFC<{ dataHook: string }>;
 
-export type TableColumn = DataTableColumn;
+export type TableColumn<RowData = RowDataDefaultType> = DataTableColumn<RowData>;
 
 export type OnSelectionChangedFn = (
   selectedIds: TableProps['selectedIds'] | null,

--- a/src/Table/index.d.ts
+++ b/src/Table/index.d.ts
@@ -12,7 +12,7 @@ export interface TableProps<RowData = RowDataDefaultType> extends UsedDataTableP
   selectionDisabled?: boolean;
   deselectRowsByDefault?: boolean;
   withWrapper?: boolean;
-  onSortClick?(colData: TableColumn<RowData>, colNum: number): void;
+  onSortClick?(colData: TableColumn, colNum: number): void;
   totalSelectableCount?: number;
   columns: TableColumn<RowData>[];
 }

--- a/src/Table/index.d.ts
+++ b/src/Table/index.d.ts
@@ -35,7 +35,7 @@ declare const Content: React.SFC<{
 }>;
 declare const BulkSelectionCheckbox: React.SFC<{ dataHook: string }>;
 
-export type TableColumn<RowData = RowDataDefaultType> = DataTableColumn<RowData>;
+export type TableColumn<RowDataType = RowDataDefaultType> = DataTableColumn<RowDataType>;
 
 export type OnSelectionChangedFn = (
   selectedIds: TableProps['selectedIds'] | null,

--- a/test/types/Table.tsx
+++ b/test/types/Table.tsx
@@ -83,7 +83,10 @@ function typedTable() {
       name: 'Joe',
       age: 42,
     }]}
-    columns={[]}
+    columns={[{
+      title: 'name',
+      render: (row: TableRowData) => row.name,
+    }]}
   />;
 }
 

--- a/test/types/Table.tsx
+++ b/test/types/Table.tsx
@@ -85,7 +85,7 @@ function typedTable() {
     }]}
     columns={[{
       title: 'name',
-      render: (row: TableRowData) => row.name,
+      render: row => row.name,
     }]}
   />;
 }


### PR DESCRIPTION
### 🔦 Summary

In https://github.com/wix/wix-style-react/pull/5190 that added type to the data displayed in `<Table>`, I forgot to pass the `RowData` to the `TableColumn` type used in the `columns` prop. This is needed to make the column's `render` method properly typed.  

### ✅ Checklist
- 🔬 Change is tested
  - [x] Component type
