### PR TITLE
DSM-538/AnnouncementModalLayout without borders 

### DIFF
--- a/src/AnnouncementModalLayout/AnnouncementModalLayout.js
+++ b/src/AnnouncementModalLayout/AnnouncementModalLayout.js
@@ -9,8 +9,8 @@ import BaseModalLayout from '../BaseModalLayout';
 import Button from '../Button';
 
 /** A layout for announcement modals, to be used inside a &lt;Modal /&gt; */
-const AnnouncementModalLayout = ({ children, ...restProps }) => (
-  <BaseModalLayout className={styles.announcementModalLayout} {...restProps}>
+const AnnouncementModalLayout = ({ children, borderless, ...restProps }) => (
+  <BaseModalLayout {...styles('root', { borderless })} {...restProps}>
     <BaseModalLayout.Illustration />
     <BaseModalLayout.Header titleAppearance={'H2'} />
     <BaseModalLayout.Content contentHideDividers>
@@ -51,6 +51,8 @@ AnnouncementModalLayout.propTypes = {
   onCloseButtonClick: PropTypes.func,
   /** a global theme for the modal, will be applied as stylable state and will affect footer buttons skin */
   theme: PropTypes.oneOf(['standard', 'premium']),
+  /** The layout will render without borders and background-color, use this when you want to render a it in a page instead of a dialog */
+  borderless: PropTypes.bool,
 
   /** ...Header.propTypes, */
   /** The modal's title */
@@ -103,6 +105,7 @@ AnnouncementModalLayout.propTypes = {
 
 AnnouncementModalLayout.defaultProps = {
   theme: 'standard',
+  borderless: false,
   actionsSize: 'medium',
 };
 

--- a/src/AnnouncementModalLayout/AnnouncementModalLayout.st.css
+++ b/src/AnnouncementModalLayout/AnnouncementModalLayout.st.css
@@ -9,7 +9,8 @@
 }
 
 /** Extending BaseModalLayout */
-.announcementModalLayout {
+.root {
+  -st-states: borderless;
   -st-extends: BaseModalLayout;
   align-items: center;
   justify-content: center;
@@ -19,18 +20,24 @@
   width: 600px;
 }
 
+.root:borderless {
+  background-color: unset;
+  border-radius: unset;
+  box-shadow: unset;
+}
+
 /** Styling proprietary components */
-.announcementModalLayout .link {
+.root .link {
   margin-top: value(spacing18);
 }
 
-.announcementModalLayout .bottomSpacing {
+.root .bottomSpacing {
   width: 100%;
   height: value(spacing48);
 }
 
 /* Extending BaseModalLayout Blocks */
-.announcementModalLayout::illustration {
+.root::illustration {
   margin-bottom: value(spacing30);
   max-height: 200px;
   min-height: 120px;
@@ -38,20 +45,20 @@
   overflow: hidden;
 }
 
-.announcementModalLayout::header {
+.root::header {
   padding: 0 value(spacing78);
   margin-bottom: value(spacing12);
 }
 
-.announcementModalLayout::content::innerContent {
+.root::content::innerContent {
   padding: 0 value(spacing78);
 }
 
-.announcementModalLayout::footer::innerContent {
+.root::footer::innerContent {
   padding: value(spacing42) value(spacing78) 0 value(spacing78);
 }
 
-.announcementModalLayout::footnote::innerContent {
+.root::footnote::innerContent {
   padding-right: value(spacing78);
   padding-left: value(spacing78);
 }

--- a/src/AnnouncementModalLayout/AnnouncementModalLayout.st.css
+++ b/src/AnnouncementModalLayout/AnnouncementModalLayout.st.css
@@ -22,6 +22,8 @@
 
 .root:borderless {
   background-color: unset;
+  max-height: unset;
+  overflow: unset;
   border-radius: unset;
   box-shadow: unset;
 }

--- a/src/AnnouncementModalLayout/index.d.ts
+++ b/src/AnnouncementModalLayout/index.d.ts
@@ -6,6 +6,7 @@ export interface AnnouncementModalLayoutProps {
   className?: string;
   dataHook?: string;
   theme?: 'standard' | 'premium';
+  borderless?: boolean;
   onCloseButtonClick?(): void;
   title?: string;
   subtitle?: string;

--- a/src/AnnouncementModalLayout/test/AnnouncementModalLayout.visual.js
+++ b/src/AnnouncementModalLayout/test/AnnouncementModalLayout.visual.js
@@ -57,6 +57,19 @@ const tests = [
     ],
   },
   {
+    describe: 'borderless',
+    its: [
+      {
+        it: 'without borders and background colors',
+        props: {
+          borderless: true,
+          illustration: false,
+          onCloseButtonClick: false,
+        },
+      },
+    ],
+  },
+  {
     describe: 'layout',
     its: [
       {


### PR DESCRIPTION
### 🔦 Summary
Adding the option to render the AnnouncementModalLayout without borders and background-color.
This is done so it will be able to use it as a replacement for the deprecated EndorseContentLayout.
### ✅ Checklist

- 📚 Change is documented
  - [V] API description
- 🔬 Change is tested
  - [V] Visual test
