### PR TITLE
<VerticalTabs> activeTabId <VerticalTabsItem> id props change to be string or number

### DIFF
--- a/src/VerticalTabs/VerticalTabs.js
+++ b/src/VerticalTabs/VerticalTabs.js
@@ -39,7 +39,7 @@ VerticalTabs.propTypes = {
   size: PropTypes.oneOf(['small', 'medium']),
 
   /** Current selected tab id */
-  activeTabId: PropTypes.number,
+  activeTabId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 
   /** Callback function called on tab selection change with the following parameters<code>(id)</code> */
   onChange: PropTypes.func,

--- a/src/VerticalTabsItem/VerticalTabsItem.js
+++ b/src/VerticalTabsItem/VerticalTabsItem.js
@@ -29,7 +29,7 @@ class VerticalTabsItem extends React.PureComponent {
     disabled: PropTypes.bool,
 
     /** identifier to help identify the current selected tab */
-    id: PropTypes.number,
+    id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   };
 
   static defaultProps = {
@@ -105,7 +105,7 @@ class VerticalTabsItem extends React.PureComponent {
         })}
         id={id}
         tabIndex={tabIndex}
-        ref={ref => (this.innerComponentRef = ref)}
+        ref={(ref) => (this.innerComponentRef = ref)}
         data-hook={dataHook}
         onClick={!disabled ? () => this.context.onChange(id) : undefined}
       >


### PR DESCRIPTION
Issue:
https://github.com/wix/wix-style-react/issues/6185

### 🔦 Summary
<VerticalTabs> activeTabId prop and <VerticalTabsItem> id prop, changed type to be string or number.

-  ✅ 👨‍💻 API change is approved by the UI Infra Developers @EgoziE 
