### PR TITLE
Suggestion - Add deprecation log to old drivers

### DIFF
--- a/src/AddItem/AddItem.driver.js
+++ b/src/AddItem/AddItem.driver.js
@@ -2,7 +2,16 @@ import textDriverFactory from '../Text/Text.driver';
 import { tooltipTestkitFactory } from 'wix-ui-core/dist/src/testkit';
 import { dataHooks } from './constants';
 
-const addItemDriverFactory = ({ element, eventTrigger }) => {
+const addItemDriverFactory = ({ element, eventTrigger, muteWarning }) => {
+  if (console && !muteWarning) {
+    // eslint-disable-next-line no-console
+    console.warn(`
+    Warning! addItemDriverFactory is deprecated and will be removed, please use AddItemDriver instead.
+    Note that AddItemDriver is async!
+    (Hide this warning by setting muteWarning: true)
+    `);
+  }
+
   const byHook = hook => element.querySelector(`[data-hook*="${hook}"]`);
   const tooltipTestkit = tooltipTestkitFactory({
     wrapper: element,

--- a/src/AddItem/test/AddItem.private.driver.js
+++ b/src/AddItem/test/AddItem.private.driver.js
@@ -2,13 +2,17 @@ import addItemDriverFactory from '../AddItem.driver';
 import { tooltipTestkitFactory } from 'wix-ui-core/dist/src/testkit';
 import { dataHooks } from '../constants';
 
-export const addItemPrivateDriverFactory = ({ element, eventTrigger }) => {
+export const addItemPrivateDriverFactory = ({
+  element,
+  eventTrigger,
+  muteWarning,
+}) => {
   const tooltipTestkit = tooltipTestkitFactory({
     wrapper: element,
     dataHook: dataHooks.itemTooltip,
   });
   return {
-    ...addItemDriverFactory({ element, eventTrigger }),
+    ...addItemDriverFactory({ element, eventTrigger, muteWarning }),
     tooltipElementExists: () => tooltipTestkit.exists(),
     getTooltipText: () => {
       tooltipTestkit.mouseEnter();

--- a/src/utils/deprecationLog.js
+++ b/src/utils/deprecationLog.js
@@ -8,10 +8,6 @@ const LOG_PREFIX = `Wix-Style-React: [WARNING] `;
 
 if (process.env.NODE_ENV !== 'production') {
   class DeprecationLogger {
-    constructor() {
-      this.log = this.log.bind(this);
-    }
-
     reportedMessages = new Set();
 
     /**
@@ -20,12 +16,12 @@ if (process.env.NODE_ENV !== 'production') {
      * @param {*} message
      * @memberof DeprecationLogger
      */
-    log(message) {
+    log = message => {
       if (!this.reportedMessages.has(message)) {
         this.reportedMessages.add(message);
         this.printWarning(message);
       }
-    }
+    };
 
     printWarning = msg => {
       const message = `${LOG_PREFIX}${msg}`;

--- a/test/utils/react/index.js
+++ b/test/utils/react/index.js
@@ -38,6 +38,7 @@ export function createRendererWithDriver(driverFactory, defaultOptions = {}) {
       wrapper: rendered.container,
       eventTrigger: Simulate,
       component,
+      muteWarning: true,
     });
   return createRendererBase(createDriver, defaultOptions);
 }


### PR DESCRIPTION
In order to push our consumers to move to uni-drivers, I suggest adding a deprecation warning to the old testkit.
This is just a suggestion, I'd like to hear your thoughts.