### PR TITLE
<DatePicker /> fix next / previous week arrows position on responsive width

### DIFF
--- a/packages/wix-ui-tpa/src/components/DatePicker/DatePicker.st.css
+++ b/packages/wix-ui-tpa/src/components/DatePicker/DatePicker.st.css
@@ -158,6 +158,14 @@
     border-radius: 0;
 }
 
+.calendar::header::arrowLeft {
+    margin-left: 5%;
+}
+
+.calendar::header::arrowRight {
+    margin-right: 5%;
+}
+
 .calendar::header::arrowLeft:skin(light), .calendar::header::arrowRight:skin(light) {
     color: value(CurrentNavigationArrowsColor);
     background: none;


### PR DESCRIPTION


<!---
Thanks for submitting a pull request 😄 !
-->

<!---
- Be as descriptive as possible when explaining what was changed.
- Link to an issue if one exists
-->

### 🔦 Summary

When resizing the component in a responsive way, the navigation arrows shift their position:
![Screen Shot 2021-03-02 at 5 17 03 PM](https://user-images.githubusercontent.com/30498431/109770274-0b865b00-7c04-11eb-8352-54ace7868135.png)

The best solution we could come up with, is add a margin (in percentage), as the gap grows bigger and bigger as the component grows wider.
![Screen Shot 2021-03-02 at 5 18 11 PM](https://user-images.githubusercontent.com/30498431/109770280-0f19e200-7c04-11eb-892a-87c434b559d5.png)

This solution was reviewed UI wise on our side, and was approved.
...

<!--- Please mark all checkbox. If one is not relevant - delete it -->

### ✅ Checklist

- [ ] 👨‍💻 API change is approved by the UI Infra Developers <!--- Please tag the relevant team member -->
- [ ] 👨‍🎨 UX change is approved by the Design System UX <!--- Please tag the relevant team member -->

- 🔬 Change is tested


  - [ ] Visual test
