### PR TITLE
<Modal/> - Testkit - export getContent method

### DIFF
--- a/src/Modal/Modal.driver.d.ts
+++ b/src/Modal/Modal.driver.d.ts
@@ -10,6 +10,7 @@ export interface ModalDriver<T> extends BaseDriver {
   closeButtonExists: () => boolean;
   clickOnOverlay: () => boolean;
   clickOnCloseButton: () => boolean;
+  getContent: () => Element;
   getContentStyle: () => CSSStyleDeclaration;
   getContentLabel: () => string | null;
   getZIndex: () => string | null;

--- a/src/Modal/Modal.driver.js
+++ b/src/Modal/Modal.driver.js
@@ -28,6 +28,8 @@ const modalDriverFactory = ({ element }) => {
       const button = getCloseButton();
       ReactTestUtils.Simulate.click(button);
     },
+    /** returns the element of the modal content (helpful to initialize a layout testkit) */
+    getContent,
     getContentStyle: () => getContent().style,
     /** returns the modal aria-label value as given in contentLabel property */
     getContentLabel: () => getContent().getAttribute('aria-label'),

--- a/src/Modal/Modal.driver.js
+++ b/src/Modal/Modal.driver.js
@@ -30,6 +30,7 @@ const modalDriverFactory = ({ element }) => {
     },
     /** returns the element of the modal content (helpful to initialize a layout testkit) */
     getContent,
+    /** returns the style of the modal content */
     getContentStyle: () => getContent().style,
     /** returns the modal aria-label value as given in contentLabel property */
     getContentLabel: () => getContent().getAttribute('aria-label'),

--- a/src/Modal/Modal.uni.driver.d.ts
+++ b/src/Modal/Modal.uni.driver.d.ts
@@ -10,6 +10,7 @@ export interface ModalUniDriver extends BaseUniDriver {
   closeButtonExists: () => Promise<boolean>;
   clickOnOverlay: () => Promise<void>;
   clickOnCloseButton: () => Promise<void>;
+  getContent: () => Promise<Element>;
   getContentStyle: () => Promise<any>;
   getContentLabel: () => Promise<string | null>;
   getZIndex: () => Promise<any>;

--- a/src/Modal/Modal.uni.driver.js
+++ b/src/Modal/Modal.uni.driver.js
@@ -30,6 +30,9 @@ export const modalUniDriverFactory = (base, body) => {
     /** click on the modal overlay (helpful for testing if the modal is dismissed) */
     clickOnOverlay: () => getOverlay().click(),
     clickOnCloseButton: () => getCloseButton().click(),
+    /** returns the element of the modal content (helpful to initialize a layout testkit) */
+    getContent,
+    /** returns the style of the modal content */
     getContentStyle: async () => await getContent()._prop('style'),
     /** returns the modal aria-label value as given in contentLabel property */
     getContentLabel: () => getContent().attr('aria-label'),

--- a/src/Modal/Modal.uni.driver.js
+++ b/src/Modal/Modal.uni.driver.js
@@ -31,7 +31,8 @@ export const modalUniDriverFactory = (base, body) => {
     clickOnOverlay: () => getOverlay().click(),
     clickOnCloseButton: () => getCloseButton().click(),
     /** returns the element of the modal content (helpful to initialize a layout testkit) */
-    getContent,
+    // eslint-disable-next-line no-restricted-properties
+    getContent: async () => await getContent().getNative(),
     /** returns the style of the modal content */
     getContentStyle: async () => await getContent()._prop('style'),
     /** returns the modal aria-label value as given in contentLabel property */

--- a/src/Modal/test/Modal.spec.js
+++ b/src/Modal/test/Modal.spec.js
@@ -101,7 +101,7 @@ describe('Modal', () => {
             />,
           );
 
-          expect((await driver.getContentStyle()).maxHeight).toBe(
+          expect((await driver.getContent().style).maxHeight).toBe(
             'calc(100vh - 48px)',
           );
         });

--- a/src/Modal/test/Modal.spec.js
+++ b/src/Modal/test/Modal.spec.js
@@ -101,7 +101,7 @@ describe('Modal', () => {
             />,
           );
 
-          expect((await driver.getContent().style).maxHeight).toBe(
+          expect((await driver.getContent()).style.maxHeight).toBe(
             'calc(100vh - 48px)',
           );
         });


### PR DESCRIPTION
### 🔦 Summary

Expose `getContent()` method from Modal.driver.
This will enable users to initialize a layout testkit more easily. e.g.
```
const modalDriver = modalTestkitFactory({ wrapper, dataHook });
const contentElement = modalDriver.getContent();
const const layoutDriver = messageBoxFunctionalLayoutTestkitFactory({
      wrapper: contentElement,
      dataHook: ...,
    });

```