### PR TITLE
<Table/> - auto layout

### DIFF
--- a/src/Table/DataTable/DataTable.js
+++ b/src/Table/DataTable/DataTable.js
@@ -191,7 +191,12 @@ class DataTable extends React.Component {
   };
 
   renderTable = rowsToRender => {
-    const { dataHook, showLastRowDivider, horizontalScroll } = this.props;
+    const {
+      dataHook,
+      showLastRowDivider,
+      horizontalScroll,
+      layout,
+    } = this.props;
     const style = { width: this.props.width };
     return (
       <div
@@ -209,6 +214,7 @@ class DataTable extends React.Component {
           style={style}
           className={classNames(this.style.table, {
             [this.style.showLastRowDivider]: showLastRowDivider,
+            [this.style.fixedLayout]: layout === 'fixed',
           })}
         >
           {!this.props.hideHeader && <TableHeader {...this.props} />}
@@ -452,12 +458,15 @@ class DataTable extends React.Component {
       data,
       virtualizedTableHeight,
       virtualizedListRef,
+      layout,
     } = this.props;
     return (
       <div data-hook={dataHook}>
         <List
           ref={virtualizedListRef}
-          className={classNames(this.style.table, this.style.virtualized)}
+          className={classNames(this.style.table, this.style.virtualized, {
+            [this.style.fixedLayout]: layout === 'fixed',
+          })}
           height={virtualizedTableHeight}
           itemCount={data.length}
           itemData={this.props}
@@ -628,6 +637,7 @@ DataTable.defaultProps = {
   horizontalScroll: false,
   stickyColumns: 0,
   isRowDisabled: () => false,
+  layout: 'fixed',
 };
 
 DataTable.propTypes = {
@@ -752,6 +762,9 @@ DataTable.propTypes = {
   leftShadowVisible: PropTypes.bool,
   rightShadowVisible: PropTypes.bool,
   onUpdateScrollShadows: PropTypes.func,
+  /** Controls table's css table-layout property
+   * The table-layout property defines the algorithm used to lay out table cells, rows, and columns. */
+  layout: PropTypes.oneOf(['auto', 'fixed']),
 };
 DataTable.displayName = 'DataTable';
 

--- a/src/Table/DataTable/DataTable.js
+++ b/src/Table/DataTable/DataTable.js
@@ -22,6 +22,7 @@ export const DataTableHeader = props => {
     leftShadowVisible,
     rightShadowVisible,
     stickyColumns,
+    layout,
   } = props;
 
   const wrapWithHorizontalScroll = table => (
@@ -43,7 +44,12 @@ export const DataTableHeader = props => {
         [styles.tableHeaderScrollContent]: horizontalScroll,
       })}
     >
-      <table style={{ width: props.width }} className={styles.table}>
+      <table
+        style={{ width: props.width }}
+        className={classNames(styles.table, {
+          [styles.fixedLayout]: layout === 'fixed',
+        })}
+      >
         <TableHeader {...props} />
       </table>
     </div>

--- a/src/Table/DataTable/DataTable.scss
+++ b/src/Table/DataTable/DataTable.scss
@@ -20,8 +20,11 @@ $cellHorizontalEdgePadding: 30px;
   @include FontRoman();
   border-collapse: collapse;
   border-spacing: 0px;
-  table-layout: fixed;
   background-color: white;
+
+  &.fixedLayout {
+    table-layout: fixed;
+  }
 
   &.virtualized {
     display: block;
@@ -53,15 +56,16 @@ $cellHorizontalEdgePadding: 30px;
       display: flex;
     }
 
-    td, th {
+    td,
+    th {
       display: flex;
       align-items: center;
     }
-
   }
 }
 
-.table td, .table th {
+.table td,
+.table th {
   padding-left: $cellHorizontalPadding;
   padding-right: $cellHorizontalPadding;
 
@@ -107,7 +111,6 @@ $cellHorizontalEdgePadding: 30px;
   }
 
   .th-container {
-
     display: flex;
     align-items: center;
 
@@ -133,7 +136,6 @@ $cellHorizontalEdgePadding: 30px;
     @include Text($weight: normal, $size: small);
   }
 }
-
 
 .table td {
   @include Text($weight: thin, $size: small, $secondary: true);
@@ -300,7 +302,11 @@ $cellHorizontalEdgePadding: 30px;
   &.leftShadowVisible {
     &:not(.withStickyColumns)::before,
     .lastSticky::after {
-      background-image: linear-gradient(to right, rgba($D10, 0.08), rgba($D80, 0));
+      background-image: linear-gradient(
+        to right,
+        rgba($D10, 0.08),
+        rgba($D80, 0)
+      );
       left: 0;
       opacity: 1;
     }
@@ -324,18 +330,18 @@ $cellHorizontalEdgePadding: 30px;
   right: 0;
 }
 
-.stickyActionCell [data-hook="table-action-cell-placeholder"] {
-   display: none;
+.stickyActionCell [data-hook='table-action-cell-placeholder'] {
+  display: none;
 }
 
-.stickyActionCell [data-hook="table-action-cell-popover-menu"] {
+.stickyActionCell [data-hook='table-action-cell-popover-menu'] {
   visibility: hidden;
 }
 
 .table {
   tr:hover {
     .stickyActionCell {
-        background-color: $D80;
+      background-color: $D80;
     }
 
     &.clickableDataRow td {
@@ -343,12 +349,12 @@ $cellHorizontalEdgePadding: 30px;
       background-color: $B50;
     }
 
-    .stickyActionCell [data-hook="table-action-cell-popover-menu"] {
+    .stickyActionCell [data-hook='table-action-cell-popover-menu'] {
       visibility: visible;
     }
   }
 
-  tr:hover.highlight{
+  tr:hover.highlight {
     .stickyActionCell {
       background-color: $B60;
     }

--- a/src/Table/DataTable/docs/ExampleAutoLayout.js
+++ b/src/Table/DataTable/docs/ExampleAutoLayout.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import DataTable from '..';
+
+const style = {
+  width: '966px',
+};
+
+const data = [
+  {
+    shortText: 'Meghan',
+    longText:
+      'By the end of the 20th century, paper-and-binder personal organizers started to be replaced by electronic devices',
+  },
+  {
+    shortText: 'Sara',
+    longText:
+      'The 2014 Paris–Tours was the 108th edition of the Paris–Tours cycle race',
+  },
+  {
+    shortText: 'Deborah',
+    longText:
+      'New Georgia, with an area of 2,037 km2, is the largest of the islands in Western Province, Solomon Islands',
+  },
+  {
+    shortText: 'Walter',
+    longText:
+      'The 2016 World Senior Curling Championships was from April 16 to 23 at the Karlstad Curling Arena in Karlstad, Sweden.',
+  },
+];
+
+class DataTableAutoLayoutExample extends React.Component {
+  render() {
+    return (
+      <div style={style}>
+        <DataTable
+          dataHook="story-data-table-auto-layout"
+          data={data}
+          columns={[
+            {
+              title: 'Short Text',
+              render: row => <span>{row.shortText}</span>,
+              width: '40%',
+            },
+            {
+              title: 'Long Text',
+              render: row => <span>{row.longText}</span>,
+            },
+          ]}
+        />
+      </div>
+    );
+  }
+}
+
+export default DataTableAutoLayoutExample;

--- a/src/Table/DataTable/docs/ExampleAutoLayout.js
+++ b/src/Table/DataTable/docs/ExampleAutoLayout.js
@@ -46,6 +46,7 @@ class DataTableAutoLayoutExample extends React.Component {
               render: row => <span>{row.longText}</span>,
             },
           ]}
+          layout="auto"
         />
       </div>
     );

--- a/src/Table/DataTable/index.d.ts
+++ b/src/Table/DataTable/index.d.ts
@@ -39,6 +39,7 @@ export interface DataTableProps<RowData = RowDataDefaultType> {
   horizontalScroll?: boolean;
   stickyColumns?: number;
   isRowDisabled?: (rowData: RowData) => boolean;
+  layout?: 'fixed' | 'auto';
 }
 
 export default class DataTable<

--- a/src/Table/DataTable/test/DataTable.visual.js
+++ b/src/Table/DataTable/test/DataTable.visual.js
@@ -5,6 +5,7 @@ import Example from '../docs/Example';
 import ExampleSortable from '../docs/ExampleSortable';
 import ExampleSortableOldDesign from '../docs/ExampleSortableOldDesign';
 import ExampleWithoutHeader from '../docs/ExampleWithoutHeader';
+import ExampleAutoLayout from '../docs/ExampleAutoLayout';
 
 const tests = [
   {
@@ -29,6 +30,10 @@ const tests = [
       {
         it: 'WithoutHeader',
         story: () => <ExampleWithoutHeader />,
+      },
+      {
+        it: 'AutoLayout',
+        story: () => <ExampleAutoLayout />,
       },
     ],
   },

--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -351,6 +351,9 @@ Table.propTypes = {
   stickyColumns: PropTypes.number,
   /** a function which will be called for every row in `data` to specify if it should appear as disabled. Example: `isRowDisabled={(rowData) => !rowData.isEnabled}` */
   isRowDisabled: PropTypes.func,
+  /** Controls table's css table-layout property
+   * The table-layout property defines the algorithm used to lay out table cells, rows, and columns. */
+  layout: PropTypes.oneOf(['auto', 'fixed']),
 };
 
 // export default Table;

--- a/src/Table/docs/examples/TableAutoLayoutExample.js
+++ b/src/Table/docs/examples/TableAutoLayoutExample.js
@@ -1,0 +1,43 @@
+/* eslint-disable */
+
+class TableExample extends React.Component {
+  state = {
+    data: [
+      {
+        shortText: 'Meghan',
+        longText:
+          'By the end of the 20th century, paper-and-binder personal organizers started to be replaced by electronic devices',
+      },
+      {
+        shortText: 'Sara',
+        longText:
+          'The 2014 Paris–Tours was the 108th edition of the Paris–Tours cycle race',
+      },
+      {
+        shortText: 'Deborah',
+        longText:
+          'New Georgia, with an area of 2,037 km2, is the largest of the islands in Western Province, Solomon Islands',
+      },
+      {
+        shortText: 'Walter',
+        longText:
+          'The 2016 World Senior Curling Championships was from April 16 to 23 at the Karlstad Curling Arena in Karlstad, Sweden.',
+      },
+    ],
+  };
+
+  render() {
+    return (
+      <Table
+        data={this.state.data}
+        columns={[
+          { title: 'Short Text', render: row => row.shortText },
+          { title: 'Long Text', render: row => row.longText },
+        ]}
+        layout="auto"
+      >
+        <Table.Content />
+      </Table>
+    );
+  }
+}

--- a/src/Table/docs/index.story.js
+++ b/src/Table/docs/index.story.js
@@ -35,6 +35,7 @@ import TableHighlightedRowsExampleRaw from '!raw-loader!./examples/TableHighligh
 import TableAlignedColumnsExampleRaw from '!raw-loader!./examples/TableAlignedColumnsExample';
 import TableVirtualizationExampleRaw from '!raw-loader!./examples/TableVirtualizationExample';
 import TableStickyScrollExampleRaw from '!raw-loader!./examples/TableStickyScrollExample';
+import TableAutoLayoutExampleRaw from '!raw-loader!./examples/TableAutoLayoutExample';
 
 const code = config =>
   baseCode({
@@ -133,6 +134,13 @@ export default {
               title: 'Table Skin',
               description: 'Supports standard and neutral.',
               source: TableSkinNeutralExample,
+              compact: true,
+            },
+            {
+              title: 'Table Layout',
+              description: `The table layout defaults to \`fixed\`, where each column gets an equal width.
+              You can also set the layout prop to \`auto\`, where each column expands to fill the longest text within it.`,
+              source: TableAutoLayoutExampleRaw,
               compact: true,
             },
             {

--- a/src/Table/docs/index.story.js
+++ b/src/Table/docs/index.story.js
@@ -139,7 +139,7 @@ export default {
             {
               title: 'Table Auto Layout',
               description: `The table layout defaults to \`fixed\`, where each column gets an equal width.
-              You can also set the layout prop to \`auto\`, where each column expands to fill the longest text within it.`,
+              You can also set the \`layout\` prop to \`auto\`, where each column expands to fill the longest text within it.`,
               source: TableAutoLayoutExampleRaw,
               compact: true,
             },

--- a/src/Table/docs/index.story.js
+++ b/src/Table/docs/index.story.js
@@ -137,7 +137,7 @@ export default {
               compact: true,
             },
             {
-              title: 'Table Layout',
+              title: 'Table Auto Layout',
               description: `The table layout defaults to \`fixed\`, where each column gets an equal width.
               You can also set the layout prop to \`auto\`, where each column expands to fill the longest text within it.`,
               source: TableAutoLayoutExampleRaw,

--- a/src/Table/index.d.ts
+++ b/src/Table/index.d.ts
@@ -44,7 +44,9 @@ declare const Content: React.SFC<{
 }>;
 declare const BulkSelectionCheckbox: React.SFC<{ dataHook: string }>;
 
-export type TableColumn<RowDataType = RowDataDefaultType> = DataTableColumn<RowDataType>;
+export type TableColumn<RowDataType = RowDataDefaultType> = DataTableColumn<
+  RowDataType
+>;
 
 export type OnSelectionChangedFn = (
   selectedIds: TableProps['selectedIds'] | null,
@@ -94,4 +96,5 @@ export type UsedDataTableProps<RowData = RowDataDefaultType> = Pick<
   | 'horizontalScroll'
   | 'stickyColumns'
   | 'isRowDisabled'
+  | 'layout'
 >;

--- a/src/Table/test/Table.tsx
+++ b/src/Table/test/Table.tsx
@@ -30,7 +30,7 @@ function tableWithAllProps() {
       onMouseEnterRow={(_rowData, _rowNum) => {}}
       onMouseLeaveRow={(_rowData, _rowNum) => {}}
       onRowClick={(_rowData, _rowNum) => {}}
-      isRowDisabled={(_rowData) => false}
+      isRowDisabled={_rowData => false}
       onSelectionChanged={(_selectedIds, change) => {}}
       onSortClick={(_colData, colNum) => {}}
       rowClass="class"
@@ -54,6 +54,7 @@ function tableWithAllProps() {
       stickyColumns={2}
       width="10"
       withWrapper
+      layout="auto"
       columns={[
         {
           align: 'center',

--- a/src/Table/test/Table.visual.js
+++ b/src/Table/test/Table.visual.js
@@ -255,6 +255,14 @@ const tests = [
           children: <Table.Content titleBarVisible={false} />,
         },
       },
+      {
+        it: 'Should display the table with auto layout',
+        props: {
+          data,
+          columns,
+          layout: 'auto',
+        },
+      },
     ],
   },
   {


### PR DESCRIPTION
The table layout defaults to `fixed`, where each column gets an equal width. You can also set the layout prop to `auto`, where each column expands to fill the longest text within it.

You can check the "Table Auto Layout" example here:
https://preview.wix-style-react.com/pr_6044/?path=/story/components-api-components--table
