### PR TITLE
feat(Image): implement `focalPoint` prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,9 @@
   },
   "devDependencies": {
     "lerna": "^3.22.1"
+  },
+  "prettier": {
+    "singleQuote": true,
+    "trailingComma": "all"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,9 +25,5 @@
   },
   "devDependencies": {
     "lerna": "^3.22.1"
-  },
-  "prettier": {
-    "singleQuote": true,
-    "trailingComma": "all"
   }
 }

--- a/packages/wix-ui-tpa/src/components/Image/Image.tsx
+++ b/packages/wix-ui-tpa/src/components/Image/Image.tsx
@@ -2,7 +2,10 @@ import classnames from 'classnames';
 import * as React from 'react';
 import { Image as CoreImage } from 'wix-ui-core/image';
 import { classes, st } from './Image.st.css';
-import { calculateDimensions } from './ImageUtils';
+import {
+  calculateDimensions,
+  resolveFocalPointCoordinates,
+} from './ImageUtils';
 import { RelativeMediaImage } from './RelativeMediaImage';
 import {
   ImageProps,
@@ -10,6 +13,7 @@ import {
   AspectRatioPresets,
   LoadingBehaviorOptions,
   HoverEffectOptions,
+  FocalPointPresets,
 } from './types';
 
 type DefaultProps = Pick<ImageProps, 'resize'>;
@@ -63,6 +67,7 @@ export class Image extends React.Component<ImageProps> {
       onLoad,
       aspectRatio,
       resize,
+      focalPoint,
       fluid,
       hoverEffect,
       loadingBehavior,
@@ -88,6 +93,9 @@ export class Image extends React.Component<ImageProps> {
       ...sourceDimensions,
       aspectRatio: aspectRatioAsNumber,
     });
+
+    const focalPointCoordinates =
+      focalPoint && resolveFocalPointCoordinates(focalPoint);
 
     const hasLoadingBehavior = loadingBehavior === LoadingBehaviorOptions.blur;
 
@@ -130,6 +138,7 @@ export class Image extends React.Component<ImageProps> {
             className={classes.image}
             sourceDimensions={sourceDimensions}
             containerDimensions={calculatedDimensions}
+            focalPoint={focalPointCoordinates}
             isPlaceholderDisplayed={hasLoadingBehavior && !isLoaded}
             onLoad={this._onLoad}
             {...imageProps}

--- a/packages/wix-ui-tpa/src/components/Image/Image.tsx
+++ b/packages/wix-ui-tpa/src/components/Image/Image.tsx
@@ -127,7 +127,14 @@ export class Image extends React.Component<ImageProps> {
             src={src}
             className={classes.image}
             {...(calculatedDimensions && {
-              nativeProps: { ...calculatedDimensions },
+              nativeProps: {
+                ...calculatedDimensions,
+                ...(focalPointCoordinates && {
+                  style: {
+                    objectPosition: `${focalPointCoordinates.x}% ${focalPointCoordinates.y}%`,
+                  },
+                }),
+              },
             })}
             onLoad={this._onLoad}
             {...imageProps}

--- a/packages/wix-ui-tpa/src/components/Image/Image.visual.tsx
+++ b/packages/wix-ui-tpa/src/components/Image/Image.visual.tsx
@@ -164,14 +164,24 @@ visualize('Image', () => {
           </div>
         ));
         snap('as custom', (done) => (
-          <ImageWithWrapper
-            src={src}
-            width={300}
-            aspectRatio={AspectRatioPresets.square}
-            resize={ResizeOptions.cover}
-            focalPoint={{ x: 70, y: 20 }}
-            onLoad={done}
-          />
+          <div style={{ display: 'flex', alignItems: 'center' }}>
+            <ImageWithWrapper
+              src={src}
+              width={300}
+              height={100}
+              resize={ResizeOptions.cover}
+              focalPoint={{ x: 0, y: 20 }}
+              onLoad={done}
+            />
+            <ImageWithWrapper
+              src={src}
+              width={50}
+              height={200}
+              resize={ResizeOptions.cover}
+              focalPoint={{ x: 30, y: 0 }}
+              onLoad={done}
+            />
+          </div>
         ));
       });
 

--- a/packages/wix-ui-tpa/src/components/Image/Image.visual.tsx
+++ b/packages/wix-ui-tpa/src/components/Image/Image.visual.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
-import { delay } from '../../test/utils';
 import { snap, story, visualize } from 'storybook-snapper';
+import { delay } from '../../test/utils';
 import { Image, ImageProps } from './';
 import { classes } from './Image.visual.st.css';
 import {
   AspectRatioPresets,
+  FocalPointPresets,
   LoadingBehaviorOptions,
   ResizeOptions,
 } from './types';
@@ -59,15 +60,9 @@ visualize('Image', () => {
   stories.forEach(({ name, src, invalidSrc }) => {
     story(name, () => {
       snap('default', (done) => <ImageWithWrapper src={src} onLoad={done} />);
-      snap('with onError', (done) => (
-        <ImageWithWrapper src={invalidSrc} onError={done} />
-      ));
+      snap('with onError', (done) => <ImageWithWrapper src={invalidSrc} onError={done} />);
       snap('with blurry loading', (done) => (
-        <ImageWithWrapper
-          src={src}
-          loadingBehavior={LoadingBehaviorOptions.blur}
-          onLoad={done}
-        />
+        <ImageWithWrapper src={src} loadingBehavior={LoadingBehaviorOptions.blur} onLoad={done} />
       ));
 
       story('with dimensions', () => {
@@ -75,44 +70,22 @@ visualize('Image', () => {
           <ImageWithWrapper src={src} width={300} height={225} onLoad={done} />
         ));
         snap('as fixed width and aspectRatio', (done) => (
-          <ImageWithWrapper
-            src={src}
-            width={300}
-            aspectRatio={1}
-            onLoad={done}
-          />
+          <ImageWithWrapper src={src} width={300} aspectRatio={1} onLoad={done} />
         ));
         snap('as fixed height and aspectRatio', (done) => (
-          <ImageWithWrapper
-            src={src}
-            height={300}
-            aspectRatio={1}
-            onLoad={done}
-          />
+          <ImageWithWrapper src={src} height={300} aspectRatio={1} onLoad={done} />
         ));
       });
 
       story('with aspectRatio', () => {
         snap('as square', (done) => (
-          <ImageWithWrapper
-            src={src}
-            aspectRatio={AspectRatioPresets.square}
-            onLoad={done}
-          />
+          <ImageWithWrapper src={src} aspectRatio={AspectRatioPresets.square} onLoad={done} />
         ));
         snap('as cinema', (done) => (
-          <ImageWithWrapper
-            src={src}
-            aspectRatio={AspectRatioPresets.cinema}
-            onLoad={done}
-          />
+          <ImageWithWrapper src={src} aspectRatio={AspectRatioPresets.cinema} onLoad={done} />
         ));
         snap('as landscape', (done) => (
-          <ImageWithWrapper
-            src={src}
-            aspectRatio={AspectRatioPresets.landscape}
-            onLoad={done}
-          />
+          <ImageWithWrapper src={src} aspectRatio={AspectRatioPresets.landscape} onLoad={done} />
         ));
         snap('as custom number', (done) => (
           <ImageWithWrapper src={src} aspectRatio={1.5} onLoad={done} />
@@ -135,6 +108,40 @@ visualize('Image', () => {
             width={300}
             height={250}
             resize={ResizeOptions.cover}
+            onLoad={done}
+          />
+        ));
+      });
+
+      story('with focalPoint', () => {
+        snap('with preset', (done) => (
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(3, 1fr)',
+              gridTemplateRows: 'repeat(3, 1fr)',
+            }}
+          >
+            {Object.values(FocalPointPresets).map((focalPoint) => (
+              <ImageWithWrapper
+                key={focalPoint}
+                src='11062b_e0a93eb2e95b4845a0f5d43b07b7e1e8~mv2.jpeg'
+                width={400}
+                height={100}
+                resize={ResizeOptions.cover}
+                focalPoint={focalPoint}
+                onLoad={done}
+              />
+            ))}
+          </div>
+        ));
+        snap('as custom', (done) => (
+          <ImageWithWrapper
+            src={src}
+            width={300}
+            aspectRatio={AspectRatioPresets.square}
+            resize={ResizeOptions.cover}
+            focalPoint={{ x: 70, y: 20 }}
             onLoad={done}
           />
         ));

--- a/packages/wix-ui-tpa/src/components/Image/Image.visual.tsx
+++ b/packages/wix-ui-tpa/src/components/Image/Image.visual.tsx
@@ -142,7 +142,7 @@ visualize('Image', () => {
       });
 
       story('with focalPoint', () => {
-        snap('with preset', (done) => (
+        snap('as preset', (done) => (
           <div
             style={{
               display: 'grid',
@@ -150,9 +150,9 @@ visualize('Image', () => {
               gridTemplateRows: 'repeat(3, 150px)',
             }}
           >
-            {Object.values(FocalPointPresets).map((focalPoint) => (
+            {Object.values(FocalPointPresets).map((focalPoint, index) => (
               <ImageWithWrapper
-                key={focalPoint}
+                key={`${focalPoint.x}, ${focalPoint.y}`}
                 src={src}
                 width={200}
                 height={100}

--- a/packages/wix-ui-tpa/src/components/Image/Image.visual.tsx
+++ b/packages/wix-ui-tpa/src/components/Image/Image.visual.tsx
@@ -60,9 +60,15 @@ visualize('Image', () => {
   stories.forEach(({ name, src, invalidSrc }) => {
     story(name, () => {
       snap('default', (done) => <ImageWithWrapper src={src} onLoad={done} />);
-      snap('with onError', (done) => <ImageWithWrapper src={invalidSrc} onError={done} />);
+      snap('with onError', (done) => (
+        <ImageWithWrapper src={invalidSrc} onError={done} />
+      ));
       snap('with blurry loading', (done) => (
-        <ImageWithWrapper src={src} loadingBehavior={LoadingBehaviorOptions.blur} onLoad={done} />
+        <ImageWithWrapper
+          src={src}
+          loadingBehavior={LoadingBehaviorOptions.blur}
+          onLoad={done}
+        />
       ));
 
       story('with dimensions', () => {
@@ -70,22 +76,44 @@ visualize('Image', () => {
           <ImageWithWrapper src={src} width={300} height={225} onLoad={done} />
         ));
         snap('as fixed width and aspectRatio', (done) => (
-          <ImageWithWrapper src={src} width={300} aspectRatio={1} onLoad={done} />
+          <ImageWithWrapper
+            src={src}
+            width={300}
+            aspectRatio={1}
+            onLoad={done}
+          />
         ));
         snap('as fixed height and aspectRatio', (done) => (
-          <ImageWithWrapper src={src} height={300} aspectRatio={1} onLoad={done} />
+          <ImageWithWrapper
+            src={src}
+            height={300}
+            aspectRatio={1}
+            onLoad={done}
+          />
         ));
       });
 
       story('with aspectRatio', () => {
         snap('as square', (done) => (
-          <ImageWithWrapper src={src} aspectRatio={AspectRatioPresets.square} onLoad={done} />
+          <ImageWithWrapper
+            src={src}
+            aspectRatio={AspectRatioPresets.square}
+            onLoad={done}
+          />
         ));
         snap('as cinema', (done) => (
-          <ImageWithWrapper src={src} aspectRatio={AspectRatioPresets.cinema} onLoad={done} />
+          <ImageWithWrapper
+            src={src}
+            aspectRatio={AspectRatioPresets.cinema}
+            onLoad={done}
+          />
         ));
         snap('as landscape', (done) => (
-          <ImageWithWrapper src={src} aspectRatio={AspectRatioPresets.landscape} onLoad={done} />
+          <ImageWithWrapper
+            src={src}
+            aspectRatio={AspectRatioPresets.landscape}
+            onLoad={done}
+          />
         ));
         snap('as custom number', (done) => (
           <ImageWithWrapper src={src} aspectRatio={1.5} onLoad={done} />
@@ -125,7 +153,7 @@ visualize('Image', () => {
             {Object.values(FocalPointPresets).map((focalPoint) => (
               <ImageWithWrapper
                 key={focalPoint}
-                src='11062b_e0a93eb2e95b4845a0f5d43b07b7e1e8~mv2.jpeg'
+                src="11062b_e0a93eb2e95b4845a0f5d43b07b7e1e8~mv2.jpeg"
                 width={400}
                 height={100}
                 resize={ResizeOptions.cover}

--- a/packages/wix-ui-tpa/src/components/Image/Image.visual.tsx
+++ b/packages/wix-ui-tpa/src/components/Image/Image.visual.tsx
@@ -146,15 +146,15 @@ visualize('Image', () => {
           <div
             style={{
               display: 'grid',
-              gridTemplateColumns: 'repeat(3, 1fr)',
-              gridTemplateRows: 'repeat(3, 1fr)',
+              gridTemplateColumns: 'repeat(3, 250px)',
+              gridTemplateRows: 'repeat(3, 150px)',
             }}
           >
             {Object.values(FocalPointPresets).map((focalPoint) => (
               <ImageWithWrapper
                 key={focalPoint}
-                src="11062b_e0a93eb2e95b4845a0f5d43b07b7e1e8~mv2.jpeg"
-                width={400}
+                src={src}
+                width={200}
                 height={100}
                 resize={ResizeOptions.cover}
                 focalPoint={focalPoint}

--- a/packages/wix-ui-tpa/src/components/Image/ImageUtils.spec.tsx
+++ b/packages/wix-ui-tpa/src/components/Image/ImageUtils.spec.tsx
@@ -1,74 +1,105 @@
-import { calculateDimensions } from './ImageUtils';
+import {
+  calculateDimensions,
+  resolveFocalPointCoordinates,
+} from './ImageUtils';
+import { FocalPointPresets } from './types';
 
 describe('ImageUtils', () => {
-  const sampleDimensions = { width: 480, height: 360 };
-  const sampleAspectRatio = 1.77;
+  describe('dimensions', () => {
+    const sampleDimensions = { width: 480, height: 360 };
+    const sampleAspectRatio = 1.77;
 
-  it('should return the dimensions as are', async () => {
-    const calculatedDimensions = calculateDimensions(sampleDimensions);
+    it('should return the dimensions as are', async () => {
+      const calculatedDimensions = calculateDimensions(sampleDimensions);
 
-    expect(calculatedDimensions).toEqual(sampleDimensions);
-  });
-
-  it('should calculate the height when having both dimensions and aspect ratio', async () => {
-    const { width } = sampleDimensions;
-    const expectedDimensions = {
-      width,
-      height: Math.round(width / sampleAspectRatio),
-    };
-    const calculatedDimensions = calculateDimensions({
-      ...sampleDimensions,
-      aspectRatio: sampleAspectRatio,
+      expect(calculatedDimensions).toEqual(sampleDimensions);
     });
 
-    expect(calculatedDimensions).toEqual(expectedDimensions);
-  });
+    it('should calculate the height when having both dimensions and aspect ratio', async () => {
+      const { width } = sampleDimensions;
+      const expectedDimensions = {
+        width,
+        height: Math.round(width / sampleAspectRatio),
+      };
+      const calculatedDimensions = calculateDimensions({
+        ...sampleDimensions,
+        aspectRatio: sampleAspectRatio,
+      });
 
-  it('should calculate the missing height by the given width and aspect ratio', async () => {
-    const { width } = sampleDimensions;
-    const expectedDimensions = {
-      width,
-      height: Math.round(width / sampleAspectRatio),
-    };
-    const calculatedDimensions = calculateDimensions({
-      width,
-      aspectRatio: sampleAspectRatio,
+      expect(calculatedDimensions).toEqual(expectedDimensions);
     });
 
-    expect(calculatedDimensions).toEqual(expectedDimensions);
-  });
+    it('should calculate the missing height by the given width and aspect ratio', async () => {
+      const { width } = sampleDimensions;
+      const expectedDimensions = {
+        width,
+        height: Math.round(width / sampleAspectRatio),
+      };
+      const calculatedDimensions = calculateDimensions({
+        width,
+        aspectRatio: sampleAspectRatio,
+      });
 
-  it('should calculate the missing width by the given height and aspect ratio', async () => {
-    const { height } = sampleDimensions;
-    const expectedDimensions = {
-      width: Math.round(height * sampleAspectRatio),
-      height,
-    };
-    const calculatedDimensions = calculateDimensions({
-      height,
-      aspectRatio: sampleAspectRatio,
+      expect(calculatedDimensions).toEqual(expectedDimensions);
     });
 
-    expect(calculatedDimensions).toEqual(expectedDimensions);
+    it('should calculate the missing width by the given height and aspect ratio', async () => {
+      const { height } = sampleDimensions;
+      const expectedDimensions = {
+        width: Math.round(height * sampleAspectRatio),
+        height,
+      };
+      const calculatedDimensions = calculateDimensions({
+        height,
+        aspectRatio: sampleAspectRatio,
+      });
+
+      expect(calculatedDimensions).toEqual(expectedDimensions);
+    });
+
+    it('should return `null` when both dimensions are missing', async () => {
+      const calculatedDimensions = calculateDimensions({});
+
+      expect(calculatedDimensions).toBeNull();
+    });
+
+    it('should return `null` when having width but aspect ratio is missing', async () => {
+      const { width } = sampleDimensions;
+      const calculatedDimensions = calculateDimensions({ width });
+
+      expect(calculatedDimensions).toBeNull();
+    });
+
+    it('should return `null` when having height but aspect ratio is missing', async () => {
+      const { height } = sampleDimensions;
+      const calculatedDimensions = calculateDimensions({ height });
+
+      expect(calculatedDimensions).toBeNull();
+    });
   });
 
-  it('should return `null` when both dimensions are missing', async () => {
-    const calculatedDimensions = calculateDimensions({});
+  describe('focal point', () => {
+    it('should return an object of coordinates as is', async () => {
+      const sampleCoordinates = { x: 120, y: 120 };
+      const coordinates = resolveFocalPointCoordinates(sampleCoordinates);
 
-    expect(calculatedDimensions).toBeNull();
-  });
+      expect(coordinates).toEqual(sampleCoordinates);
+    });
 
-  it('should return `null` when having width but aspect ratio is missing', async () => {
-    const { width } = sampleDimensions;
-    const calculatedDimensions = calculateDimensions({ width });
+    it('should return an object of coordinates when having preset', async () => {
+      const [[samplePreset, sampleCoordinates]] = Object.entries(
+        FocalPointPresets,
+      );
+      const coordinates = resolveFocalPointCoordinates(samplePreset);
 
-    expect(calculatedDimensions).toBeNull();
-  });
+      expect(coordinates).toEqual(sampleCoordinates);
+    });
 
-  it('should return `null` when having height but aspect ratio is missing', async () => {
-    const { height } = sampleDimensions;
-    const calculatedDimensions = calculateDimensions({ height });
+    it('should return `null` when having incorrect preset', async () => {
+      const incorrectPreset = 'Something';
+      const coordinates = resolveFocalPointCoordinates(incorrectPreset);
 
-    expect(calculatedDimensions).toBeNull();
+      expect(coordinates).toBeNull();
+    });
   });
 });

--- a/packages/wix-ui-tpa/src/components/Image/ImageUtils.tsx
+++ b/packages/wix-ui-tpa/src/components/Image/ImageUtils.tsx
@@ -1,4 +1,4 @@
-import { Dimensions } from './types';
+import { Dimensions, FocalPoint, FocalPointPresets } from './types';
 
 /**
  * This function calculates the dimensions according the following logic:
@@ -32,4 +32,20 @@ export function calculateDimensions({
   }
 
   return { width: calculatedWidth, height: calculatedHeight };
+}
+
+/**
+ * This function resolves the focal point coordinates according the following logic:
+ * 1. Given a preset string => returns its coordinates
+ * 2. Given an incorrect preset string => returns `null`
+ * 3. Otherwise => returns the given coordinates
+ */
+export function resolveFocalPointCoordinates(
+  focalPoint: string | FocalPoint,
+): FocalPoint | null {
+  if (typeof focalPoint === 'string') {
+    return FocalPointPresets[focalPoint] || null;
+  }
+
+  return focalPoint;
 }

--- a/packages/wix-ui-tpa/src/components/Image/RelativeMediaImage/RelativeMediaImage.tsx
+++ b/packages/wix-ui-tpa/src/components/Image/RelativeMediaImage/RelativeMediaImage.tsx
@@ -14,6 +14,7 @@ const Placeholder = ({
   className,
   sourceDimensions,
   containerDimensions,
+  focalPoint,
   ...imageProps
 }: RelativeMediaImageProps) => (
   <MediaImage
@@ -21,6 +22,7 @@ const Placeholder = ({
       uri: src,
       ...sourceDimensions,
       options: {
+        focalPoint,
         filters: {
           blur: 3,
         },
@@ -40,6 +42,7 @@ export class RelativeMediaImage extends React.Component<RelativeMediaImageProps>
       sourceDimensions,
       containerDimensions,
       isPlaceholderDisplayed,
+      focalPoint,
       onLoad,
       ...imageProps
     } = this.props;
@@ -53,6 +56,7 @@ export class RelativeMediaImage extends React.Component<RelativeMediaImageProps>
               className={st(classes.placeholder, className)}
               sourceDimensions={sourceDimensions}
               containerDimensions={containerDimensions}
+              focalPoint={focalPoint}
               {...imageProps}
             />
           )}
@@ -60,6 +64,9 @@ export class RelativeMediaImage extends React.Component<RelativeMediaImageProps>
             mediaPlatformItem={{
               uri: src,
               ...sourceDimensions,
+              options: {
+                focalPoint,
+              },
             }}
             className={st(classes.root, className)}
             onLoad={onLoad}

--- a/packages/wix-ui-tpa/src/components/Image/docs/examples.ts
+++ b/packages/wix-ui-tpa/src/components/Image/docs/examples.ts
@@ -103,7 +103,7 @@ export const resizingExample = `
 `;
 
 export const aspectRatioExample = `
-<div style={{ display: 'flex', justifyContent: 'space-evenly' }}>
+<div style={{ display: 'flex', justifyContent: 'space-evenly', alignItems: 'center' }}>
   <Image
     src="c5f754_dd75514d14fa4057b4f4a6cc8ce7add3~mv2.jpg"
     width={300}
@@ -135,22 +135,33 @@ export const aspectRatioExample = `
 `;
 
 export const focalPointExample = `
-<div style={{ display: 'flex', justifyContent: 'space-evenly' }}>
+<div style={{ display: 'flex', justifyContent: 'space-evenly', alignItems: 'center' }}>
   <Image
     src="c5f754_dd75514d14fa4057b4f4a6cc8ce7add3~mv2.jpg"
-    width={480}
-    height={360}
+    width={300}
+    height={100}
     alt="Garfield smiles and puts his hand over chest"
     resize="${ResizeOptions.cover}"
-    focalPoint="${FocalPointPresets.topLeft}"
+    focalPoint="${getKeyByValue(
+      FocalPointPresets,
+      FocalPointPresets.bottomCenter,
+    )}"
   />
   <Image
     src="c5f754_dd75514d14fa4057b4f4a6cc8ce7add3~mv2.jpg"
-    width={480}
-    height={360}
+    width={300}
+    height={100}
     alt="Garfield smiles and puts his hand over chest"
     resize="${ResizeOptions.cover}"
-    focalPoint={{ x: 120, y: 120 }}
+    focalPoint={{ x: 0, y: 20 }}
+  />
+  <Image
+    src="c5f754_dd75514d14fa4057b4f4a6cc8ce7add3~mv2.jpg"
+    width={50}
+    height={200}
+    alt="Garfield smiles and puts his hand over chest"
+    resize="${ResizeOptions.cover}"
+    focalPoint={{ x: 30, y: 0 }}
   />
 </div>
 `;

--- a/packages/wix-ui-tpa/src/components/Image/docs/examples.ts
+++ b/packages/wix-ui-tpa/src/components/Image/docs/examples.ts
@@ -21,7 +21,8 @@ export const commonExampleProps = {
   ],
   focalPoint: [
     ...Object.keys(FocalPointPresets),
-    { label: 'example of custom number (120,120)', value: { x: 120, y: 120 } },
+    { label: 'custom point (20,0)', value: { x: 20, y: 0 } },
+    { label: 'custom point (0,70)', value: { x: 0, y: 70 } },
   ],
   hoverEffect: Object.keys(HoverEffectOptions),
   loadingBehavior: Object.keys(LoadingBehaviorOptions),

--- a/packages/wix-ui-tpa/src/components/Image/docs/examples.ts
+++ b/packages/wix-ui-tpa/src/components/Image/docs/examples.ts
@@ -1,5 +1,6 @@
 import {
   AspectRatioPresets,
+  FocalPointPresets,
   HoverEffectOptions,
   LoadingBehaviorOptions,
   ResizeOptions,
@@ -17,6 +18,10 @@ export const commonExampleProps = {
     ...Object.keys(AspectRatioPresets),
     { label: 'example of custom number (2.33)', value: 2.33 },
     { label: 'none', value: null },
+  ],
+  focalPoint: [
+    ...Object.keys(FocalPointPresets),
+    { label: 'example of custom number (120,120)', value: { x: 120, y: 120 } },
   ],
   hoverEffect: Object.keys(HoverEffectOptions),
   loadingBehavior: Object.keys(LoadingBehaviorOptions),
@@ -125,6 +130,27 @@ export const aspectRatioExample = `
     alt="Garfield smiles and puts his hand over chest"
     resize="${ResizeOptions.cover}"
     aspectRatio={1.333}
+  />
+</div>
+`;
+
+export const focalPointExample = `
+<div style={{ display: 'flex', justifyContent: 'space-evenly' }}>
+  <Image
+    src="c5f754_dd75514d14fa4057b4f4a6cc8ce7add3~mv2.jpg"
+    width={480}
+    height={360}
+    alt="Garfield smiles and puts his hand over chest"
+    resize="${ResizeOptions.cover}"
+    focalPoint="${FocalPointPresets.topLeft}"
+  />
+  <Image
+    src="c5f754_dd75514d14fa4057b4f4a6cc8ce7add3~mv2.jpg"
+    width={480}
+    height={360}
+    alt="Garfield smiles and puts his hand over chest"
+    resize="${ResizeOptions.cover}"
+    focalPoint={{ x: 120, y: 120 }}
   />
 </div>
 `;

--- a/packages/wix-ui-tpa/src/components/Image/docs/index.story.tsx
+++ b/packages/wix-ui-tpa/src/components/Image/docs/index.story.tsx
@@ -129,7 +129,7 @@ export default {
             {
               title: 'Focal Point',
               description:
-                'The center of the image can be repositioned using `focalPoint`, which determines the focused area by given coordinates of x and y in **percentages**. The prop is relevant when `resize` is set as `cover` and mainly useful to make sure that the important area of the image is actually visible and not cropped. Also, the prop accepts predefined values of coordinates such as `topLeft`/`centerRight`/`bottomCenter` and so on.',
+                'The center of the image can be repositioned using `focalPoint`, which determines the focused point by given coordinates of x and y in **percentages**. The prop is relevant when `resize` is set as `cover` and mainly useful to make sure that the important area of the image is actually visible and not cropped. Also, the prop accepts predefined values of coordinates such as `topLeft`/`centerRight`/`bottomCenter` and so on.',
               source: examples.focalPointExample,
             },
             {

--- a/packages/wix-ui-tpa/src/components/Image/docs/index.story.tsx
+++ b/packages/wix-ui-tpa/src/components/Image/docs/index.story.tsx
@@ -127,6 +127,12 @@ export default {
               source: examples.aspectRatioExample,
             },
             {
+              title: 'Focal Point',
+              description:
+                'The center of the image can be repositioned using `focalPoint`, which determines the focused area by given coordinates of x and y in **percentages**. The prop is relevant when `resize` is set as `cover` and mainly useful to make sure that the important area of the image is actually visible and not cropped. Also, the prop accepts predefined values of coordinates such as `topLeft`/`centerRight`/`bottomCenter` and so on.',
+              source: examples.focalPointExample,
+            },
+            {
               title: 'Fluidly',
               description:
                 "The image can be adapted and scaled relatively to the containing layout using the `fluid` prop. This behaves in contrast to the default fixed mode defining that the image is always displayed the same without considering resizing of the containing element. Note that in both modes the dimensions (whether given explicitly or calculated by the bounding rectangle) specify the size of the source to be fetched - but the difference is that in fixed mode the image is **displayed statically** by these dimensions, whereas in fluid mode, the image **scales to fit** the containing element.<br/><br/> In the example below, we set a fixed width of 600px and aspect ratio as `square` which makes the height to equal to 600px. So, the minimal resolution for fetching the resource is 600x600 pixels. However, we place the image inside an element with a different height in **fluid** mode, and that's why the image is fitted to the element. Also, if we try to resize the viewport we'd notice that the image scales accordingly.",

--- a/packages/wix-ui-tpa/src/components/Image/types.ts
+++ b/packages/wix-ui-tpa/src/components/Image/types.ts
@@ -17,7 +17,7 @@ export interface ImageProps extends TPAComponentProps {
   resize?: ResizeOptions;
   /** Specifies the proportional relationship between width and height */
   aspectRatio?: keyof typeof AspectRatioPresets | number;
-  /** Centers an area of the image by given coordinates of x and y in percentages */
+  /** Centers a point of the image by given coordinates of x and y in percentages */
   focalPoint?: Extract<keyof typeof FocalPointPresets, 'string'> | FocalPoint;
   /** Specifies wether the image adapts and scales relatively to the containing layout */
   fluid?: boolean;

--- a/packages/wix-ui-tpa/src/components/Image/types.ts
+++ b/packages/wix-ui-tpa/src/components/Image/types.ts
@@ -15,10 +15,12 @@ export interface ImageProps extends TPAComponentProps {
   onError?: React.EventHandler<React.SyntheticEvent>;
   /** Specifies how the image is resized to fit its container */
   resize?: ResizeOptions;
+  /** Specifies the proportional relationship between width and height */
+  aspectRatio?: keyof typeof AspectRatioPresets | number;
+  /** Centers an area of the image by given coordinates of x and y in percentages */
+  focalPoint?: Extract<keyof typeof FocalPointPresets, 'string'> | FocalPoint;
   /** Specifies wether the image adapts and scales relatively to the containing layout */
   fluid?: boolean;
-  // Specifies the proportional relationship between width and height
-  aspectRatio?: keyof typeof AspectRatioPresets | number;
   /** An effect to appear when the image is hovered  */
   hoverEffect?: HoverEffectOptions;
   /** An experience to set while the image is fetched and loaded  */
@@ -39,6 +41,23 @@ export const AspectRatioPresets = {
   square: 1,
   cinema: 16 / 9,
   landscape: 4 / 3,
+};
+
+export interface FocalPoint {
+  x: number;
+  y: number;
+}
+
+export const FocalPointPresets: { [key: string]: FocalPoint } = {
+  topLeft: { x: 0, y: 0 },
+  topCenter: { x: 50, y: 0 },
+  topRight: { x: 100, y: 0 },
+  centerLeft: { x: 0, y: 50 },
+  center: { x: 50, y: 50 },
+  centerRight: { x: 100, y: 50 },
+  bottomLeft: { x: 0, y: 100 },
+  bottomCenter: { x: 50, y: 100 },
+  bottomRight: { x: 100, y: 100 },
 };
 
 export enum HoverEffectOptions {


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!---
- Be as descriptive as possible when explaining what was changed.
- Link to an issue if one exists
-->

### 🔦 Summary

This PR implements `focalPoint` prop supporting a list of presents or a custom point.

From the visuals:
![image](https://user-images.githubusercontent.com/7141972/107516966-d0b97600-6bb5-11eb-8cc8-f8675b9b3f72.png)
![image](https://user-images.githubusercontent.com/7141972/107517026-e4fd7300-6bb5-11eb-8d7a-5622f323f713.png)