### PR TITLE
Updated colors based on DS for plain theme, disabled status

### DIFF
--- a/src/AddItem/AddItem.st.css
+++ b/src/AddItem/AddItem.st.css
@@ -3,7 +3,7 @@
   -st-named:
     B10, B20, B30, B40, B50,
     D60, D70, D80,
-    D10-05, D10-30,
+    D10-10, D10-05, D10-30,
     F00,
 }
 
@@ -72,8 +72,7 @@
 
 .root:theme(plain):disabled {
   cursor: not-allowed;
-  background-color: value(D10-05);
-  color: value(D10-30);
+  color: value(D10-10);
 }
 
 /* Theme dashes */


### PR DESCRIPTION
Background and text colors have been changed by DS for <AddItem> in plain theme for when it is disabled.
https://app.zeplin.io/project/5c8f6f1f9f489505cac756dc/screen/5d13613814eb0b04e67bfaf0

### ✅ Checklist
❓ 👨‍💻 API change is approved by the UI Infra Developers (I guess this PR is where I should get an approval?)
✅  👨‍🎨 UX change is approved by the Design System UX @angelez
❓ Visual test (requested access to Applitools - cannot login yet)