### PR TITLE
<DropdownLayout /> Fix DropdownLayout option re-renders

### DIFF
--- a/packages/wix-style-react/src/DropdownLayout/DropdownLayout.js
+++ b/packages/wix-style-react/src/DropdownLayout/DropdownLayout.js
@@ -440,7 +440,7 @@ class DropdownLayout extends React.PureComponent {
 
   _isBuilderOption({ option }) {
     const { value } = option;
-    return typeof value === 'function' || React.isValidElement(value);
+    return typeof value === 'function' || (typeof value === 'object' && React.isValidElement(value));
   }
 
   _isCustomOption({ option }) {

--- a/packages/wix-style-react/src/DropdownLayout/DropdownLayout.js
+++ b/packages/wix-style-react/src/DropdownLayout/DropdownLayout.js
@@ -440,7 +440,7 @@ class DropdownLayout extends React.PureComponent {
 
   _isBuilderOption({ option }) {
     const { value } = option;
-    return typeof value === 'function';
+    return typeof value === 'function' || React.isValidElement(value);
   }
 
   _isCustomOption({ option }) {


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

### 🔦 Summary

Currently, when options in dropdown are JSX elements, they are being re-rendered when "selected option" changes (triggering state change and recalculation of the tree). Adding this option ensures if a value is a functional component or any other react component, they will be returned as is.


<!--- Please mark all checkbox. If one is not relevant - delete it -->

### ✅ Checklist

- [ ] 👨‍💻 API change is approved by the UI Infra Developers <!--- Please tag the relevant team member -->
- [ ] 👨‍🎨 UX change is approved by the Design System UX <!--- Please tag the relevant team member -->
- 📚 Change is documented
  - [ ] Story
  - [ ] API description
  - [ ] Cheatsheet
  - [ ] Other (explain)
- 🔬 Change is tested
  - [x] Component
  - [ ] Visual test
