### PR TITLE
Adding missing `throttle.cancel()` invocations on component unmount

### DIFF
--- a/src/MessageBox/FunctionalLayout/MessageBoxFunctionalLayout.js
+++ b/src/MessageBox/FunctionalLayout/MessageBoxFunctionalLayout.js
@@ -21,6 +21,7 @@ class MessageBoxFunctionalLayout extends React.PureComponent {
 
   componentWillUnmount() {
     if (this.state.hasScroll) {
+      this._handleMessageBoxScroll.cancel();
       this.messageBoxRef.removeEventListener(
         'scroll',
         this._handleMessageBoxScroll,

--- a/src/common/ScrollableContainer/ScrollableContainer.js
+++ b/src/common/ScrollableContainer/ScrollableContainer.js
@@ -52,12 +52,14 @@ const ScrollableContainer = ({
     return () => {
       // Unregistering from relevant events on component unmount
       if (onScrollPositionChanged) {
+        handleScrollPositionChanged.cancel();
         scrollableElement.removeEventListener(
           'scroll',
           handleScrollPositionChanged,
         );
       }
       if (onScrollChanged) {
+        handleScrollChanged.cancel();
         scrollableElement.removeEventListener('scroll', handleScrollChanged);
       }
     };


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!---
- Be as descriptive as possible when explaining what was changed.
- Link to an issue if one exists
-->

### 🔦 Summary

Adding missing `throttle.cancel()` invocations on component unmount 
