### PR TITLE
<InputArea/> - Tests noise fixes

### DIFF
--- a/src/InputArea/InputArea.js
+++ b/src/InputArea/InputArea.js
@@ -40,7 +40,9 @@ class InputArea extends React.PureComponent {
       this._calculateComputedRows();
     }
     if (this.props.hasCounter && prevProps.value !== this.props.value) {
-      this.setState({ counter: (this.props.value || this.props.defaultValue || '').length })
+      this.setState({
+        counter: (this.props.value || this.props.defaultValue || '').length,
+      });
     }
   }
 

--- a/src/InputArea/InputArea.js
+++ b/src/InputArea/InputArea.js
@@ -243,9 +243,18 @@ class InputArea extends React.PureComponent {
       computedStyle.getPropertyValue('line-height'),
       10,
     );
-    const lineHeightValue = isNaN(lineHeight)
-      ? this._getDefaultLineHeight() * fontSize
-      : lineHeight;
+    let lineHeightValue;
+
+    if (isNaN(lineHeight)) {
+      if (isNaN(fontSize)) {
+        return InputArea.MIN_ROWS;
+      }
+
+      lineHeightValue = this._getDefaultLineHeight() * fontSize;
+    } else {
+      lineHeightValue = lineHeight;
+    }
+
     return Math.floor(this.textArea.scrollHeight / lineHeightValue);
   };
 

--- a/src/InputArea/InputArea.js
+++ b/src/InputArea/InputArea.js
@@ -46,6 +46,10 @@ class InputArea extends React.PureComponent {
     }
   }
 
+  componentWillUnmount() {
+    this._updateComputedStyle.cancel();
+  }
+
   render() {
     const {
       dataHook,


### PR DESCRIPTION
### 🔦 Summary

Fixes 2 separate bugs, both occur when testing `InputArea` with the.`autoGrow` property and both cause a lot of noise.

The first is this error - `Error: Uncaught [TypeError: Cannot read property 'style' of null]`
* It is caused by a debounced function getting called after the `InputArea` has been unmounted, and is fixed by cancelling the debounced function on unmount.

The second is this warning - `Warning: Received NaN for the 'rows' attribute. If this is expected, cast the value to a string.`
* It is caused by the `InputArea` not having a font-size in its computed style when running tests, and is fixed by returning `MIN_ROWS` as its row count in that case.

### ✅ Checklist

- 🔬 Change is tested
  - [x] Component
