### PR TITLE
Playing with @babel/preset-env targets

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -4,6 +4,9 @@ module.exports = {
       '@babel/preset-env',
       {
         modules: false,
+        targets: {
+          ie: '11',
+        },
       },
     ],
     '@babel/preset-react',

--- a/babel.config.js
+++ b/babel.config.js
@@ -4,7 +4,7 @@ module.exports = {
       '@babel/preset-env',
       {
         modules: false,
-        targets: '>0.25%',
+        targets: '> 0.25%, not dead',
       },
     ],
     '@babel/preset-react',

--- a/babel.config.js
+++ b/babel.config.js
@@ -4,9 +4,7 @@ module.exports = {
       '@babel/preset-env',
       {
         modules: false,
-        targets: {
-          ie: '11',
-        },
+        targets: '>0.25%',
       },
     ],
     '@babel/preset-react',


### PR DESCRIPTION

<!---
Thanks for submitting a pull request 😄 !
-->

<!---
- Be as descriptive as possible when explaining what was changed.
- Link to an issue if one exists
-->

### 🔦 Summary

Setting the `targets` value of babel preset-env to IE-11 as minimum to see if it reduces bundle-sizes

