### PR TITLE
<Table/> - deprecate hideHeader prop

### DIFF
--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -294,7 +294,7 @@ Table.propTypes = {
   isRowHighlight: PropTypes.func,
   /** Whether there are more items to be loaded. Event listeners are removed if false. */
   hasMore: PropTypes.bool,
-  /** Should we hide the header of the table. */
+  /** [deprecated] This prop has no affect. To hide the table header, render `<Table.Content titleBarVisible={false}>` in `children`. */
   hideHeader: PropTypes.bool,
   /** An id to pass to the table */
   id: PropTypes.string,

--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -4,6 +4,7 @@ import defaultTo from 'lodash/defaultTo';
 import classNames from 'classnames';
 import { ScrollSync } from 'react-scroll-sync';
 
+import deprecationLog from '../utils/deprecationLog';
 import { st, classes } from './Table.st.css';
 import DataTable from './DataTable';
 import Checkbox from '../Checkbox';
@@ -135,7 +136,15 @@ export class Table extends React.Component {
       onSelectionChanged,
       hasMore,
       horizontalScroll,
+      hideHeader,
     } = this.props;
+
+    if (hideHeader) {
+      deprecationLog(
+        '<Table>\'s "hideHeader" prop is deprecated. To hide the table header, render "<Table.Content titleBarVisible={false}>" in its "children" prop',
+      );
+    }
+
     let hasUnselectables = null;
     let allIds = data.map((rowData, rowIndex) =>
       rowData.unselectable

--- a/src/Table/docs/examples/TableHideHeaderExample.js
+++ b/src/Table/docs/examples/TableHideHeaderExample.js
@@ -1,0 +1,26 @@
+/* eslint-disable */
+
+class TableHideHeaderExample extends React.Component {
+  state = {
+    data: [
+      { firstName: 'Meghan', lastName: 'Bishop' },
+      { firstName: 'Sara', lastName: 'Porter' },
+      { firstName: 'Deborah', lastName: 'Rhodes' },
+      { firstName: 'Walter', lastName: 'Jenning' },
+    ],
+  };
+
+  render() {
+    return (
+      <Table
+        data={this.state.data}
+        columns={[
+          { title: 'First', render: row => row.firstName },
+          { title: 'Last', render: row => row.lastName },
+        ]}
+      >
+        <Table.Content titleBarVisible={false} />
+      </Table>
+    );
+  }
+}

--- a/src/Table/docs/index.story.js
+++ b/src/Table/docs/index.story.js
@@ -24,6 +24,7 @@ import TableRowDetailsExampleRaw from '!raw-loader!./examples/TableRowDetailsExa
 import TableSkinNeutralExample from '!raw-loader!./examples/TableSkinNeutralExample';
 import TableToolbarExampleRaw from '!raw-loader!./examples/TableToolbarExample';
 import TableSubToolbarExampleRaw from '!raw-loader!./examples/TableSubToolbarExample';
+import TableHideHeaderExampleRaw from '!raw-loader!./examples/TableHideHeaderExample';
 import TableBulkSelectionCheckboxExampleRaw from '!raw-loader!./examples/TableBulkSelectionCheckboxExample';
 import TableWithUnselectableRowsExampleRaw from '!raw-loader!./examples/TableWithUnselectableRowsExample';
 import TableEmptyStateExampleRaw from '!raw-loader!./examples/TableEmptyStateExample';
@@ -148,6 +149,12 @@ export default {
               description:
                 'A Table can contain a sticky sub-toolbar, an area for additional actions such as displaying a tag list of filtered items.',
               source: TableSubToolbarExampleRaw,
+              compact: true,
+            },
+            {
+              title: 'Hidden Header',
+              description: 'A table with hidden header.',
+              source: TableHideHeaderExampleRaw,
               compact: true,
             },
             {


### PR DESCRIPTION
### 🔦 Summary
According to [this Slack thread](https://wix.slack.com/archives/C39FTGUBZ/p1597667418084400), `hideHeader` prop is copied from `<DataTable>` but has no affect in `<Table>`, so it is better to deprecate it and explain and demo how `<Table>`'s header can be hidden.

### ✅ Checklist

- [x] 👨‍💻 API change is approved by the UI Infra Developers @gendeld 
- 📚 Change is documented
  - [x] Story
  - [x] API description
 