### PR TITLE
<TextButton/> - fix Text child component not inheriting button's color

### DIFF
--- a/src/TextButton/TextButton.st.css
+++ b/src/TextButton/TextButton.st.css
@@ -6,13 +6,18 @@
 :import {
   -st-from: '../Foundation/stylable/colors.st.css';
   -st-named: P10, P20, D80, D10, D20, F00, D10-30, D80-70, R10, R20,
-   THEME-COLOR-10,  THEME-COLOR-20;
+    THEME-COLOR-10, THEME-COLOR-20;
 }
 
 :import {
   -st-from: '../Foundation/stylable/typography.st.css';
   -st-named: text-tiny-thin, text-tiny-normal, text-small-thin,
     text-small-normal, text-medium-thin, text-medium-normal;
+}
+
+:import {
+  -st-from: "../Text/Text.st.css";
+  -st-default: Text;
 }
 
 .root {
@@ -56,7 +61,8 @@
   box-shadow: 0 0 0 3px value(F00);
 }
 
-.root:fluid, .root:fluid::content {
+.root:fluid,
+.root:fluid::content {
   width: 100%;
 }
 
@@ -174,6 +180,7 @@
   -st-mixin: text-tiny-thin;
   height: 18px;
 }
+
 .root:size(tiny):weight(normal) {
   -st-mixin: text-tiny-normal;
   height: 18px;
@@ -213,4 +220,9 @@
 .root:size(tiny)::suffix {
   width: 18px;
   height: 18px;
+}
+
+/* children components */
+.root Text {
+  color: inherit;
 }


### PR DESCRIPTION
When a `<Text/>` component is passed as `<TextButtons/>`'s child, it does not inherit the text color.

As can be seen in the Ellipsis example here:

https://www.wix.com/pages/wix-style-react/?path=/story/components-api-components--textbutton

Before:
![image](https://user-images.githubusercontent.com/4023882/90520083-8e1c6100-e171-11ea-9fd1-36cee2d8e6aa.png)
After:
![image](https://user-images.githubusercontent.com/4023882/90523157-3c75d580-e175-11ea-97a5-d5f2d9f7f1b7.png)

