### PR TITLE
unpin wix-style-react version

### DIFF
--- a/packages/wix-ui-tpa/package.json
+++ b/packages/wix-ui-tpa/package.json
@@ -71,7 +71,7 @@
     "lodash": "^4.17.11",
     "normalize-scroll-left": "^0.2.1",
     "react-resize-detector": "^4.1.3",
-    "wix-style-react": "9.72.0",
+    "wix-style-react": "^9.79.0",
     "wix-ui-core": "^3.0.150",
     "wix-ui-icons-common": "^2.0.0",
     "yoshi-stylable-dependencies": "^4.86.0",


### PR DESCRIPTION
pinning `wix-style-react` version in `wix-ui-tpa/package.json` has an
effect:

* `lerna bootstrap` would install `wix-style-react` dependencies twice,
  including all of its chromedriver and such. This has negative impact
  on build time
* because of the pin, `packages/wix-ui-tpa/node_modules/wix-style-react`
  is a full package and not a link to `packages/wix-style-react`. Thus,
  a published `wix-style-react` version is used and not the local one

This PR removes the pin, fixing both items above