### PR TITLE
add `npx` for wuf invocation

### DIFF
--- a/packages/wix-style-react/.wuf/update-components.sh
+++ b/packages/wix-style-react/.wuf/update-components.sh
@@ -3,7 +3,7 @@
 rm .wuf/components.json || true
 
 # create components list
-wuf update \
+npx --no-install wuf update \
   --shape .wuf/required-component-files.json \
   --components src \
   --max-mismatch 1 \
@@ -12,14 +12,14 @@ wuf update \
 
 
 # vanilla testkits
-wuf export-testkits \
+npx --no-install wuf export-testkits \
   --components .wuf/components.json \
   --definitions .wuf/testkits/definitions.js \
   --template .wuf/testkits/vanilla.template.ejs \
   --output testkit/index.js
 
 # vanilla testkits typescript definitions
-wuf export-testkits \
+npx --no-install wuf export-testkits \
   --components .wuf/components.json \
   --definitions .wuf/testkits/definitions.js \
   --template .wuf/testkits/vanilla-typescript.template.ejs \
@@ -27,14 +27,14 @@ wuf export-testkits \
 
 
 # enzyme testkits
-wuf export-testkits \
+npx --no-install wuf export-testkits \
   --components .wuf/components.json \
   --definitions .wuf/testkits/definitions.js \
   --template .wuf/testkits/enzyme.template.ejs \
   --output testkit/enzyme.js
 
 # enzyme testkits typescript definitions
-wuf export-testkits \
+npx --no-install wuf export-testkits \
   --components .wuf/components.json \
   --definitions .wuf/testkits/definitions.js \
   --template .wuf/testkits/enzyme-typescript.template.ejs \
@@ -42,14 +42,14 @@ wuf export-testkits \
 
 
 # protractor testkits
-wuf export-testkits \
+npx --no-install wuf export-testkits \
   --components .wuf/components.json \
   --definitions .wuf/testkits/definitions.js \
   --template .wuf/testkits/protractor.template.ejs \
   --output testkit/protractor.js
 
 # protractor testkits typescript definitions
-wuf export-testkits \
+npx --no-install wuf export-testkits \
   --components .wuf/components.json \
   --definitions .wuf/testkits/definitions.js \
   --template .wuf/testkits/protractor-typescript.template.ejs \
@@ -57,14 +57,14 @@ wuf export-testkits \
 
 
 # puppeteer testkits
-wuf export-testkits \
+npx --no-install wuf export-testkits \
   --components .wuf/components.json \
   --definitions .wuf/testkits/definitions.js \
   --template .wuf/testkits/puppeteer.template.ejs \
   --output testkit/puppeteer.js
 
 # puppeteer testkits typescript definitions
-wuf export-testkits \
+npx --no-install wuf export-testkits \
   --components .wuf/components.json \
   --definitions .wuf/testkits/definitions.js \
   --template .wuf/testkits/puppeteer-typescript.template.ejs \

--- a/packages/wix-ui-tpa/.wuf/update-components.sh
+++ b/packages/wix-ui-tpa/.wuf/update-components.sh
@@ -4,7 +4,7 @@
 rm .wuf/components.json || true
 
 # create components list
-wuf update \
+npx --no-install wuf update \
   --shape .wuf/required-component-files.json \
   --components src/components \
   --exclude "(TPAComponentsConfig|ErrorMessageWrapper)" \
@@ -16,28 +16,28 @@ wuf update \
 mkdir -p src/testkit
 
 # vanilla testkits
-wuf export-testkits \
+npx --no-install wuf export-testkits \
   --components .wuf/components.json \
   --definitions .wuf/testkits/definitions.js \
   --template .wuf/testkits/vanilla.template.ejs \
   --output src/testkit/index.ts
 
 # enzyme testkits
-wuf export-testkits \
+npx --no-install wuf export-testkits \
   --components .wuf/components.json \
   --definitions .wuf/testkits/definitions.js \
   --template .wuf/testkits/enzyme.template.ejs \
   --output src/testkit/enzyme.ts
 
 # protractor testkits
-wuf export-testkits \
+npx --no-install wuf export-testkits \
   --components .wuf/components.json \
   --definitions .wuf/testkits/definitions.js \
   --template .wuf/testkits/protractor.template.ejs \
   --output src/testkit/protractor.ts
 
 # puppeteer testkits
-wuf export-testkits \
+npx --no-install wuf export-testkits \
   --components .wuf/components.json \
   --definitions .wuf/testkits/definitions.js \
   --template .wuf/testkits/puppeteer.template.ejs \


### PR DESCRIPTION
something happened in CI and wuf is no longer found on the $PATH
since `wuf` is already install with `npm install`, there's no need to
install it again with `npx`, hence the `--no-install` flag
