### PR TITLE
`<PageHeader/>`- subtitle ellipsis for 2 lines

### DIFF
--- a/src/PageHeader/PageHeader.js
+++ b/src/PageHeader/PageHeader.js
@@ -198,6 +198,7 @@ export default class PageHeader extends React.PureComponent {
                   >
                     <Text
                       className={classes.root}
+                      maxWidth={288}
                       ellipsis={typeof subtitle === 'string'}
                       light={isDarkTheme(hasBackgroundImage, minimized)}
                       secondary={!isDarkTheme(hasBackgroundImage, minimized)}

--- a/src/PageHeader/PageHeader.js
+++ b/src/PageHeader/PageHeader.js
@@ -1,5 +1,4 @@
 import s from './PageHeader.scss';
-import { classes } from './PageHeader.st.css';
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
@@ -197,7 +196,7 @@ export default class PageHeader extends React.PureComponent {
                     data-hook="page-header-subtitle"
                   >
                     <Text
-                      className={classes.root}
+                      lineClamp={2}
                       maxWidth="288px"
                       ellipsis={typeof subtitle === 'string'}
                       light={isDarkTheme(hasBackgroundImage, minimized)}

--- a/src/PageHeader/PageHeader.js
+++ b/src/PageHeader/PageHeader.js
@@ -198,7 +198,7 @@ export default class PageHeader extends React.PureComponent {
                   >
                     <Text
                       className={classes.root}
-                      maxWidth={288}
+                      maxWidth="288px"
                       ellipsis={typeof subtitle === 'string'}
                       light={isDarkTheme(hasBackgroundImage, minimized)}
                       secondary={!isDarkTheme(hasBackgroundImage, minimized)}

--- a/src/PageHeader/PageHeader.js
+++ b/src/PageHeader/PageHeader.js
@@ -1,4 +1,5 @@
 import s from './PageHeader.scss';
+import { classes } from './PageHeader.st.css';
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
@@ -196,6 +197,7 @@ export default class PageHeader extends React.PureComponent {
                     data-hook="page-header-subtitle"
                   >
                     <Text
+                      className={classes.root}
                       ellipsis={typeof subtitle === 'string'}
                       light={isDarkTheme(hasBackgroundImage, minimized)}
                       secondary={!isDarkTheme(hasBackgroundImage, minimized)}

--- a/src/PageHeader/PageHeader.st.css
+++ b/src/PageHeader/PageHeader.st.css
@@ -1,6 +1,0 @@
-.root {
-  white-space: normal !important;
-  display: -webkit-box !important;
-  -webkit-line-clamp: 2 !important; /* number of lines to show */
-  -webkit-box-orient: vertical;
-}

--- a/src/PageHeader/PageHeader.st.css
+++ b/src/PageHeader/PageHeader.st.css
@@ -1,0 +1,6 @@
+.root {
+  white-space: normal !important;
+  display: -webkit-box !important;
+  -webkit-line-clamp: 2 !important; /* number of lines to show */
+  -webkit-box-orient: vertical;
+}

--- a/src/PageHeader/docs/examples.js
+++ b/src/PageHeader/docs/examples.js
@@ -3,6 +3,7 @@ export const breadcrumbs = `
   breadcrumbs={<Breadcrumbs activeId="3" items={[{id: '1', value: '#1 item'}, {id: '2', value: '#2 item'}, {id: '3', value: '#3 item'}]} onClick={() => {}}/>}
   onBackClicked={() => {}}
   title="Page Header"
+  subtitle="I am a relatively long subtitle to fill this space"
 />
 `;
 

--- a/src/PageHeader/docs/examples.js
+++ b/src/PageHeader/docs/examples.js
@@ -16,8 +16,17 @@ export const actionBar = `
 
 export const editableTitle = `
 <Page.Header
-  title={<EditableTitle initialValue="This title is editable"/>} 
+  title={<EditableTitle initialValue="This title is editable"/>}
   breadcrumbs={<Breadcrumbs activeId="3" items={[{id: '1', value: '#1 item'}, {id: '2', value: '#2 item'}, {id: '3', value: '#3 item'}]} onClick={() => {}}/>}
   actionsBar={<Button>Action</Button>}
+/>
+`;
+
+export const ellipsis = `
+<Page.Header
+  breadcrumbs={<Breadcrumbs activeId="3" items={[{id: '1', value: '#1 item'}, {id: '2', value: '#2 item'}, {id: '3', value: '#3 item'}]} onClick={() => {}}/>}
+  onBackClicked={() => {}}
+  title="Page Title long enough to expose ellipsis on page title"
+  subtitle="I am a relatively long subtitle to fill this space and demonstrate the subtitle which cannot wrap up to two lines, but no more. There more text to demonstrate that it cannot exceed the three lines. I am a relatively long subtitle to fill this space and demonstrate the subtitle which cannot wrap up to two lines, but no more. There more text to demonstrate that it cannot exceed the three lines."
 />
 `;

--- a/src/PageHeader/docs/index.story.js
+++ b/src/PageHeader/docs/index.story.js
@@ -77,7 +77,7 @@ export default {
           }),
 
           example({
-            title: 'Ellipsis title',
+            title: 'Ellipsis',
             description:
               'Title are limited to a single line of text.\n' +
               'Subtitles are limited to 2 lines of text.\n',

--- a/src/PageHeader/docs/index.story.js
+++ b/src/PageHeader/docs/index.story.js
@@ -75,6 +75,14 @@ export default {
             description: 'Title can be set with the EditableTitle component',
             source: examples.editableTitle,
           }),
+
+          example({
+            title: 'Ellipsis title',
+            description:
+              'Title are limited to a single line of text.\n' +
+              'Subtitles are limited to 2 lines of text.\n',
+            source: examples.ellipsis,
+          }),
         ],
       }),
 

--- a/src/PageHeader/docs/index.story.js
+++ b/src/PageHeader/docs/index.story.js
@@ -79,8 +79,8 @@ export default {
           example({
             title: 'Ellipsis',
             description:
-              'Title are limited to a single line of text.\n' +
-              'Subtitles are limited to 2 lines of text.\n',
+              'Title is limited to a single line of text.\n' +
+              'Subtitle is limited to 2 lines of text.\n',
             source: examples.ellipsis,
           }),
         ],

--- a/src/PageHeader/test/PageHeader.visual.js
+++ b/src/PageHeader/test/PageHeader.visual.js
@@ -39,7 +39,7 @@ const tests = [
             <PageHeader
               {...defaultProps}
               title="PageHeader title - very very long very very long very very long very very long very very long"
-              subtitle="PageHeader subtitle - very very long very very long very very long very very long very very long very very long very very long"
+              subtitle="PageHeader subtitle - very very long very very long very very long very very long very very long very very long very very long very very long very very long very very long very very long very very long very very long"
             />
           </PageHeaderContainer>
         ),

--- a/src/Text/RawText.js
+++ b/src/Text/RawText.js
@@ -54,6 +54,7 @@ const RawText = React.forwardRef(
       maxWidth,
       zIndex,
       showTooltip,
+      style,
       ...rest
     },
     ref,
@@ -77,6 +78,7 @@ const RawText = React.forwardRef(
         ...textProps,
         'data-hook': dataHook,
         className: st(classes.root, styleAttributes, className),
+        style,
         ...styleDataAttributes,
       },
       children,

--- a/src/Text/Text.js
+++ b/src/Text/Text.js
@@ -12,13 +12,16 @@ const TextWithEllipsis = ({ className, ...props }) => {
         size: props.size,
         weight: props.weight,
       })}
-      render={({ ref, ellipsisClasses }) => (
-        <RawText
-          {...componentProps}
-          ref={ref}
-          className={ellipsisClasses(className)}
-        />
-      )}
+      render={({ ref, ellipsisClasses, style }) => {
+        return (
+          <RawText
+            {...componentProps}
+            ref={ref}
+            className={ellipsisClasses(className)}
+            style={style}
+          />
+        );
+      }}
     />
   );
 };

--- a/src/common/Ellipsis/Ellipsis.js
+++ b/src/common/Ellipsis/Ellipsis.js
@@ -21,6 +21,9 @@ class Ellipsis extends React.PureComponent {
     /** The render function, use it to render a text you want to truncate with ellipsis. */
     render: PropTypes.func,
 
+    /** ellipsis lines number */
+    lineClamp: PropTypes.number,
+
     // Tooltip props
     ...TooltipCommonProps,
   };
@@ -54,17 +57,30 @@ class Ellipsis extends React.PureComponent {
   _updateEllipsisState = () => {
     const { ellipsis } = this.props;
     const { isActive } = this.state;
-    const { current: textElement } = this.ref;
     const shouldBeActive =
-      ellipsis &&
-      textElement &&
-      (textElement.scrollWidth - textElement.parentNode.offsetWidth > 1 ||
-        textElement.offsetWidth < textElement.scrollWidth ||
-        textElement.scrollHeight - textElement.parentNode.offsetHeight > 1 ||
-        textElement.offsetHeight < textElement.scrollHeight);
+      ellipsis && (this._widthCheck() || this._HeightCheck());
 
     if (shouldBeActive !== isActive)
       this.setState({ isActive: shouldBeActive });
+  };
+
+  _widthCheck = () => {
+    const { current: textElement } = this.ref;
+
+    return (
+      textElement &&
+      (textElement.scrollWidth - textElement.parentNode.offsetWidth > 1 ||
+        textElement.offsetWidth < textElement.scrollWidth)
+    );
+  };
+
+  _HeightCheck = () => {
+    const { current: textElement } = this.ref;
+    return (
+      textElement &&
+      (textElement.scrollHeight - textElement.parentNode.offsetHeight > 1 ||
+        textElement.offsetHeight < textElement.scrollHeight)
+    );
   };
 
   /**
@@ -79,12 +95,18 @@ class Ellipsis extends React.PureComponent {
   }
 
   _renderText = () => {
-    const { ellipsis, render } = this.props;
+    const { ellipsis, render, lineClamp } = this.props;
 
     return render({
       ref: this.ref,
       ellipsisClasses: (...classNames) =>
-        [ellipsis && classes.text, ...classNames].filter(Boolean).join(' '),
+        [
+          ellipsis && classes.text,
+          ellipsis && lineClamp && classes.lineClamp,
+          ...classNames,
+        ]
+          .filter(Boolean)
+          .join(' '),
     });
   };
 

--- a/src/common/Ellipsis/Ellipsis.js
+++ b/src/common/Ellipsis/Ellipsis.js
@@ -99,6 +99,7 @@ class Ellipsis extends React.PureComponent {
 
     return render({
       ref: this.ref,
+      ...(lineClamp && { style: { WebkitLineClamp: lineClamp } }),
       ellipsisClasses: (...classNames) =>
         [
           ellipsis && classes.text,

--- a/src/common/Ellipsis/Ellipsis.js
+++ b/src/common/Ellipsis/Ellipsis.js
@@ -48,7 +48,7 @@ class Ellipsis extends React.PureComponent {
   }
 
   /**
-   * An ellipsis is considered active when either the text's scroll width is wider than it's container or itself.
+   * An ellipsis is considered active when either the text's scroll width/height is wider than it's container or itself.
    * @private
    */
   _updateEllipsisState = () => {

--- a/src/common/Ellipsis/Ellipsis.js
+++ b/src/common/Ellipsis/Ellipsis.js
@@ -59,7 +59,9 @@ class Ellipsis extends React.PureComponent {
       ellipsis &&
       textElement &&
       (textElement.scrollWidth - textElement.parentNode.offsetWidth > 1 ||
-        textElement.offsetWidth < textElement.scrollWidth);
+        textElement.offsetWidth < textElement.scrollWidth ||
+        textElement.scrollHeight - textElement.parentNode.offsetHeight > 1 ||
+        textElement.offsetHeight < textElement.scrollHeight);
 
     if (shouldBeActive !== isActive)
       this.setState({ isActive: shouldBeActive });

--- a/src/common/Ellipsis/Ellipsis.st.css
+++ b/src/common/Ellipsis/Ellipsis.st.css
@@ -13,6 +13,13 @@
   vertical-align: bottom !important;
 }
 
+.lineClamp {
+  white-space: normal !important;
+  display: -webkit-box !important;
+  -webkit-line-clamp: 2 !important; /* number of lines to show */
+  -webkit-box-orient: vertical;
+}
+
 /* Tooltip */
 .tooltip {
   -st-extends: Tooltip;

--- a/src/common/Ellipsis/Ellipsis.st.css
+++ b/src/common/Ellipsis/Ellipsis.st.css
@@ -16,7 +16,6 @@
 .lineClamp {
   white-space: normal !important;
   display: -webkit-box !important;
-  -webkit-line-clamp: 2 !important; /* number of lines to show */
   -webkit-box-orient: vertical;
 }
 

--- a/src/common/Ellipsis/EllipsisUtils.js
+++ b/src/common/Ellipsis/EllipsisUtils.js
@@ -18,6 +18,7 @@ export const extractEllipsisProps = ({
   showTooltip,
   textAlign,
   zIndex,
+  lineClamp,
   ...componentProps
 }) => {
   return {
@@ -37,6 +38,7 @@ export const extractEllipsisProps = ({
       showTooltip,
       textAlign,
       zIndex,
+      lineClamp,
     },
     componentProps,
   };


### PR DESCRIPTION
### 🔦 Summary
Apply ellipsis when subtitle is more than 2 lines. 


<!--- Please mark all checkbox. If one is not relevant - delete it -->

### ✅ Checklist

- [ ] 👨‍💻 API change is approved by the UI Infra Developers <!--- Please tag the relevant team member -->
- [ ] 👨‍🎨 UX change is approved by the Design System UX <!--- Please tag the relevant team member -->
- 📚 Change is documented
  - [ ] Story
  - [ ] API description
  - [ ] Cheatsheet
  - [ ] Other (explain)
- 🔬 Change is tested
  - [ ] Component
  - [ ] Visual test
