### PR TITLE
<InputWithOptions /> fix missing name prop for native select, which wasn't passed from props

### DIFF
--- a/packages/wix-style-react/src/InputWithOptions/InputWithOptions.js
+++ b/packages/wix-style-react/src/InputWithOptions/InputWithOptions.js
@@ -191,13 +191,14 @@ class InputWithOptions extends Component {
   }
 
   _renderNativeSelect() {
-    const { options, onSelect } = this.props;
+    const { options, onSelect, name } = this.props;
     return (
       <div className={classes.nativeSelectWrapper}>
         {this.renderInput()}
         <select
           data-hook="native-select"
           className={classes.nativeSelect}
+          name={name}
           onChange={event => {
             this._onChange(event);
 


### PR DESCRIPTION
### 🔦 Summary

`name` wasn't passed to native html <select/> element in case `native` prop was used.
