### PR TITLE
<Tag/> - add lightOutlined theme

### DIFF
--- a/src/Tag/Tag.js
+++ b/src/Tag/Tag.js
@@ -128,13 +128,13 @@ Tag.propTypes = {
    * and mouse event as second parameter when clicking on Tag */
   onClick: PropTypes.func,
 
-  /** Callback function that pass `id` property as parameter when removing the Tag  */
+  /** Callback function that pass `id` property as parameter when removing the Tag. If the Tag is rendered inside of a `TagList`, its `onRemove` handler is set by the TagList's `onTagRemove` prop  */
   onRemove: PropTypes.func,
 
   /** If the Tag is removable then it will contain a small clickable X */
   removable: PropTypes.bool,
 
-  /** The height of the Tag */
+  /** The height of the Tag. If the Tag is rendered inside of a `TagList`, its `size` is set by the TagList's `size` prop */
   size: PropTypes.oneOf(['tiny', 'small', 'medium', 'large']),
 
   /** theme of the Tag */

--- a/src/Tag/Tag.js
+++ b/src/Tag/Tag.js
@@ -87,7 +87,7 @@ class Tag extends React.PureComponent {
         [styles.withThumb]: thumb,
         [styles.disabled]: disabled,
         [styles.clickable]: onClick !== noop,
-        [styles.hoverable]: !disabled,
+        [styles.hoverable]: !disabled && onClick !== noop,
       },
     );
   }

--- a/src/Tag/Tag.js
+++ b/src/Tag/Tag.js
@@ -145,6 +145,7 @@ Tag.propTypes = {
     'dark',
     'neutral',
     'light',
+    'lightOutlined',
   ]),
 
   /** An optional thumb to display as part of the Tag */

