### PR TITLE
SelectableAccordion: Don't render item's content if it is not provided

### DIFF
--- a/packages/wix-style-react/src/SelectableAccordion/Item/Item.js
+++ b/packages/wix-style-react/src/SelectableAccordion/Item/Item.js
@@ -163,12 +163,12 @@ export default class SelectableAccordionItem extends React.PureComponent {
               {this._renderTitle({ reducedSpacingAndImprovedLayout })}
               {this._renderSubtitle()}
             </div>
-            <div className={classes.content}>
+            {this.props.content && <div className={classes.content}>
               <Collapse open={open}>
                 <div className={classes.inner}>{this._renderContent()}</div>
               </Collapse>
               <Divider className={classes.divider} />
-            </div>
+            </div>}
           </div>
         )}
       </WixStyleReactContext.Consumer>

--- a/packages/wix-style-react/src/SelectableAccordion/Item/Item.js
+++ b/packages/wix-style-react/src/SelectableAccordion/Item/Item.js
@@ -131,7 +131,7 @@ export default class SelectableAccordionItem extends React.PureComponent {
 
   render() {
     const { hovered } = this.state;
-    const { open, verticalPadding } = this.props;
+    const { content, open, verticalPadding } = this.props;
 
     return (
       <WixStyleReactContext.Consumer>
@@ -163,7 +163,7 @@ export default class SelectableAccordionItem extends React.PureComponent {
               {this._renderTitle({ reducedSpacingAndImprovedLayout })}
               {this._renderSubtitle()}
             </div>
-            {this.props.content && <div className={classes.content}>
+            {content && <div className={classes.content}>
               <Collapse open={open}>
                 <div className={classes.inner}>{this._renderContent()}</div>
               </Collapse>


### PR DESCRIPTION
### 🔦 Summary
As part of implementing [PING-1696](https://jira.wixpress.com/browse/PING-1696), we need to implement `<SelectableAccordion>` with items without content. For such items, we don't need the empty `<Collapse>` element to be rendered.

### ✅ Checklist

- [X] 👨‍🎨 UX change is approved by the Design System UX @TalZa1810 ([Slack discussion](https://wix.slack.com/archives/C39FTGUBZ/p1613472486091600))
