### PR TITLE
[wix-ui-tpa] dropdown error fix

### DIFF
--- a/packages/wix-ui-tpa/src/components/Dropdown/Dropdown.st.css
+++ b/packages/wix-ui-tpa/src/components/Dropdown/Dropdown.st.css
@@ -4,6 +4,11 @@
 }
 
 :import {
+    -st-from: "wix-ui-core/dist/src/components/popover/Popover.st.css";
+    -st-named: popoverContent;
+}
+
+:import {
     -st-from: "../Input/Input.st.css";
     -st-named: colorPlaceholder;
 }
@@ -154,7 +159,7 @@
 
 
 .root {
-    -st-states: alignment(enum(center)), mobile;
+    -st-states: alignment(enum(center)), mobile, error;
 }
 
 .root:mobile .label {
@@ -216,18 +221,24 @@
 
 .dropdown .dropdownBase {
     color: value(DefaultButtonTextColor) !important;
-    border-color: value(DefaultButtonBorderColor) !important;
     border-width: value(DefaultBorderWidth) !important;
     background: value(DefaultBackgroundColor) !important;
     font: font(value(DefaultTextFont)) !important;
 }
 
+.dropdown .dropdownBase:not(:error) {
+    border-color: value(DefaultButtonBorderColor) !important;
+}
+
 .root.overrideStyleParams .dropdown .dropdownBase {
     color: value(CurrentButtonTextColor) !important;
-    border-color: value(CurrentButtonBorderColor) !important;
     border-width: value(CurrentBorderWidth) !important;
     background: value(CurrentBackgroundColor) !important;
     font: value(CurrentTextFont) !important;
+}
+
+.root.overrideStyleParams .dropdown .dropdownBase:not(:error) {
+    border-color: value(CurrentButtonBorderColor) !important;
 }
 
 .dropdown .dropdownBase::arrowIcon {
@@ -286,7 +297,7 @@
     border: 1px solid applyOpacity(color(color-5), 0.4);
 }
 
-.root.overrideStyleParams .dropdown::popoverContent {
+.root.overrideStyleParams .dropdown > .popoverContent {
     border: 1px solid applyOpacity(value(CurrentItemTextColor), 0.4);
     background-color: value(CurrentDropdownBackgroundColor);
 }

--- a/packages/wix-ui-tpa/src/components/Dropdown/Dropdown.visual.st.css
+++ b/packages/wix-ui-tpa/src/components/Dropdown/Dropdown.visual.st.css
@@ -1,0 +1,10 @@
+:import {
+    -st-from: "./Dropdown.st.css";
+    -st-named: overrideStyleParams;
+}
+
+.root {
+    -st-mixin: overrideStyleParams(
+        DefaultButtonBorderColor gold
+    )
+}

--- a/packages/wix-ui-tpa/src/components/Dropdown/Dropdown.visual.tsx
+++ b/packages/wix-ui-tpa/src/components/Dropdown/Dropdown.visual.tsx
@@ -33,11 +33,11 @@ class DropdownVisual extends React.Component<any> {
     const { mobile } = this.props;
 
     return (
-        <TPAComponentsProvider value={{ mobile }}>
-          <VisualTestContainer>
-            <Dropdown {...this.props} />
-          </VisualTestContainer>
-        </TPAComponentsProvider>
+      <TPAComponentsProvider value={{ mobile }}>
+        <VisualTestContainer>
+          <Dropdown {...this.props} />
+        </VisualTestContainer>
+      </TPAComponentsProvider>
     );
   }
 }
@@ -105,10 +105,12 @@ visualize('Dropdown', () => {
 
   story('wired', () => {
     snap('error should always show red border', () => (
-        <DropdownVisual error
-                        errorMessage={'Error message'}
-                        options={simpleOptions}
-                        className={classes.root}/>
-    ))
-  })
+      <DropdownVisual
+        error
+        errorMessage={'Error message'}
+        options={simpleOptions}
+        className={classes.root}
+      />
+    ));
+  });
 });

--- a/packages/wix-ui-tpa/src/components/Dropdown/Dropdown.visual.tsx
+++ b/packages/wix-ui-tpa/src/components/Dropdown/Dropdown.visual.tsx
@@ -5,6 +5,7 @@ import { VisualTestContainer } from '../../../test/visual/VisualTestContainer';
 import { Dropdown } from './';
 import { optionsWithSections, simpleOptions } from './helpers';
 import { ReactComponent as Heart } from '../../assets/icons/Heart.svg';
+import { classes } from './Dropdown.visual.st.css';
 
 const optionsWithIconAndSubtitles = [
   {
@@ -32,11 +33,11 @@ class DropdownVisual extends React.Component<any> {
     const { mobile } = this.props;
 
     return (
-      <TPAComponentsProvider value={{ mobile }}>
-        <VisualTestContainer>
-          <Dropdown {...this.props} />
-        </VisualTestContainer>
-      </TPAComponentsProvider>
+        <TPAComponentsProvider value={{ mobile }}>
+          <VisualTestContainer>
+            <Dropdown {...this.props} />
+          </VisualTestContainer>
+        </TPAComponentsProvider>
     );
   }
 }
@@ -101,4 +102,13 @@ visualize('Dropdown', () => {
       snap(testConfig.it, <DropdownVisual {...testConfig.props} />);
     });
   });
+
+  story('wired', () => {
+    snap('error should always show red border', () => (
+        <DropdownVisual error
+                        errorMessage={'Error message'}
+                        options={simpleOptions}
+                        className={classes.root}/>
+    ))
+  })
 });

--- a/packages/wix-ui-tpa/src/components/Dropdown/DropdownBase.st.css
+++ b/packages/wix-ui-tpa/src/components/Dropdown/DropdownBase.st.css
@@ -71,7 +71,7 @@
 .root:error,
 .root:error:focus,
 .root:error:hover {
-    border-color: value(errorColor);
+    border-color: color(value(errorColor)) !important;
 }
 
 

--- a/packages/wix-ui-tpa/src/components/Dropdown/docs/DropdownExtendedExample.tsx
+++ b/packages/wix-ui-tpa/src/components/Dropdown/docs/DropdownExtendedExample.tsx
@@ -34,6 +34,17 @@ export const DropdownExtendedExample: React.FC = () => {
           options={optionsWithSections}
         />
       </div>
+
+      <div>
+        <h3>Dropdown with error</h3>
+        <Dropdown
+          className={classes.root}
+          initialSelectedId="0"
+          error
+          errorMessage={'There was an error'}
+          options={optionsWithSections}
+        />
+      </div>
     </>
   );
 };


### PR DESCRIPTION
When overriding dropdown styles, the border color passed from the TPA takes over the dropdown error border color (red).
This PR fixes that.