--- a/src/Tag/Tag.js
+++ b/src/Tag/Tag.js
@@ -128,13 +128,13 @@ Tag.propTypes = {
    * and mouse event as second parameter when clicking on Tag */
   onClick: PropTypes.func,
 
-  /** Callback function that pass `id` property as parameter when removing the Tag. If the Tag is rendered inside of a `TagList`, its `onRemove` handler is set by the TagList's `onTagRemove` prop  */
+  /** Callback function that pass `id` property as parameter when removing the Tag  */
   onRemove: PropTypes.func,
 
   /** If the Tag is removable then it will contain a small clickable X */
   removable: PropTypes.bool,
 
-  /** The height of the Tag. If the Tag is rendered inside of a `TagList`, its `size` is set by the TagList's `size` prop */
+  /** The height of the Tag */
   size: PropTypes.oneOf(['tiny', 'small', 'medium', 'large']),
 
   /** theme of the Tag */

--- a/src/Tag/Tag.scss
+++ b/src/Tag/Tag.scss
@@ -28,6 +28,7 @@
 .tinySize {
   padding: 0 9px;
   border-radius: 9px;
+  max-height: 18px;
 
   &.light-outlined-theme {
     padding: 0 8px;
@@ -60,7 +61,7 @@
 .smallSize {
   padding: 3px 12px;
   border-radius: 12px;
-
+  max-height: 24px;
 
   &.light-outlined-theme {
     padding: 2px 11px;
@@ -97,7 +98,7 @@
 .mediumSize {
   padding: 6px 12px;
   border-radius: 15px;
-
+  max-height: 30px;
 
   &.light-outlined-theme {
     padding: 5px 11px;
@@ -134,7 +135,7 @@
 .largeSize {
   padding: 6px 18px;
   border-radius: 18px;
-
+  max-height: 36px;
 
   &.light-outlined-theme {
     padding: 5px 17px;

--- a/src/Tag/Tag.scss
+++ b/src/Tag/Tag.scss
@@ -29,12 +29,24 @@
   padding: 0 9px;
   border-radius: 9px;
 
+  &.light-outlined-theme {
+    padding: 0 8px;
+  }
+
   &.withThumb {
     padding-left: 3px;
+
+    &.light-outlined-theme {
+      padding-left: 2px;
+    }
   }
 
   &.withRemoveButton {
     padding-right: 3px;
+
+    &.light-outlined-theme {
+      padding-right: 2px;
+    }
   }
 
   .thumb {
@@ -49,12 +61,25 @@
   padding: 3px 12px;
   border-radius: 12px;
 
+
+  &.light-outlined-theme {
+    padding: 2px 11px;
+  }
+
   &.withThumb {
     padding-left: 3px;
+
+    &.light-outlined-theme {
+      padding-left: 2px;
+    }
   }
 
   &.withRemoveButton {
     padding-right: 3px;
+
+    &.light-outlined-theme {
+      padding-right: 2px;
+    }
   }
 
   .thumb {
@@ -73,12 +98,25 @@
   padding: 6px 12px;
   border-radius: 15px;
 
+
+  &.light-outlined-theme {
+    padding: 5px 11px;
+  }
+
   &.withThumb {
     padding-left: 6px;
+
+    &.light-outlined-theme {
+      padding-left: 5px;
+    }
   }
 
   &.withRemoveButton {
     padding-right: 6px;
+
+    &.light-outlined-theme {
+      padding-right: 5px;
+    }
   }
 
   .thumb {
@@ -97,12 +135,25 @@
   padding: 6px 18px;
   border-radius: 18px;
 
+
+  &.light-outlined-theme {
+    padding: 5px 17px;
+  }
+
   &.withThumb {
     padding-left: 6px;
+
+    &.light-outlined-theme {
+      padding-left: 5px;
+    }
   }
 
   &.withRemoveButton {
     padding-right: 6px;
+
+    &.light-outlined-theme {
+      padding-right: 5px;
+    }
   }
 
   .thumb {
@@ -171,6 +222,16 @@
       background-color: $B50;
     }
   }
+
+  &.light-outlined-theme {
+    border: 1px solid $D60;
+    background-color: $D80;
+
+    &.hoverable:hover {
+      background-color: $B50;
+      border-color: $B30;
+    }
+  }
 }
 
 .disabled {
@@ -182,12 +243,24 @@
   .tinySize {
     padding: 0 9px;
 
+    &.light-outlined-theme {
+      padding: 0 8px;
+    }
+
     &.withThumb {
       padding-right: 3px;
+
+      &.light-outlined-theme {
+        padding-right: 2px;
+      }
     }
 
     &.withRemoveButton {
       padding-left: 3px;
+
+      &.light-outlined-theme {
+        padding-left: 2px;
+      }
     }
 
     .thumb {
@@ -199,12 +272,24 @@
   .smallSize {
     padding: 0 12px;
 
+    &.light-outlined-theme {
+      padding: 0 11px;
+    }
+
     &.withThumb {
       padding-right: 3px;
+
+      &.light-outlined-theme {
+        padding-right: 2px;
+      }
     }
 
     &.withRemoveButton {
       padding-left: 3px;
+
+      &.light-outlined-theme {
+        padding-left: 2px;
+      }
     }
 
     .thumb {
@@ -221,12 +306,24 @@
   .mediumSize {
     padding: 0 12px;
 
+    &.light-outlined-theme {
+      padding: 0 11px;
+    }
+
     &.withThumb {
       padding-right: 6px;
+
+      &.light-outlined-theme {
+        padding-right: 5px;
+      }
     }
 
     &.withRemoveButton {
       padding-left: 6px;
+
+      &.light-outlined-theme {
+        padding-left: 5px;
+      }
     }
 
     .thumb {
@@ -243,12 +340,24 @@
   .largeSize {
     padding: 0 18px;
 
+    &.light-outlined-theme {
+      padding: 0 17px;
+    }
+
     &.withThumb {
       padding-right: 6px;
+
+      &.light-outlined-theme {
+        padding-right: 5px;
+      }
     }
 
     &.withRemoveButton {
       padding-left: 6px;
+
+      &.light-outlined-theme {
+        padding-left: 5px;
+      }
     }
 
     .thumb {

--- a/src/Tag/docs/examples.js
+++ b/src/Tag/docs/examples.js
@@ -43,6 +43,10 @@ export const themes = `
       <Tag theme="light" onClick={(x)=>{}} onRemove={()=>{}}>
           Hello World
       </Tag>
+      <br/><br/>
+      <Tag theme="lightOutlined" onClick={(x)=>{}} onRemove={()=>{}}>
+          Hello World
+      </Tag>
 </React.Fragment>
 `;
 

--- a/src/Tag/index.d.ts
+++ b/src/Tag/index.d.ts
@@ -25,4 +25,5 @@ export type TagTheme =
   | 'warning'
   | 'dark'
   | 'neutral'
-  | 'light';
+  | 'light'
+  | 'lightOutlined';

--- a/src/Tag/test/Tag.spec.js
+++ b/src/Tag/test/Tag.spec.js
@@ -155,18 +155,28 @@ describe('Tag', () => {
       expect(await driver.isClickable()).toBe(true);
     });
 
-    it('should change color on hover when not disabled', async () => {
-      const driver = createDriver(<Tag id={id}>{label}</Tag>);
+    it('should change color on hover when not disable and have onClick handler', async () => {
+      const driver = createDriver(
+        <Tag id={id} onClick={() => void 0}>
+          {label}
+        </Tag>,
+      );
 
       expect(await driver.isHoverable()).toBe(true);
     });
 
     it('should not change color on hover when disabled', async () => {
       const driver = createDriver(
-        <Tag id={id} disabled>
+        <Tag id={id} onClick={() => void 0} disabled>
           {label}
         </Tag>,
       );
+
+      expect(await driver.isHoverable()).toBe(false);
+    });
+
+    it('should not change color on hover when there is no onClick handler', async () => {
+      const driver = createDriver(<Tag id={id}>{label}</Tag>);
 
       expect(await driver.isHoverable()).toBe(false);
     });


### PR DESCRIPTION
### 🔦 Summary
1. Add `lightOutlined` theme to `<Tag>` component, according to [this UX](https://zpl.io/bzq6pJE). This is done to implement **Channels indication** ([UX](https://share.goabstract.com/5877c8a2-7d85-4a0d-bdb5-db11d2bb928d?collectionId=b72f94b0-3cda-4d53-b677-4cfa55457dd7&collectionLayerId=69e79831-655a-4a28-b139-97e579773538&mode=build&selected=2892704313-8C555CB5-F234-4758-AC6C-99BDCE7F09DB&sha=bc3dc76d50c1143a0a798310077c9271157a66de)).
1. After I noticed that setting `size` to my `Tag`s in `TagList` had no effect, I realized I need to set the `size` of the `TagList`, so I updated the description of the `<Tag>`'s `size` prop (and also `onRemove`), so others will be aware of it.
1. Fix a bug where `Tag`s with no `onClick` handler are hoverable. They should not be hoverable, as nothing happens when the mouse hover over them.

Note: Because the `lightOutlined` theme adds `1px` border to the `Tag`, I reduced the padding in `1px` to keep the `Tag` in the same dimensions. However, for some sizes and dimensions, the padding was `0`, so I left it as is, which means it might make `Tag`s with `lightOutlined` theme slightly bigger. Let me know if you want me to handle it in another way.

### ✅ Checklist

- [X] 👨‍💻 API change is approved by the UI Infra Developers (@EgoziE)
- [X] 👨‍🎨 UX change is approved by the Design System UX (@milkyfruit)
- 📚 Change is documented
  - [X] Story
  - [X] API description
  - 🔬 Change is tested
  - [X] Component
  - [X] Visual test
