### PR TITLE
<MarketingLayout/> - update size tiny columns and spacing

### DIFF
--- a/src/MarketingLayout/MarketingLayout.js
+++ b/src/MarketingLayout/MarketingLayout.js
@@ -10,8 +10,8 @@ import { stVars as colorsStVars } from '../Foundation/stylable/colors.st.css';
 
 const cellSpansBySize = {
   [SIZES.tiny]: {
-    image: 3,
-    spacer: 1,
+    image: 4,
+    spacer: 0,
     content: 8,
   },
   [SIZES.small]: {
@@ -144,7 +144,7 @@ class MarketingLayout extends React.PureComponent {
     const contentCell = this._renderContentCell(cellSpans.content);
 
     return (
-      <Layout>
+      <Layout gap={size === SIZES.tiny ? '12px' : undefined}>
         {inverted
           ? [imageCell, contentCell, spacerCell]
           : [contentCell, spacerCell, imageCell]}

--- a/src/MarketingLayout/MarketingLayout.js
+++ b/src/MarketingLayout/MarketingLayout.js
@@ -11,7 +11,6 @@ import { stVars as colorsStVars } from '../Foundation/stylable/colors.st.css';
 const cellSpansBySize = {
   [SIZES.tiny]: {
     image: 4,
-    spacer: 0,
     content: 8,
   },
   [SIZES.small]: {
@@ -143,8 +142,12 @@ class MarketingLayout extends React.PureComponent {
     const imageCell = this._renderImageCell(cellSpans.image);
     const contentCell = this._renderContentCell(cellSpans.content);
 
-    return (
-      <Layout gap={size === SIZES.tiny ? '12px' : undefined}>
+    return size === SIZES.tiny ? (
+      <Layout gap="12px">
+        {inverted ? [imageCell, contentCell] : [contentCell, imageCell]}
+      </Layout>
+    ) : (
+      <Layout>
         {inverted
           ? [imageCell, contentCell, spacerCell]
           : [contentCell, spacerCell, imageCell]}

--- a/src/MarketingLayout/MarketingLayout.js
+++ b/src/MarketingLayout/MarketingLayout.js
@@ -143,7 +143,7 @@ class MarketingLayout extends React.PureComponent {
     const contentCell = this._renderContentCell(cellSpans.content);
 
     return size === SIZES.tiny ? (
-      <Layout gap="12px">
+      <Layout gap="24px">
         {inverted ? [imageCell, contentCell] : [contentCell, imageCell]}
       </Layout>
     ) : (


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!---
- Be as descriptive as possible when explaining what was changed.
- Link to an issue if one exists
-->

### 🔦 Summary

updated the layout columns and spacing for `<MarketingLayout/>` when using size tiny
set image columns span to be 4 columns instead of 3
remove spacer column for tiny layout
set spacing between columns to be 24px instead of 30px

<!--- Please mark all checkbox. If one is not relevant - delete it -->

### ✅ Checklist

- [ ] 👨‍💻 API change is approved by the UI Infra Developers <!--- Please tag the relevant team member -->
- [x] 👨‍🎨 UX change is approved by the Design System UX @milkyfruit 