### PR TITLE
<Ellipsis/> - fix endless render loop

### DIFF
--- a/src/Text/Text.js
+++ b/src/Text/Text.js
@@ -5,11 +5,12 @@ import { st, classes } from './Text.st.css';
 import Ellipsis, { extractEllipsisProps } from '../common/Ellipsis';
 
 const TextWithEllipsis = ({ className, ...props }) => {
+  const { ellipsisProps, componentProps } = extractEllipsisProps(props);
+
   if (!React.Children.count(props.children)) {
-    return <RawText {...props} />;
+    return <RawText className={className} {...componentProps} />;
   }
 
-  const { ellipsisProps, componentProps } = extractEllipsisProps(props);
   return (
     <Ellipsis
       {...ellipsisProps}

--- a/src/Text/Text.js
+++ b/src/Text/Text.js
@@ -5,7 +5,9 @@ import { st, classes } from './Text.st.css';
 import Ellipsis, { extractEllipsisProps } from '../common/Ellipsis';
 
 const TextWithEllipsis = ({ className, ...props }) => {
-  if (!React.Children.count(props.children)) return null;
+  if (!React.Children.count(props.children)) {
+    return <RawText {...props} />;
+  }
 
   const { ellipsisProps, componentProps } = extractEllipsisProps(props);
   return (

--- a/src/Text/Text.js
+++ b/src/Text/Text.js
@@ -5,6 +5,8 @@ import { st, classes } from './Text.st.css';
 import Ellipsis, { extractEllipsisProps } from '../common/Ellipsis';
 
 const TextWithEllipsis = ({ className, ...props }) => {
+  if (!React.Children.count(props.children)) return null;
+
   const { ellipsisProps, componentProps } = extractEllipsisProps(props);
   return (
     <Ellipsis

--- a/src/common/Ellipsis/Ellipsis.js
+++ b/src/common/Ellipsis/Ellipsis.js
@@ -193,7 +193,7 @@ class Ellipsis extends React.PureComponent {
     const tooltipDisabled =
       disabled || showTooltip === false || !isActive || !textElement;
 
-    return ellipsis ? (
+    return ellipsis && showTooltip ? (
       <Tooltip
         className={st(classes.tooltip, wrapperClassName)}
         disabled={tooltipDisabled}

--- a/src/common/Ellipsis/Ellipsis.js
+++ b/src/common/Ellipsis/Ellipsis.js
@@ -173,7 +173,7 @@ class Ellipsis extends React.PureComponent {
     const {
       appendTo,
       wrapperClassName,
-      disabled,
+      disabled: ellipsisDisabled,
       enterDelay,
       exitDelay,
       fixed,
@@ -186,18 +186,20 @@ class Ellipsis extends React.PureComponent {
       showTooltip,
       textAlign,
       zIndex,
+      ellipsis,
     } = this.props;
     const { isActive, textContent } = this.state;
     const { current: textElement } = this.ref;
+    const tooltipDisabled =
+      ellipsisDisabled || showTooltip === false || !isActive || !textElement;
 
-    return showTooltip && isActive ? (
+    return ellipsis ? (
       <Tooltip
         className={st(classes.tooltip, wrapperClassName)}
-        disabled={!isActive || !textElement}
+        disabled={tooltipDisabled}
         content={textContent}
         {...{
           appendTo,
-          disabled: disabled || !showTooltip,
           enterDelay,
           exitDelay,
           fixed,

--- a/src/common/Ellipsis/Ellipsis.js
+++ b/src/common/Ellipsis/Ellipsis.js
@@ -190,8 +190,7 @@ class Ellipsis extends React.PureComponent {
     } = this.props;
     const { isActive, textContent } = this.state;
     const { current: textElement } = this.ref;
-    const tooltipDisabled =
-      disabled || showTooltip === false || !isActive || !textElement;
+    const tooltipDisabled = disabled || !isActive || !textElement;
 
     return ellipsis && showTooltip ? (
       <Tooltip

--- a/src/common/Ellipsis/Ellipsis.js
+++ b/src/common/Ellipsis/Ellipsis.js
@@ -173,7 +173,7 @@ class Ellipsis extends React.PureComponent {
     const {
       appendTo,
       wrapperClassName,
-      disabled: ellipsisDisabled,
+      disabled,
       enterDelay,
       exitDelay,
       fixed,
@@ -191,7 +191,7 @@ class Ellipsis extends React.PureComponent {
     const { isActive, textContent } = this.state;
     const { current: textElement } = this.ref;
     const tooltipDisabled =
-      ellipsisDisabled || showTooltip === false || !isActive || !textElement;
+      disabled || showTooltip === false || !isActive || !textElement;
 
     return ellipsis ? (
       <Tooltip


### PR DESCRIPTION
When text component inside ellipsis is rendered it calculated whether to activate the tooltip,
if tooltip state is active
text content is rendered inside <Tooltip />
else
text content is rendered outside of it
React does not know these components are the same,
causing a remount when tooltip activity status changes.
In marginal cases (where the difference in having ellipsis or not is a few pixels)
this can cause an infinite render loop.

To recreate this error - open these examples and resize the window until it breaks.

Before (Broken):
https://www.wix-style-react.com/?path=/story/introduction-playground--playground&snippet=58be2f3e-cc3b-419b-bba4-075f1b286bee

After (Fixed):
https://preview.wix-style-react.com/pr_6076/?path=/story/introduction-playground--playground&snippet=58be2f3e-cc3b-419b-bba4-075f1b286bee